### PR TITLE
tooling: add ephemeral worktree workflow for parallel dev

### DIFF
--- a/.claude/hooks/wt-create.sh
+++ b/.claude/hooks/wt-create.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# WorktreeCreate hook for Claude Code's `--worktree` feature.
+#
+# Replaces Claude's default `git worktree add` so the new branch follows
+# the issue-aware naming convention from CLAUDE.md (Worktree Workflow).
+# The hook contract: read the event JSON from stdin, return the worktree
+# path on stdout, exit non-zero to abort creation.
+#
+# Branch name source of truth:
+#   - SQLAI_WT_BRANCH env var (set by scripts/wt-new), if present.
+#   - Fallback `wt/<slug>` for direct `claude --worktree <slug>` calls,
+#     so the feature still works without our wrapper.
+set -euo pipefail
+
+payload=$(cat)
+
+# `jq -er` exits non-zero on null/missing fields, which then aborts the
+# hook (and the worktree create) instead of letting the literal string
+# "null" be passed to `git worktree add` later.
+worktree_path=$(printf '%s' "$payload" | jq -er '.worktree_path')
+source_path=$(printf '%s' "$payload" | jq -er '.source_path')
+slug=$(basename "$worktree_path")
+
+branch=${SQLAI_WT_BRANCH:-wt/$slug}
+
+# `origin/HEAD` is a local symbolic ref pointing at whatever the remote's
+# default branch was at the last `git remote set-head` (or the last
+# clone). No `git fetch` runs here, so this is *not* guaranteed fresh —
+# the caller is responsible for `git fetch` if they care. We only fall
+# back to local HEAD when origin/HEAD has never been resolved (e.g.
+# brand-new clone with no remote).
+base=origin/HEAD
+if ! git -C "$source_path" rev-parse --verify --quiet "$base" >/dev/null; then
+	printf 'wt-create: origin/HEAD not set; using local HEAD as base\n' >&2
+	base=HEAD
+fi
+
+# --no-track keeps the new branch from inheriting `origin/main` as its
+# upstream. The first `git push` will need `-u origin <branch>` (or rely
+# on push.autoSetupRemote in Git 2.37+) and will create a matching
+# remote branch — which is exactly what the PR flow wants.
+git -C "$source_path" worktree add --no-track -b "$branch" "$worktree_path" "$base" >&2
+
+printf '%s\n' "$worktree_path"

--- a/.claude/hooks/wt-remove.sh
+++ b/.claude/hooks/wt-remove.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# WorktreeRemove hook for Claude Code's `--worktree` feature.
+#
+# Best-effort cleanup. Claude Code ignores this hook's exit code, so we
+# never block removal — we only surface warnings the user might miss in a
+# busy session and prune stale `.git/worktrees/` refs.
+#
+# We intentionally do NOT use `set -e`: each check below is independent,
+# and a single failure shouldn't suppress the others. Failures are
+# announced explicitly to stderr instead.
+set -uo pipefail
+
+payload=$(cat)
+
+# `jq -er` returns non-zero on null/missing. If we can't even parse the
+# payload there's no point continuing — print a clear error so the
+# user sees it in `claude --debug` output and exit 0 (don't pretend to
+# block removal; Claude Code ignores our exit code anyway).
+if ! worktree_path=$(printf '%s' "$payload" | jq -er '.worktree_path'); then
+	echo "wt-remove: payload missing .worktree_path" >&2
+	exit 0
+fi
+if ! source_path=$(printf '%s' "$payload" | jq -er '.source_path'); then
+	echo "wt-remove: payload missing .source_path" >&2
+	exit 0
+fi
+# .branch may legitimately be absent (detached worktrees).
+branch=$(printf '%s' "$payload" | jq -r '.branch // ""')
+
+if [ -d "$worktree_path" ]; then
+	if dirty=$(git -C "$worktree_path" status --porcelain 2>&1); then
+		if [ -n "$dirty" ]; then
+			printf 'wt-remove: %s has uncommitted changes (Claude Code is removing it anyway)\n' "$worktree_path" >&2
+		fi
+	else
+		printf 'wt-remove: could not run git status in %s: %s\n' "$worktree_path" "$dirty" >&2
+	fi
+
+	# Branch not pushed anywhere: caller may lose work after removal.
+	if [ -n "$branch" ]; then
+		if ! git -C "$worktree_path" rev-parse --verify --quiet "@{upstream}" >/dev/null 2>&1; then
+			printf 'wt-remove: branch %s has no upstream (unpushed commits will be unreachable)\n' "$branch" >&2
+		fi
+	fi
+fi
+
+# Let stderr through — a failure here usually means a corrupt
+# `.git/worktrees/<name>` entry that needs human attention; silencing it
+# is exactly the bug we don't want.
+git -C "$source_path" worktree prune >/dev/null

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/wt-create.sh"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/wt-remove.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Build output
 /bin/
 
+# Override a global ignore of .claude/: this repo ships hooks, settings,
+# rules, and skills that need to live with the code.
+!/.claude/
+
+# But never commit local worktrees Claude Code creates inside the repo.
+/.claude/worktrees/
+
 # Go test/coverage artifacts
 *.test
 *.out

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Gitignored files Claude Code copies into new worktrees (gitignore syntax).
+# Currently none — add patterns here when local secrets or per-checkout
+# config (e.g. .env, .claude/settings.local.json) start to exist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,45 @@ fail `make lint`, which is what CI runs. Configure your editor to run
 
 There is no git pre-commit hook; `make lint` is the single source of truth.
 
+## Worktree Workflow
+
+Parallel feature work happens in ephemeral git worktrees driven by Claude
+Code's native `--worktree` flag. Each worktree maps 1:1 to a GitHub issue
+and is expected to produce exactly one PR before being torn down.
+
+Worktrees live at `.claude/worktrees/<slug>/` (gitignored). Each gets its
+own `bin/`, so builds don't collide across parallel sessions.
+
+Branch name format (date is `YYMMDD`, time is 12-hour `HHMM` + `a`/`p`):
+
+    <gh-username>/gh-<issue#>/<YYMMDD>/<HHMM[a|p]>/<slug>
+    e.g. spilchen/gh-42/260419/0245p/validate-sql  # 2026-04-19, 2:45pm
+
+The slashes are real ref hierarchy — they group cleanly in `gh pr list`
+and the GitHub UI. The timestamp prevents collisions when reopening the
+same issue under a new slug.
+
+Helpers in `scripts/`:
+
+- `scripts/wt-new -i <issue#> -s <slug>` — verifies the issue exists,
+  computes the branch, and execs `claude --worktree <slug>`. The
+  `WorktreeCreate` hook in `.claude/settings.json` creates the actual
+  branch off `origin/HEAD`. Note: `origin/HEAD` is a *local* symbolic
+  ref — no `git fetch` runs, so the worktree starts from whatever
+  origin pointed at the last time you fetched. Run `git fetch` first
+  if you need the freshest base.
+- `scripts/wt-ls` — list worktrees with PR state (OPEN/MERGED/CLOSED/
+  NONE/DIRTY).
+- `scripts/wt-prune` — query `gh` for each worktree's branch; remove
+  worktree + branch if its PR has merged. Skips dirty worktrees unless
+  `--force`. Use `--dry-run` first if unsure.
+
+Direct `claude --worktree <slug>` (without `wt-new`) still works — the
+hook falls back to a `wt/<slug>` branch.
+
+Make wrappers: `make wt-new ISSUE=42 SLUG=foo`, `make wt-ls`,
+`make wt-prune`.
+
 # Interaction Style
 
 * Be direct and honest.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOLANGCI_LINT           := $(BIN_DIR)/golangci-lint
 
 .DEFAULT_GOAL := help
 
-.PHONY: help build test fmt fmt-check vet lint clean tools
+.PHONY: help build test fmt fmt-check vet lint clean tools wt-new wt-ls wt-prune
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -52,3 +52,12 @@ lint: fmt-check vet $(GOLANGCI_LINT) ## Run gofmt check, go vet, and pinned gola
 
 clean: ## Remove build artifacts and installed tools.
 	rm -rf $(BIN_DIR)
+
+wt-new: ## Create a worktree (use: make wt-new ISSUE=42 SLUG=foo).
+	@scripts/wt-new --issue $(ISSUE) --slug $(SLUG)
+
+wt-ls: ## List worktrees with PR state.
+	@scripts/wt-ls
+
+wt-prune: ## Remove worktrees whose PRs have merged.
+	@scripts/wt-prune

--- a/scripts/wt-ls
+++ b/scripts/wt-ls
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/wt-ls — list worktrees under .claude/worktrees/ with PR state.
+#
+# Output columns: PATH  BRANCH  PR  STATE
+#   PR is the PR number if one exists for the branch, "-" otherwise.
+#   STATE is OPEN / MERGED / CLOSED / NONE / DIRTY / MISSING / GH-ERR.
+#   DIRTY (uncommitted changes) and MISSING (worktree dir gone) override
+#   the PR state because they're the more actionable signal. GH-ERR means
+#   the gh query failed for that branch — the listing keeps going so a
+#   transient outage doesn't black out the whole table.
+set -euo pipefail
+
+command -v gh >/dev/null || { echo "wt-ls: gh CLI is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "wt-ls: jq is required" >&2; exit 1; }
+
+repo_root=$(git rev-parse --show-toplevel)
+prefix="$repo_root/.claude/worktrees/"
+
+# See wt-prune for an explanation of the porcelain parser; bare repos
+# are filtered out the same way.
+mapfile -t entries < <(
+	git worktree list --porcelain | awk -v pfx="$prefix" '
+		function emit(   ) {
+			if (path != "" && index(path, pfx) == 1 && !is_bare)
+				print path "\t" branch
+			path = ""; branch = ""; is_bare = 0
+		}
+		/^worktree / { emit(); path = substr($0, 10) }
+		/^branch /   { branch = substr($0, 8); sub("^refs/heads/", "", branch) }
+		/^bare$/     { is_bare = 1 }
+		END          { emit() }
+	'
+)
+
+if [ ${#entries[@]} -eq 0 ]; then
+	echo "wt-ls: no worktrees under $prefix"
+	exit 0
+fi
+
+{
+	printf '%s\t%s\t%s\t%s\n' PATH BRANCH PR STATE
+	for entry in "${entries[@]}"; do
+		path="${entry%%	*}"
+		branch="${entry#*	}"
+
+		rel="${path#"$repo_root/"}"
+
+		if [ -z "$branch" ]; then
+			printf '%s\t%s\t%s\t%s\n' "$rel" "(detached)" "-" "NONE"
+			continue
+		fi
+
+		if [ ! -d "$path" ]; then
+			printf '%s\t%s\t%s\t%s\n' "$rel" "$branch" "-" "MISSING"
+			continue
+		fi
+
+		dirty=$(git -C "$path" status --porcelain)
+
+		# `gh pr list` failure here means we can't tell PR state for this
+		# branch; flag it as GH-ERR rather than masking it as NONE.
+		if pr_json=$(gh pr list --head "$branch" --state all \
+			--json number,state --jq '.[0]' 2>/dev/null); then
+			if [ -n "$pr_json" ] && [ "$pr_json" != "null" ]; then
+				pr_num=$(printf '%s' "$pr_json" | jq -r .number)
+				pr_state=$(printf '%s' "$pr_json" | jq -r .state)
+			else
+				pr_num="-"
+				pr_state="NONE"
+			fi
+		else
+			pr_num="-"
+			pr_state="GH-ERR"
+		fi
+
+		[ -n "$dirty" ] && pr_state="DIRTY"
+
+		printf '%s\t%s\t%s\t%s\n' "$rel" "$branch" "$pr_num" "$pr_state"
+	done
+} | column -t -s $'\t'

--- a/scripts/wt-new
+++ b/scripts/wt-new
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# scripts/wt-new — create a worktree + Claude Code session for an issue.
+#
+# Usage:
+#   scripts/wt-new --issue <N> --slug <slug>
+#   scripts/wt-new -i 42 -s validate-sql
+#
+# Builds a branch named:
+#   <gh-username>/gh-<N>/<YYMMDD>/<HHMM[a|p]>/<slug>
+# e.g. spilchen/gh-42/260419/0245p/validate-sql
+#
+# The branch is created by .claude/hooks/wt-create.sh after this script
+# execs `claude --worktree <slug>`. The worktree lives at
+# .claude/worktrees/<slug>/ (Claude Code's native default).
+set -euo pipefail
+
+usage() {
+	cat <<'EOF' >&2
+Usage: scripts/wt-new --issue <N> --slug <slug>
+
+Options:
+  -i, --issue N       GitHub issue number this worktree addresses (required)
+  -s, --slug TEXT     Short slug for branch + directory name (required)
+  -h, --help          Show this help
+EOF
+	exit "${1:-1}"
+}
+
+issue=""
+slug=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-i|--issue|-s|--slug)
+			[ $# -ge 2 ] || { printf 'wt-new: missing value for %s\n' "$1" >&2; usage 1; }
+			case "$1" in
+				-i|--issue) issue="$2" ;;
+				-s|--slug)  slug="$2"  ;;
+			esac
+			shift 2
+			;;
+		-h|--help)  usage 0 ;;
+		*) printf 'wt-new: unexpected arg %q\n' "$1" >&2; usage 1 ;;
+	esac
+done
+
+[ -n "$issue" ] || { echo "wt-new: --issue is required" >&2; usage 1; }
+[ -n "$slug" ]  || { echo "wt-new: --slug is required"  >&2; usage 1; }
+
+case "$issue" in
+	''|*[!0-9]*) echo "wt-new: --issue must be a positive integer (got $issue)" >&2; exit 1 ;;
+esac
+
+# Slugify: lowercase, non-alnum -> '-', collapse repeats, trim ends.
+slug=$(printf '%s' "$slug" \
+	| tr '[:upper:]' '[:lower:]' \
+	| sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')
+[ -n "$slug" ] || { echo "wt-new: slug becomes empty after sanitization" >&2; exit 1; }
+
+command -v gh >/dev/null || { echo "wt-new: gh CLI is required" >&2; exit 1; }
+
+# Cache the gh username so we're not hitting the API every time.
+# Note: switching `gh auth` accounts will leave a stale cache; delete
+# `$cache_dir/gh-user` (printed below on cache miss) to refresh.
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/sql-ai-tools"
+mkdir -p "$cache_dir"
+user_cache="$cache_dir/gh-user"
+if [ -s "$user_cache" ]; then
+	# `read -r` strips the trailing newline if a human edits the file.
+	read -r user < "$user_cache"
+else
+	user=$(gh api user --jq .login)
+	if [ -z "$user" ]; then
+		echo "wt-new: gh api user returned an empty login (auth issue?)" >&2
+		exit 1
+	fi
+	printf '%s' "$user" > "$user_cache"
+fi
+
+# Verify the issue exists (and isn't a PR).
+if ! gh issue view "$issue" --json number >/dev/null 2>&1; then
+	echo "wt-new: issue #$issue not found in this repo" >&2
+	exit 1
+fi
+
+# Timestamp: YYMMDD/HHMM[a|p], 12-hour clock, lowercased meridiem, no M.
+# `LC_ALL=C` keeps the AM/PM literal stable across locales so the
+# AM/PM → a/p substitution always matches.
+ts=$(LC_ALL=C date +'%y%m%d/%I%M%p' | sed 's/AM$/a/; s/PM$/p/')
+branch="$user/gh-$issue/$ts/$slug"
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+	echo "wt-new: local branch ref $branch already exists" >&2
+	exit 1
+fi
+worktree_path=".claude/worktrees/$slug"
+if [ -e "$worktree_path" ]; then
+	echo "wt-new: worktree directory $worktree_path already exists" >&2
+	exit 1
+fi
+
+command -v claude >/dev/null || { echo "wt-new: claude CLI is required" >&2; exit 1; }
+
+printf 'wt-new: creating worktree %s on branch %s\n' "$worktree_path" "$branch" >&2
+export SQLAI_WT_BRANCH="$branch"
+export SQLAI_WT_ISSUE="$issue"
+exec claude --worktree "$slug"

--- a/scripts/wt-prune
+++ b/scripts/wt-prune
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# scripts/wt-prune — remove worktrees whose PR has merged.
+#
+# Walks every worktree rooted under .claude/worktrees/, queries gh for a
+# merged PR on the worktree's branch, and removes the worktree + branch
+# if one is found. Dirty worktrees are skipped unless --force is passed.
+#
+# Usage:
+#   scripts/wt-prune              # remove merged + clean worktrees
+#   scripts/wt-prune --dry-run    # report what would happen, change nothing
+#   scripts/wt-prune --force      # also remove dirty merged worktrees
+#
+# A `gh` failure (auth, rate limit, network) is treated as fatal: we never
+# want to silently SKIP a branch that actually has a merged PR just
+# because the API was momentarily unhappy.
+set -euo pipefail
+
+usage() {
+	cat <<'EOF' >&2
+Usage: scripts/wt-prune [--dry-run] [--force]
+
+  --dry-run   Report what would be removed; change nothing.
+  --force     Also remove dirty merged worktrees (uses git worktree remove
+              --force --force, which discards uncommitted work).
+  -h, --help  Show this help.
+EOF
+}
+
+dry_run=false
+force=false
+for arg in "$@"; do
+	case "$arg" in
+		--dry-run) dry_run=true ;;
+		--force)   force=true ;;
+		-h|--help) usage; exit 0 ;;
+		*) echo "wt-prune: unknown arg $arg" >&2; usage; exit 1 ;;
+	esac
+done
+
+if [ "$dry_run" = true ] && [ "$force" = true ]; then
+	echo "wt-prune: --dry-run and --force are mutually exclusive" >&2
+	exit 1
+fi
+
+command -v gh >/dev/null || { echo "wt-prune: gh CLI is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "wt-prune: jq is required" >&2; exit 1; }
+
+repo_root=$(git rev-parse --show-toplevel)
+prefix="$repo_root/.claude/worktrees/"
+
+# Parse `git worktree list --porcelain` into (path \t branch) lines for
+# worktrees rooted under our prefix. The porcelain format also emits a
+# `bare` line for bare repos; we skip those by ignoring records that have
+# no checkout (no `branch` and no `detached` line).
+mapfile -t entries < <(
+	git worktree list --porcelain | awk -v pfx="$prefix" '
+		function emit(   ) {
+			if (path != "" && index(path, pfx) == 1 && !is_bare)
+				print path "\t" branch
+			path = ""; branch = ""; is_bare = 0
+		}
+		/^worktree / { emit(); path = substr($0, 10) }
+		/^branch /   { branch = substr($0, 8); sub("^refs/heads/", "", branch) }
+		/^bare$/     { is_bare = 1 }
+		END          { emit() }
+	'
+)
+
+if [ ${#entries[@]} -eq 0 ]; then
+	echo "wt-prune: no worktrees under $prefix"
+	exit 0
+fi
+
+removed=0
+warnings=0
+for entry in "${entries[@]}"; do
+	path="${entry%%	*}"
+	branch="${entry#*	}"
+
+	if [ -z "$branch" ]; then
+		printf 'SKIP %s (detached, no branch to query)\n' "$path"
+		continue
+	fi
+
+	# `gh pr list --jq '.[0].number // empty'` exits 0 with empty stdout
+	# when no PR matches and 0 with the number when one does. Letting
+	# `set -e` abort on non-zero exit keeps real gh failures (auth,
+	# network) from being misread as "no merged PR".
+	merged_pr=$(gh pr list --head "$branch" --state merged \
+		--json number --jq '.[0].number // empty')
+
+	if [ -z "$merged_pr" ]; then
+		printf 'SKIP %s (no merged PR for %s)\n' "$path" "$branch"
+		continue
+	fi
+
+	# Worktree's checkout state. If the directory is already gone (manual
+	# rm), git status fails — treat that as "clean enough to prune".
+	if [ -d "$path" ]; then
+		dirty=$(git -C "$path" status --porcelain)
+	else
+		dirty=""
+	fi
+
+	if [ -n "$dirty" ] && [ "$force" = false ]; then
+		printf 'SKIP %s (PR #%s merged but worktree is dirty; use --force)\n' \
+			"$path" "$merged_pr"
+		continue
+	fi
+
+	if [ "$dry_run" = true ]; then
+		printf 'DRY-RUN MERGED #%s: would remove %s and branch %s\n' \
+			"$merged_pr" "$path" "$branch"
+		continue
+	fi
+
+	printf 'MERGED #%s: removing %s and branch %s\n' "$merged_pr" "$path" "$branch"
+
+	# `git worktree remove` needs --force to drop a worktree with local
+	# (committed) changes; a *second* --force is required when the tree
+	# is dirty. Don't pass --force on a clean tree — that would defeat
+	# the safety net the script's --force flag is supposed to gate.
+	rm_flags=()
+	if [ -n "$dirty" ]; then
+		rm_flags=(--force --force)
+	fi
+	if ! git -C "$repo_root" worktree remove "${rm_flags[@]}" "$path"; then
+		printf 'WARN: git worktree remove failed for %s\n' "$path" >&2
+		warnings=$((warnings + 1))
+		continue
+	fi
+	if ! git -C "$repo_root" branch -D "$branch" >/dev/null; then
+		printf 'WARN: git branch -D %s failed (worktree was removed)\n' "$branch" >&2
+		warnings=$((warnings + 1))
+	fi
+	removed=$((removed + 1))
+done
+
+if [ "$dry_run" = false ] && [ "$removed" -gt 0 ]; then
+	git -C "$repo_root" worktree prune || \
+		printf 'WARN: git worktree prune failed\n' >&2
+fi
+
+printf 'wt-prune: removed %d worktree(s)' "$removed"
+[ "$warnings" -gt 0 ] && printf ', %d warning(s)' "$warnings"
+printf '\n'


### PR DESCRIPTION
Pair Claude Code's native `--worktree` flag (v2.1.76+) with thin shell helpers so each parallel feature stream lives in its own worktree, maps 1:1 to a GitHub issue, and is torn down once its PR merges.

## What lands

- `.claude/settings.json` wires `WorktreeCreate`/`WorktreeRemove` hooks.
- `.claude/hooks/wt-create.sh` creates the branch using our naming convention `<user>/gh-<N>/<YYMMDD>/<HHMM[a|p]>/<slug>` with `--no-track` so the first `git push` lands on its own remote branch rather than `origin/main`. Falls back to `wt/<slug>` when invoked directly without the wrapper.
- `.claude/hooks/wt-remove.sh` warns about dirty / unpushed state on session exit (best-effort: `WorktreeRemove` ignores exit codes).
- `scripts/wt-new` validates the issue, slugifies the name, exports the computed branch, and `exec`s `claude --worktree <slug>`.
- `scripts/wt-prune` queries `gh` for each branch and removes worktree + branch once its PR has merged. Supports `--dry-run` / `--force`; skips dirty worktrees by default.
- `scripts/wt-ls` lists worktrees with a PR-state column (`OPEN`/`MERGED`/`CLOSED`/`NONE`/`DIRTY`).
- `.worktreeinclude` is a placeholder for future gitignored copies.
- `Makefile` wraps the scripts with `wt-new` / `wt-ls` / `wt-prune` targets.

## Notes

- `.gitignore` overrides a global `.claude/` ignore so hooks and settings can be tracked, while keeping the per-repo `.claude/worktrees/` directory ignored.
- `CLAUDE.md` gets a new **Worktree Workflow** section after Build/Test/Lint.
- Smoke-tested locally: hook creates `.claude/worktrees/wt-smoke` with `--no-track` branch, `wt-ls` shows it, `wt-prune --dry-run` correctly skips (no merged PR), `wt-remove.sh` warns on dirty / missing-upstream state. `make lint` and `make test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)