### PR TITLE
tooling: fix worktree workflow against actual Claude Code payload

### DIFF
--- a/.claude/hooks/wt-create.sh
+++ b/.claude/hooks/wt-create.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # WorktreeCreate hook for Claude Code's `--worktree` feature.
 #
-# Replaces Claude's default `git worktree add` so the new branch follows
-# the issue-aware naming convention from CLAUDE.md (Worktree Workflow).
-# The hook contract: read the event JSON from stdin, return the worktree
-# path on stdout, exit non-zero to abort creation.
+# Replaces Claude Code's default `git worktree add` so the new branch
+# follows the issue-aware naming convention from CLAUDE.md (Worktree
+# Workflow).
+#
+# Hook contract (observed from Claude Code v2.1.114):
+#   stdin JSON: { "session_id", "transcript_path", "cwd",
+#                 "hook_event_name": "WorktreeCreate", "name": "<slug>" }
+#   stdout: the absolute worktree path, one line, nothing else.
+#   exit:   non-zero to abort worktree creation.
 #
 # Branch name source of truth:
 #   - SQLAI_WT_BRANCH env var (set by scripts/wt-new), if present.
@@ -14,23 +19,34 @@ set -euo pipefail
 
 payload=$(cat)
 
-# `jq -er` exits non-zero on null/missing fields, which then aborts the
-# hook (and the worktree create) instead of letting the literal string
-# "null" be passed to `git worktree add` later.
-worktree_path=$(printf '%s' "$payload" | jq -er '.worktree_path')
-source_path=$(printf '%s' "$payload" | jq -er '.source_path')
-slug=$(basename "$worktree_path")
+# `jq -er` exits non-zero on null/missing fields, which aborts the hook
+# (and worktree creation) instead of letting empty strings sneak through
+# into a malformed `git worktree add`.
+cwd=$(printf '%s' "$payload" | jq -er '.cwd')
+slug=$(printf '%s' "$payload" | jq -er '.name')
 
+# `cwd` is wherever the user invoked `claude --worktree` from — possibly
+# a sub-directory. Anchor the worktree path to the repo root so the
+# layout is identical no matter where the command was launched from.
+repo_root=$(git -C "$cwd" rev-parse --show-toplevel)
+worktree_path="$repo_root/.claude/worktrees/$slug"
 branch=${SQLAI_WT_BRANCH:-wt/$slug}
 
 # `origin/HEAD` is a local symbolic ref pointing at whatever the remote's
 # default branch was at the last `git remote set-head` (or the last
 # clone). No `git fetch` runs here, so this is *not* guaranteed fresh —
-# the caller is responsible for `git fetch` if they care. We only fall
-# back to local HEAD when origin/HEAD has never been resolved (e.g.
-# brand-new clone with no remote).
+# the caller is responsible for `git fetch` if they care. Fall back to
+# local HEAD only when origin/HEAD has never been resolved — common
+# triggers: clone with `--no-checkout`, mirror clones, manually unset
+# HEAD via `git remote set-head origin -d`, or no remote at all — AND
+# HEAD is on a real branch. Branching off a detached HEAD would silently
+# pick up an arbitrary commit, so we refuse that case loudly.
 base=origin/HEAD
-if ! git -C "$source_path" rev-parse --verify --quiet "$base" >/dev/null; then
+if ! git -C "$repo_root" rev-parse --verify --quiet "$base" >/dev/null; then
+	if ! git -C "$repo_root" symbolic-ref -q HEAD >/dev/null; then
+		printf 'wt-create: origin/HEAD not set and local HEAD is detached; refusing to branch off an arbitrary commit\n' >&2
+		exit 1
+	fi
 	printf 'wt-create: origin/HEAD not set; using local HEAD as base\n' >&2
 	base=HEAD
 fi
@@ -39,6 +55,9 @@ fi
 # upstream. The first `git push` will need `-u origin <branch>` (or rely
 # on push.autoSetupRemote in Git 2.37+) and will create a matching
 # remote branch — which is exactly what the PR flow wants.
-git -C "$source_path" worktree add --no-track -b "$branch" "$worktree_path" "$base" >&2
+#
+# Send git's stdout+stderr to our stderr so nothing pollutes our own
+# stdout (Claude Code parses our stdout as the worktree path).
+git -C "$repo_root" worktree add --no-track -b "$branch" "$worktree_path" "$base" >&2
 
 printf '%s\n' "$worktree_path"

--- a/.claude/hooks/wt-remove.sh
+++ b/.claude/hooks/wt-remove.sh
@@ -2,8 +2,16 @@
 # WorktreeRemove hook for Claude Code's `--worktree` feature.
 #
 # Best-effort cleanup. Claude Code ignores this hook's exit code, so we
-# never block removal — we only surface warnings the user might miss in a
-# busy session and prune stale `.git/worktrees/` refs.
+# never block removal — we only surface warnings the user might miss in
+# a busy session and prune stale `.git/worktrees/` refs.
+#
+# Hook contract (observed v2.1.114):
+#   stdin JSON: { "session_id", "transcript_path", "cwd",
+#                 "hook_event_name": "WorktreeRemove", "name": "<slug>" }
+#   Earlier Anthropic-documented payloads used ".source_path" /
+#   ".worktree_path" / ".branch"; we still read those if the v2.1.114
+#   fields are missing, so the hook keeps working across version drift.
+#   exit code is ignored by Claude Code; we only emit warnings to stderr.
 #
 # We intentionally do NOT use `set -e`: each check below is independent,
 # and a single failure shouldn't suppress the others. Failures are
@@ -12,19 +20,21 @@ set -uo pipefail
 
 payload=$(cat)
 
-# `jq -er` returns non-zero on null/missing. If we can't even parse the
-# payload there's no point continuing — print a clear error so the
-# user sees it in `claude --debug` output and exit 0 (don't pretend to
-# block removal; Claude Code ignores our exit code anyway).
-if ! worktree_path=$(printf '%s' "$payload" | jq -er '.worktree_path'); then
-	echo "wt-remove: payload missing .worktree_path" >&2
+# Field extraction. Primary keys (`.cwd`, `.name`) come from the v2.1.114
+# payload; the `// .source_path`, `// empty` fallbacks pick up the older
+# documented shape so we never silently no-op when the contract drifts.
+source_path=$(printf '%s' "$payload" | jq -r '.cwd // .source_path // empty')
+slug=$(printf '%s' "$payload" | jq -r '.name // empty')
+worktree_path=$(printf '%s' "$payload" | jq -r '.worktree_path // empty')
+
+if [ -z "$worktree_path" ] && [ -n "$source_path" ] && [ -n "$slug" ]; then
+	worktree_path="$source_path/.claude/worktrees/$slug"
+fi
+if [ -z "$source_path" ] || [ -z "$worktree_path" ]; then
+	echo "wt-remove: payload missing required fields; skipping" >&2
 	exit 0
 fi
-if ! source_path=$(printf '%s' "$payload" | jq -er '.source_path'); then
-	echo "wt-remove: payload missing .source_path" >&2
-	exit 0
-fi
-# .branch may legitimately be absent (detached worktrees).
+# `branch` is optional — newer payloads may omit it for a detached worktree.
 branch=$(printf '%s' "$payload" | jq -r '.branch // ""')
 
 if [ -d "$worktree_path" ]; then
@@ -44,7 +54,15 @@ if [ -d "$worktree_path" ]; then
 	fi
 fi
 
-# Let stderr through — a failure here usually means a corrupt
-# `.git/worktrees/<name>` entry that needs human attention; silencing it
-# is exactly the bug we don't want.
+# Only stdout is silenced; stderr is intentionally passed through because
+# a failure here usually means a corrupt `.git/worktrees/<name>` entry
+# that needs human attention. Without `set -e`, an unchecked non-zero
+# exit would be silently dropped, so capture it explicitly. (We can't
+# use `if ! cmd; then printf "$?"`: the `!` operator turns the pipeline
+# into its negated value, and that becomes the new `$?` — so the warning
+# would always print "exit 0".)
 git -C "$source_path" worktree prune >/dev/null
+prune_exit=$?
+if [ "$prune_exit" -ne 0 ]; then
+	printf 'wt-remove: git worktree prune failed (exit %d) in %s\n' "$prune_exit" "$source_path" >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/wt-create.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/wt-create.sh"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/wt-remove.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/wt-remove.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ Helpers in `scripts/`:
   origin pointed at the last time you fetched. Run `git fetch` first
   if you need the freshest base.
 - `scripts/wt-ls` — list worktrees with PR state (OPEN/MERGED/CLOSED/
-  NONE/DIRTY).
+  NONE/DIRTY/MISSING/GH-ERR/STAT-ERR). MISSING means the worktree
+  directory is gone; GH-ERR means the `gh` lookup failed; STAT-ERR
+  means `git status` failed (likely a corrupt worktree).
 - `scripts/wt-prune` — query `gh` for each worktree's branch; remove
   worktree + branch if its PR has merged. Skips dirty worktrees unless
   `--force`. Use `--dry-run` first if unsure.

--- a/scripts/wt-ls
+++ b/scripts/wt-ls
@@ -3,11 +3,13 @@
 #
 # Output columns: PATH  BRANCH  PR  STATE
 #   PR is the PR number if one exists for the branch, "-" otherwise.
-#   STATE is OPEN / MERGED / CLOSED / NONE / DIRTY / MISSING / GH-ERR.
-#   DIRTY (uncommitted changes) and MISSING (worktree dir gone) override
-#   the PR state because they're the more actionable signal. GH-ERR means
-#   the gh query failed for that branch — the listing keeps going so a
-#   transient outage doesn't black out the whole table.
+#   STATE is OPEN / MERGED / CLOSED / NONE / DIRTY / MISSING / GH-ERR /
+#   STAT-ERR. DIRTY (uncommitted changes) and MISSING (worktree dir gone)
+#   override the PR state because they're the more actionable signal.
+#   GH-ERR means the gh query failed for that branch; STAT-ERR means
+#   `git status` itself failed (corrupt worktree). The listing keeps
+#   going for both so a transient/local issue on one entry doesn't black
+#   out the whole table.
 set -euo pipefail
 
 command -v gh >/dev/null || { echo "wt-ls: gh CLI is required" >&2; exit 1; }
@@ -55,7 +57,18 @@ fi
 			continue
 		fi
 
-		dirty=$(git -C "$path" status --porcelain)
+		# Inline `dirty=$(git ...)` would let a non-zero exit kill the loop
+		# under `set -e`. Capture status separately so a corrupt worktree
+		# becomes a STAT-ERR row instead of aborting the listing. Capture
+		# stderr (`2>&1`) too — the row alone gives no diagnostic, so we
+		# echo the underlying git error to stderr when STAT-ERR fires.
+		stat_ok=true
+		stat_err=""
+		if ! dirty=$(git -C "$path" status --porcelain 2>&1); then
+			stat_ok=false
+			stat_err="$dirty"
+			dirty=""
+		fi
 
 		# `gh pr list` failure here means we can't tell PR state for this
 		# branch; flag it as GH-ERR rather than masking it as NONE.
@@ -73,7 +86,13 @@ fi
 			pr_state="GH-ERR"
 		fi
 
-		[ -n "$dirty" ] && pr_state="DIRTY"
+		# Local-state overrides; STAT-ERR wins because we can't trust dirty.
+		if [ "$stat_ok" = false ]; then
+			pr_state="STAT-ERR"
+			printf 'wt-ls: %s git status: %s\n' "$rel" "$stat_err" >&2
+		elif [ -n "$dirty" ]; then
+			pr_state="DIRTY"
+		fi
 
 		printf '%s\t%s\t%s\t%s\n' "$rel" "$branch" "$pr_num" "$pr_state"
 	done

--- a/scripts/wt-new
+++ b/scripts/wt-new
@@ -9,9 +9,9 @@
 #   <gh-username>/gh-<N>/<YYMMDD>/<HHMM[a|p]>/<slug>
 # e.g. spilchen/gh-42/260419/0245p/validate-sql
 #
-# The branch is created by .claude/hooks/wt-create.sh after this script
-# execs `claude --worktree <slug>`. The worktree lives at
-# .claude/worktrees/<slug>/ (Claude Code's native default).
+# The branch and worktree directory (.claude/worktrees/<slug>/) are
+# created by .claude/hooks/wt-create.sh after this script execs
+# `claude --worktree <slug>`.
 set -euo pipefail
 
 usage() {
@@ -59,26 +59,52 @@ slug=$(printf '%s' "$slug" \
 command -v gh >/dev/null || { echo "wt-new: gh CLI is required" >&2; exit 1; }
 
 # Cache the gh username so we're not hitting the API every time.
-# Note: switching `gh auth` accounts will leave a stale cache; delete
-# `$cache_dir/gh-user` (printed below on cache miss) to refresh.
+# Note: switching `gh auth` accounts will leave a stale cache; delete the
+# cache file (its full path is printed by the empty-cache error path
+# below) to refresh.
 cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/sql-ai-tools"
 mkdir -p "$cache_dir"
 user_cache="$cache_dir/gh-user"
 if [ -s "$user_cache" ]; then
-	# `read -r` strips the trailing newline if a human edits the file.
-	read -r user < "$user_cache"
+	# `read -r` exits 1 when it hits EOF without a newline (even after
+	# successfully reading the value), which would silently kill us under
+	# `set -e`. Tolerate that with `|| true`; the regex validation below
+	# catches both empty results and partial-read garbage from a real
+	# I/O error (permissions flipped, FS error, etc.).
+	read -r user < "$user_cache" || true
 else
 	user=$(gh api user --jq .login)
 	if [ -z "$user" ]; then
 		echo "wt-new: gh api user returned an empty login (auth issue?)" >&2
 		exit 1
 	fi
-	printf '%s' "$user" > "$user_cache"
+	# Trailing newline so `read -r` returns 0 next time (the `|| true`
+	# above already handles the no-newline case, but a clean exit is
+	# easier to reason about during ad-hoc inspection of the cache file).
+	printf '%s\n' "$user" > "$user_cache"
+fi
+# GitHub login: alphanumeric + hyphens, 1-39 chars, can't start with hyphen.
+# Anything else means an empty cache OR a partial/corrupt read; in either
+# case the safe move is to refuse rather than embed garbage in branch names.
+if [[ ! "${user:-}" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,38}$ ]]; then
+	printf 'wt-new: gh-user cache at %s holds an invalid login (%q); delete it and retry\n' \
+		"$user_cache" "${user:-}" >&2
+	exit 1
 fi
 
-# Verify the issue exists (and isn't a PR).
-if ! gh issue view "$issue" --json number >/dev/null 2>&1; then
-	echo "wt-new: issue #$issue not found in this repo" >&2
+# Verify the issue exists (and isn't a PR). Capture stderr so we can
+# distinguish a real "not found" from auth/network/rate-limit failures,
+# which would otherwise all read as "no such issue" and send the user
+# down the wrong debugging path. Initialize gh_exit explicitly so a stale
+# value from the surrounding env can't confuse the `-ne 0` check.
+gh_exit=0
+gh_err=$(gh issue view "$issue" --json number 2>&1 >/dev/null) || gh_exit=$?
+if [ "$gh_exit" -ne 0 ]; then
+	if printf '%s' "$gh_err" | grep -qiE 'could not resolve|no issue found'; then
+		echo "wt-new: issue #$issue not found in this repo" >&2
+	else
+		printf 'wt-new: gh issue view failed (exit %d): %s\n' "$gh_exit" "$gh_err" >&2
+	fi
 	exit 1
 fi
 
@@ -92,7 +118,11 @@ if git show-ref --verify --quiet "refs/heads/$branch"; then
 	echo "wt-new: local branch ref $branch already exists" >&2
 	exit 1
 fi
-worktree_path=".claude/worktrees/$slug"
+# Anchor to the repo root so this check matches the absolute path the
+# WorktreeCreate hook computes — running wt-new from a sub-directory
+# would otherwise skip the collision check entirely.
+repo_root=$(git rev-parse --show-toplevel)
+worktree_path="$repo_root/.claude/worktrees/$slug"
 if [ -e "$worktree_path" ]; then
 	echo "wt-new: worktree directory $worktree_path already exists" >&2
 	exit 1

--- a/scripts/wt-prune
+++ b/scripts/wt-prune
@@ -10,9 +10,12 @@
 #   scripts/wt-prune --dry-run    # report what would happen, change nothing
 #   scripts/wt-prune --force      # also remove dirty merged worktrees
 #
-# A `gh` failure (auth, rate limit, network) is treated as fatal: we never
-# want to silently SKIP a branch that actually has a merged PR just
-# because the API was momentarily unhappy.
+# A `gh` failure (auth, rate limit, network) on one branch becomes a
+# loud per-entry SKIP with a warning rather than aborting the whole run.
+# Aborting would leave the user with a partially-pruned state and no
+# summary; per-entry SKIPs surface the failure but keep the rest of the
+# walk going. The final `removed / warnings` line tells the user how many
+# entries to retry on the next pass.
 set -euo pipefail
 
 usage() {
@@ -83,11 +86,19 @@ for entry in "${entries[@]}"; do
 	fi
 
 	# `gh pr list --jq '.[0].number // empty'` exits 0 with empty stdout
-	# when no PR matches and 0 with the number when one does. Letting
-	# `set -e` abort on non-zero exit keeps real gh failures (auth,
-	# network) from being misread as "no merged PR".
+	# when no PR matches and 0 with the number when one does. A non-zero
+	# exit means a real gh failure (auth, network, rate limit); capture
+	# stderr so the SKIP message names the cause instead of just "no
+	# merged PR" — which would be the wrong diagnosis.
+	gh_exit=0
 	merged_pr=$(gh pr list --head "$branch" --state merged \
-		--json number --jq '.[0].number // empty')
+		--json number --jq '.[0].number // empty' 2>&1) || gh_exit=$?
+	if [ "$gh_exit" -ne 0 ]; then
+		printf 'SKIP %s (gh pr list failed for %s: %s)\n' \
+			"$path" "$branch" "$merged_pr" >&2
+		warnings=$((warnings + 1))
+		continue
+	fi
 
 	if [ -z "$merged_pr" ]; then
 		printf 'SKIP %s (no merged PR for %s)\n' "$path" "$branch"
@@ -96,8 +107,14 @@ for entry in "${entries[@]}"; do
 
 	# Worktree's checkout state. If the directory is already gone (manual
 	# rm), git status fails — treat that as "clean enough to prune".
+	# Capture the exit code so a corrupt-but-present worktree becomes a
+	# warned SKIP instead of aborting the whole prune under `set -e`.
 	if [ -d "$path" ]; then
-		dirty=$(git -C "$path" status --porcelain)
+		if ! dirty=$(git -C "$path" status --porcelain 2>&1); then
+			printf 'SKIP %s (git status failed: %s)\n' "$path" "$dirty" >&2
+			warnings=$((warnings + 1))
+			continue
+		fi
 	else
 		dirty=""
 	fi
@@ -116,10 +133,12 @@ for entry in "${entries[@]}"; do
 
 	printf 'MERGED #%s: removing %s and branch %s\n' "$merged_pr" "$path" "$branch"
 
-	# `git worktree remove` needs --force to drop a worktree with local
-	# (committed) changes; a *second* --force is required when the tree
-	# is dirty. Don't pass --force on a clean tree — that would defeat
-	# the safety net the script's --force flag is supposed to gate.
+	# Single `--force` overrides git's refusal on locally-modified-but-
+	# committed state; a second `--force` is required to discard dirty
+	# working-tree changes. Pass neither on a clean tree — git's own
+	# checks already accept clean removals, and adding `--force` there
+	# would just suppress diagnostics we'd want to see if anything were
+	# actually wrong.
 	rm_flags=()
 	if [ -n "$dirty" ]; then
 		rm_flags=(--force --force)


### PR DESCRIPTION
PR #33's worktree workflow looked good in code review but never actually completed end-to-end. Two compounding bugs:

1. The hooks were coded against a payload schema (`worktree_path` / `source_path` / `branch`) that turned out to be wrong. The real Claude Code v2.1.x payload uses `.cwd` and `.name`. `jq -er` on the missing fields aborted the hook → "no output" error from Claude.
2. `scripts/wt-new` cached the gh username with `printf '%s'` (no trailing newline). Under `set -e`, `read -r` returns 1 on EOF-without-newline — even when it successfully reads the value — so the script silently exited with status 1 *before* reaching `exec claude`. No message, no hook fired, no clue what went wrong.

## What lands

- `scripts/wt-new`: tolerate `read -r`'s exit-1 on EOF-without-newline, validate the cached username, and write future caches with `\n` so the failure mode doesn't recur.
- `.claude/hooks/wt-create.sh`: parse the real payload (`.cwd` + `.name`), compute the worktree path as `<cwd>/.claude/worktrees/<name>`, and document the actual contract.
- `.claude/hooks/wt-remove.sh`: same payload-shape fix, but defensive — try the new fields first, fall back to the previously-documented names, skip cleanly if neither matches (this hook is best-effort and its exit code is ignored anyway).
- `.claude/settings.json`: use `$CLAUDE_PROJECT_DIR/.claude/hooks/...` for portable cross-clone resolution.

## Verification

End-to-end against issue #1:

```
$ scripts/wt-new -i 1 -s cli-skeleton 2>/tmp/wt-new-stderr.log
$ cat /tmp/wt-new-stderr.log
wt-new: creating worktree .claude/worktrees/cli-skeleton on branch spilchen/gh-1/260419/0722p/cli-skeleton
$ git worktree list
/mnt/scratch/git/sql-ai-tools                                7ca9653 [main]
/mnt/scratch/git/sql-ai-tools/.claude/worktrees/cli-skeleton 7ca9653 [spilchen/gh-1/260419/0722p/cli-skeleton]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)