### PR TITLE
ci: avoid duplicate runs on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

The workflow triggered on every `push` plus `pull_request`, so a push to a branch with an open PR fired both events and ran CI twice. The existing concurrency group keyed on `github.ref` did not collapse them because the two events resolve to different refs (`refs/heads/<branch>` vs `refs/pull/<n>/merge`).

Scope `push` to `main` only. PR branches are still covered by the `pull_request` trigger, and direct pushes to `main` continue to run CI, but PR updates only run once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)