### PR TITLE
tooling: use --rebase in auto-merge-pr skill

### DIFF
--- a/.claude/skills/auto-merge-pr/SKILL.md
+++ b/.claude/skills/auto-merge-pr/SKILL.md
@@ -154,10 +154,10 @@ EOF
 If `should_merge == true`, queue the merge:
 
 ```bash
-gh pr merge <pr> --auto --merge
+gh pr merge <pr> --auto --rebase
 ```
 
-`--auto` makes GitHub merge the PR once required checks pass. `--merge` uses a merge commit (not squash, not rebase).
+`--auto` makes GitHub merge the PR once required checks pass. `--rebase` rebases the PR commits onto the base branch (this repo disallows merge commits).
 
 If `gh pr merge --auto` fails with `auto-merge is not enabled for this repository`, the repo's settings → "Pull Requests" → "Allow auto-merge" checkbox is off. Report the failure to the user along with the verdict, but do NOT attempt a non-auto merge as a fallback (the user may have other reasons for wanting a human gate).
 


### PR DESCRIPTION
## Summary

The `auto-merge-pr` skill queued auto-merge with `--merge`, but this repo disallows merge commits. `gh pr merge --auto --merge` fails with `Merge commits are not allowed on this repository`. Switch to `--rebase`, which is the allowed merge method here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)