### PR TITLE
docs: require license header on all Go files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,24 @@ When reviewing, other than technical correctness, you should also focus on the
 above aspects. Do not over-emphasize on grammar and comment typos, prefix with
 "nit:" in reviews.
 
+### License Header
+
+Every `.go` file **must** begin with this header (followed by a blank line
+before the package doc or `package` clause). Replace `{YEAR}` with the
+year the file is first added (do not bump on later edits):
+
+```go
+// Copyright {YEAR} The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+```
+
+Exemptions: generated files (anything with a `// Code generated ... DO NOT
+EDIT.` marker, e.g. `*.pb.go`, `*_string.go`, mocks) and vendored code.
+
+Enforcement is currently manual. Automated checking is tracked in #40.
+
 ### TODO Comments
 
 Every TODO in source code **must** reference an open GitHub issue in this

--- a/main.go
+++ b/main.go
@@ -1,3 +1,8 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 // Command sql-ai-tools is the CLI / MCP server entry point for the
 // agent-friendly CockroachDB SQL tooling described in the project README.
 package main


### PR DESCRIPTION
## Summary
- Add a CLAUDE.md rule mandating the standard CockroachDB license header at the top of every `.go` file.
- Apply the header to `main.go`, which was the only file missing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)