### PR TITLE
lint: enforce Go license-header rule via golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,22 @@ linters:
     - unused
     - misspell
     - revive
+    - goheader
+  settings:
+    goheader:
+      values:
+        regexp:
+          YEAR: '20\d{2}'
+      template: |-
+        Copyright {{ YEAR }} The Cockroach Authors.
+
+        Use of this software is governed by the CockroachDB Software License
+        included in the /LICENSE file.
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party
 
 formatters:
   enable:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ year the file is first added (do not bump on later edits):
 Exemptions: generated files (anything with a `// Code generated ... DO NOT
 EDIT.` marker, e.g. `*.pb.go`, `*_string.go`, mocks) and vendored code.
 
-Enforcement is currently manual. Automated checking is tracked in #40.
+Enforcement is automated: `make lint` runs `golangci-lint`'s `goheader`
+linter against this template (see `.golangci.yml`), so missing or incorrect
+headers fail CI.
 
 ### TODO Comments
 


### PR DESCRIPTION
The CockroachDB license header documented in `CLAUDE.md` was previously enforced only by reviewer vigilance, so a missing or malformed header could slip through review and into CI.

Enable golangci-lint's `goheader` linter with the documented template (any 4-digit year is accepted, since the header records the file's first-added year and we cannot derive that from the working tree). Generated files are skipped via `exclusions.generated: lax`, which honors the standard `// Code generated ... DO NOT EDIT.` marker, and `vendor`/`third_party` are excluded by path. No Makefile change is needed because `make lint` already invokes golangci-lint.

Update `CLAUDE.md` to point readers at the automated check.

Resolves: #40