### PR TITLE
cli: add cobra-based command skeleton with version subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ auto-installed into `bin/` by the Makefile — do not rely on a system install.
 
 All workflows go through the Makefile:
 
-- `make build` — compile to `bin/sql-ai-tools`
+- `make build` — compile to `bin/crdb-sql`
 - `make test` — run the Go test suite (`go test ./...`)
 - `make fmt` — auto-format sources with gofmt
 - `make fmt-check` — fail if any file is not gofmt-clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY                  := sql-ai-tools
+BINARY                  := crdb-sql
 BIN_DIR                 := bin
 BIN                     := $(BIN_DIR)/$(BINARY)
 GO_PKGS                 := ./...

--- a/README.md
+++ b/README.md
@@ -88,14 +88,18 @@ and function validation against the builtins registry.
 make build
 ```
 
-Produces `bin/sql-ai-tools`.
+Produces `bin/crdb-sql`.
 
 ### Run
 
 ```bash
-# Parse and pretty-print a SQL statement
-./bin/sql-ai-tools
-# Output: SELECT 1
+# Show available subcommands
+./bin/crdb-sql --help
+
+# Print binary and parser versions
+./bin/crdb-sql version
+# crdb-sql: dev
+# cockroachdb-parser: v0.26.2
 ```
 
 ### Test & Lint

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package cmd hosts the cobra command tree for the crdb-sql CLI.
+//
+// The root is a thin shell: each subcommand (validate, format, parse,
+// etc.) is defined in its own file and attached via newRootCmd, which
+// builds a fresh tree per call. Avoiding package-global commands keeps
+// tests independent (no flag-state leakage between t.Run cases) and
+// removes the need for init()-time registration.
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// newRootCmd builds a fresh root command with all subcommands attached.
+// Construct one per Execute call (and per test) so cobra's parsed-flag
+// state never leaks across invocations.
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "crdb-sql",
+		Short: "Agent-friendly SQL tooling for CockroachDB",
+		Long: `crdb-sql exposes CockroachDB's parser, type system, and structured
+error infrastructure as a CLI (and, eventually, an MCP server) so that
+AI agents can validate, format, and reason about CockroachDB SQL without
+round-tripping through a live cluster.`,
+		// Both silences are deliberate: cobra should neither print the
+		// usage dump on a runtime error (noisy) nor print the error
+		// itself (we want a single source of truth). The Execute caller
+		// owns error printing and exit-code translation; do not flip
+		// these without updating that caller.
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.AddCommand(newVersionCmd())
+	return root
+}
+
+// Execute runs the root command against process arguments and returns
+// whatever cobra surfaces. It does not print the error or call
+// os.Exit; the caller owns that translation. This keeps the cmd
+// package importable from tests without side effects on process state.
+func Execute() error {
+	return newRootCmd().ExecuteContext(context.Background())
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	// Blank import: keep cockroachdb-parser in this module's import
+	// graph so `go mod tidy` does not drop it before a real subcommand
+	// (validate/format/parse) imports a parser package directly. It
+	// also makes the parser appear in `debug.ReadBuildInfo().Deps` for
+	// `go build` artifacts. Note: `go test` binaries do NOT populate
+	// Deps, so under `go test` parserVersionFrom falls back to
+	// "unknown" — see TestParserVersionFrom for the synthetic-BuildInfo
+	// coverage that exercises the real resolution branches.
+	_ "github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+)
+
+// parserModulePath is the import path we look up in build info to
+// report the cockroachdb-parser version. The `replace` directive does
+// not change the recorded module path, so this constant must match the
+// top-level require in go.mod.
+const parserModulePath = "github.com/cockroachdb/cockroachdb-parser"
+
+// devVersion is the sentinel Version uses for unstamped local builds.
+// parserVersionFrom uses it to decide whether a missing parser dep is a
+// soft "unknown" (acceptable under `go test` / `go run`) or a hard
+// error (a stamped release binary that lost the blank import).
+const devVersion = "dev"
+
+// Version is the binary version string. It defaults to devVersion for
+// local builds and is intended to be stamped at link time via:
+//
+//	go build -ldflags "-X github.com/spilchen/sql-ai-tools/cmd.Version=<version>"
+//
+// Release tooling owns this value; do not mutate it from runtime code.
+var Version = devVersion
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print binary and parser versions",
+		Long: `Print the crdb-sql binary version and the resolved
+cockroachdb-parser module version. The parser version is read from the
+embedded Go build info, so it reflects whatever go.mod (including any
+replace directive) selected at build time.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			parser, err := parserVersion(Version)
+			if err != nil {
+				return err
+			}
+			// Suppress EPIPE: it's the normal outcome when a downstream
+			// consumer closes stdout early (e.g. piping into `head -n1`
+			// of a future longer-output subcommand). Surfacing it as a
+			// non-zero exit with a stderr "broken pipe" message is
+			// hostile for a tool meant to be piped. Partial output is
+			// acceptable for `version` (the user has already seen at
+			// least one useful line by the time the pipe closes). The
+			// EPIPE check is Linux/macOS only; Windows is not a
+			// supported target so we don't guard for ERROR_BROKEN_PIPE.
+			out := cmd.OutOrStdout()
+			_, werr := fmt.Fprintf(out, "crdb-sql: %s\ncockroachdb-parser: %s\n", Version, parser)
+			if werr != nil && !errors.Is(werr, syscall.EPIPE) {
+				return werr
+			}
+			return nil
+		},
+	}
+}
+
+// parserVersion resolves the cockroachdb-parser module version for the
+// running binary. binVersion is the binary's own Version: dev builds
+// tolerate a missing dep (returns "unknown") because `go test` and
+// `go run` do not populate build-info Deps; a stamped release build
+// instead returns an error so a regression that drops the blank import
+// surfaces as a non-zero exit rather than silent "unknown" output.
+func parserVersion(binVersion string) (string, error) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		if binVersion == devVersion {
+			return "unknown", nil
+		}
+		return "", errors.New("build info unavailable")
+	}
+	return parserVersionFrom(info, binVersion)
+}
+
+// parserVersionFrom is the testable core of parserVersion. It consumes
+// a *debug.BuildInfo so each resolution branch (replace-version wins,
+// dep-version fallback, dep absent, dep present but no usable version)
+// can be exercised in unit tests without depending on `go build`
+// populating Deps.
+//
+// When go.mod uses a `replace` directive, the matching dep's own
+// Version field is the placeholder
+// "v0.0.0-00010101000000-000000000000"; the real version lives on
+// dep.Replace. The replacement wins when present.
+func parserVersionFrom(info *debug.BuildInfo, binVersion string) (string, error) {
+	for _, dep := range info.Deps {
+		if dep.Path != parserModulePath {
+			continue
+		}
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			return dep.Replace.Version, nil
+		}
+		if dep.Version != "" {
+			return dep.Version, nil
+		}
+		// Dep recorded but neither slot has a usable version. Treat
+		// as missing rather than reporting a confusing empty string.
+		break
+	}
+	if binVersion == devVersion {
+		return "unknown", nil
+	}
+	return "", fmt.Errorf("parser module %q missing from build info; blank import may have been dropped", parserModulePath)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionCmd exercises the `version` subcommand end-to-end through
+// a fresh root command.
+//
+// The binary line is pinned exactly: Version is the package var "dev"
+// under `go test` (release stamping happens via -ldflags only).
+//
+// The parser line is checked for shape only. Under `go test`,
+// debug.ReadBuildInfo().Deps does not list cockroachdb-parser even
+// though the cmd package's blank import pulls it into the test binary,
+// so parserVersion("dev") returns "unknown" here. The full resolution
+// path (replace present, version-only, missing dep) is covered by
+// TestParserVersionFrom against a synthetic *debug.BuildInfo.
+func TestVersionCmd(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"version"})
+
+	require.NoError(t, root.Execute())
+
+	got := buf.String()
+	require.Contains(t, got, "crdb-sql: dev\n",
+		"binary line should report Version verbatim under go test")
+
+	parserLine := extractLine(got, "cockroachdb-parser: ")
+	require.NotEmpty(t, parserLine,
+		"version output missing cockroachdb-parser line; got:\n%s", got)
+}
+
+// TestVersionCmdRejectsExtraArgs locks in the cobra.NoArgs contract on
+// the version subcommand: any positional arg beyond `version` itself
+// must produce a non-nil error from Execute. An accidental switch to
+// cobra.ArbitraryArgs would silently regress this and would be caught
+// here.
+func TestVersionCmdRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"version", "oops"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestParserVersionFrom covers each resolution branch of
+// parserVersionFrom by feeding it a synthetic *debug.BuildInfo. This
+// is the path that's invisible to TestVersionCmd because `go test`
+// does not populate ReadBuildInfo().Deps.
+func TestParserVersionFrom(t *testing.T) {
+	tests := []struct {
+		name           string
+		deps           []*debug.Module
+		binVersion     string
+		expected       string
+		expectedErrSub string
+	}{
+		{
+			name: "replace version wins over placeholder",
+			deps: []*debug.Module{
+				{
+					Path:    parserModulePath,
+					Version: "v0.0.0-00010101000000-000000000000",
+					Replace: &debug.Module{Version: "v0.26.2"},
+				},
+			},
+			binVersion: devVersion,
+			expected:   "v0.26.2",
+		},
+		{
+			name: "dep version used when no replace",
+			deps: []*debug.Module{
+				{Path: parserModulePath, Version: "v0.26.2"},
+			},
+			binVersion: devVersion,
+			expected:   "v0.26.2",
+		},
+		{
+			name:       "missing dep tolerated for dev build",
+			deps:       []*debug.Module{{Path: "example.com/other", Version: "v1.0.0"}},
+			binVersion: devVersion,
+			expected:   "unknown",
+		},
+		{
+			name:           "missing dep is hard error for stamped build",
+			deps:           []*debug.Module{{Path: "example.com/other", Version: "v1.0.0"}},
+			binVersion:     "v1.2.3",
+			expectedErrSub: "missing from build info",
+		},
+		{
+			name: "dep present but version empty falls through to missing",
+			deps: []*debug.Module{
+				{Path: parserModulePath, Replace: &debug.Module{Version: ""}},
+			},
+			binVersion: devVersion,
+			expected:   "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &debug.BuildInfo{Deps: tc.deps}
+			got, err := parserVersionFrom(info, tc.binVersion)
+			if tc.expectedErrSub != "" {
+				require.ErrorContains(t, err, tc.expectedErrSub)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// extractLine returns the substring following prefix on the line where
+// it appears, with the trailing newline stripped. Returns "" if prefix
+// is not found.
+func extractLine(s, prefix string) string {
+	idx := strings.Index(s, prefix)
+	if idx < 0 {
+		return ""
+	}
+	rest := s[idx+len(prefix):]
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		rest = rest[:nl]
+	}
+	return rest
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,11 @@ go 1.26
 
 toolchain go1.26.2
 
-require github.com/cockroachdb/cockroachdb-parser v0.26.2
+require (
+	github.com/cockroachdb/cockroachdb-parser v0.0.0-00010101000000-000000000000
+	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/bazelbuild/rules_go v0.46.0 // indirect
@@ -30,6 +34,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jaegertracing/jaeger v1.18.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -41,8 +46,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/twpayne/go-geom v1.4.1 // indirect
 	github.com/twpayne/go-kml v1.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
@@ -261,6 +262,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jaegertracing/jaeger v1.18.1 h1:eFqjEpTKq2FfiZ/YX53oxeCePdIZyWvDfXaTAGj0r5E=
 github.com/jaegertracing/jaeger v1.18.1/go.mod h1:WRzMFH62rje1VgbShlgk6UbWUNoo08uFFvs/x50aZKk=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -396,6 +399,7 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
 github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/sectioneight/md-to-godoc v0.0.0-20161108233149-55e43be6c335/go.mod h1:lPZq22klO8la1kyImIDhrGytugMV0TsrsZB55a+xxI0=
@@ -416,11 +420,14 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spilchen/cockroachdb-parser v0.26.2 h1:nChOYJrs1ATSkD+5jGy85ktaxNfDmTH4tHfeb5v8Buo=
 github.com/spilchen/cockroachdb-parser v0.26.2/go.mod h1:mPvhIwz0gDHQczlYlTTCZjLLoEF+krKST+ywrWTZLNE=
@@ -497,6 +504,7 @@ go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -3,27 +3,25 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-// Command sql-ai-tools is the CLI / MCP server entry point for the
-// agent-friendly CockroachDB SQL tooling described in the project README.
+// Command crdb-sql is the CLI entry point for the agent-friendly
+// CockroachDB SQL tooling described in the project README. It is a thin
+// shell over the cobra command tree in package cmd; all behavior lives
+// there.
 package main
 
 import (
 	"fmt"
-	"log"
+	"os"
 
-	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
-	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/spilchen/sql-ai-tools/cmd"
 )
 
 func main() {
-	stmt, err := parser.ParseOne("SELECT 1")
-	if err != nil {
-		log.Fatal(err)
+	if err := cmd.Execute(); err != nil {
+		// cmd.Execute() suppresses cobra's own error printing
+		// (SilenceErrors on rootCmd) so that this is the single
+		// place errors reach the user.
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
 	}
-	cfg := tree.DefaultPrettyCfg()
-	pretty, err := cfg.Pretty(stmt.AST)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(pretty)
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder `main.go` (hardcoded `SELECT 1` parser demo) with a cobra command tree so future subcommands (validate/format/parse/etc., issues #2/#3/#5/#6/#9/#11/#18/#24/#26/#27/#30/#31/#32) can register against a stable root.

Visible behaviours:

- `crdb-sql --help` lists subcommands.
- `crdb-sql version` prints the binary version and the resolved cockroachdb-parser module version.

## Notable design choices

- **Binary renamed** from `sql-ai-tools` to `crdb-sql` per the issue's Demo. Only the binary moves; the project, Go module path, and GitHub repo remain `sql-ai-tools` (the umbrella for the CLI plus the future MCP server). Makefile, README, and CLAUDE.md updated.
- **Error contract pinned**: `cmd/root.go` sets both `SilenceUsage: true` and `SilenceErrors: true`; `main` owns error printing and exit-code translation as a single source of truth.
- **Parser version resolution** via `runtime/debug.ReadBuildInfo()`, preferring `dep.Replace.Version` so the spilchen fork's tag is reported (the recorded version is the `v0.0.0-00010101000000-...` placeholder when a `replace` directive is in effect).
- **Blank import** of `cockroachdb-parser/pkg/sql/parser` in `cmd/version.go` anchors the module in the build graph so it appears in `info.Deps`. Safe to remove once a real subcommand imports a parser package directly.
- **EPIPE swallowed** in `version` RunE so `crdb-sql version | head -0` exits 0 cleanly.

## Test coverage

`cmd/version_test.go` exercises the subcommand end-to-end through the cobra root and pins the binary line exactly. The parser line is shape-checked only because under `go test`, cockroachdb-parser is not enumerated in `info.Deps` even with the blank import — the full resolution path is exercised manually against a real `go build` of the binary (`./bin/crdb-sql version` reports `cockroachdb-parser: v0.26.2`).

Resolves #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)