### PR TITLE
mcp: add stdio MCP server skeleton with ping tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,40 @@ Produces `bin/crdb-sql`.
 # cockroachdb-parser: v0.26.2
 ```
 
+### Use as an MCP server
+
+`crdb-sql mcp` runs the binary as a Model Context Protocol server over
+stdio. The current build only registers a `ping` health-check tool;
+real SQL tools (`validate_sql`, `format_sql`, …) listed in the
+[Features](#features) table land in subsequent issues.
+
+Register the binary with Claude Code:
+
+```bash
+claude mcp add crdb-sql -- "$(pwd)/bin/crdb-sql" mcp
+```
+
+The leading `--` is required so the `mcp` argument is forwarded to
+`crdb-sql` instead of being parsed by the `claude` CLI. No transport
+flags are needed — `claude mcp add` defaults to stdio, which is what
+this server speaks.
+
+Verify discovery from inside Claude Code:
+
+```
+/mcp
+```
+
+`crdb-sql` should appear in the list with its `ping` tool. Calling
+`ping` returns:
+
+```json
+{"ok": true, "parser_version": "v0.26.2"}
+```
+
+The `parser_version` value should match the `cockroachdb-parser:` line
+from `./bin/crdb-sql version`.
+
 ### Test & Lint
 
 ```bash

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+
+	internalmcp "github.com/spilchen/sql-ai-tools/internal/mcp"
+)
+
+// newMCPCmd builds the `crdb-sql mcp` subcommand. It launches an MCP
+// server bound to stdio so an MCP client (Claude Code, VS Code, etc.)
+// can spawn the binary and discover the registered tools. The command
+// blocks until the client disconnects (stdin closes); a clean
+// disconnect returns nil, anything else surfaces as the cobra error.
+//
+// Today the only registered tool is the `ping` skeleton from
+// internal/mcp; future issues attach the real tools to the same server
+// constructor.
+func newMCPCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcp",
+		Short: "Run the crdb-sql MCP server on stdio",
+		Long: `Start an MCP (Model Context Protocol) server that speaks JSON-RPC
+over stdio. Intended to be launched by an MCP client (e.g. Claude Code
+via "claude mcp add"); the process exits when the client closes stdin.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// Resolve the parser version up front so a stamped release
+			// build with a missing dep fails fast — same hard-fail
+			// behavior the version subcommand uses, rather than letting
+			// the server come up reporting a confusing empty string.
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return err
+			}
+			s := internalmcp.NewServer(Version, parserVer)
+			// Wrap the transport error so a failure in the stdio loop
+			// surfaces through cobra's "Error:" line as obviously
+			// transport-layer rather than as an opaque message from
+			// somewhere deep in mcp-go. %w preserves errors.Is/As for
+			// any caller that wants to distinguish specific causes.
+			if err := server.ServeStdio(s); err != nil {
+				return fmt.Errorf("mcp stdio server: %w", err)
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPCmdRegistered guards the cobra wiring: the `mcp` subcommand
+// must be discoverable from a fresh root, and `mcp --help` must succeed
+// and print the subcommand's Use line. We deliberately do not exercise
+// the stdio loop here — that requires speaking JSON-RPC and belongs to
+// the manual "register with Claude Code" verification in the README.
+func TestMCPCmdRegistered(t *testing.T) {
+	root := newRootCmd()
+
+	sub, _, err := root.Find([]string{"mcp"})
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+	require.Equal(t, "mcp", sub.Name())
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mcp", "--help"})
+	require.NoError(t, root.Execute())
+	require.Contains(t, buf.String(), "crdb-sql mcp")
+}
+
+// TestMCPCmdRejectsExtraArgs locks in cobra.NoArgs on the mcp
+// subcommand so an accidental switch (e.g. to ArbitraryArgs) — which
+// would let a stray argument silently swallow stdio — fails loudly.
+func TestMCPCmdRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mcp", "oops"})
+
+	require.Error(t, root.Execute())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ round-tripping through a live cluster.`,
 		SilenceErrors: true,
 	}
 	root.AddCommand(newVersionCmd())
+	root.AddCommand(newMCPCmd())
 	return root
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.2
 
 require (
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-00010101000000-000000000000
+	github.com/mark3labs/mcp-go v0.48.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.10.0
 )
@@ -31,6 +32,7 @@ require (
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
@@ -46,9 +48,11 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/twpayne/go-geom v1.4.1 // indirect
 	github.com/twpayne/go-kml v1.5.2 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/fanixk/geohash v0.0.0-20150324002647-c1f9b5fa157a/go.mod h1:UgNw+PTmm
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.7.3/go.mod h1:V1d2J5pfxYH6EjBAgSK7YNXcXlTWxUHdE1sVDXkjnig=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
@@ -230,6 +232,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -307,6 +311,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mark3labs/mcp-go v0.48.0 h1:o+MXuGW/HCeR2ny5LcAcZQn2bo6I2xaZMEHnpRG+dtw=
+github.com/mark3labs/mcp-go v0.48.0/go.mod h1:JKTC7R2LLVagkEWK7Kwu7DbmA6iIvnNAod6yrHiQMag=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -419,6 +425,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
@@ -465,6 +473,8 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package mcp builds the crdb-sql Model Context Protocol server.
+//
+// Today the server only registers the `ping` health-check tool; future
+// issues will hang real SQL-aware tools (validate_sql, format_sql, …)
+// off the same NewServer constructor. Keeping construction pure (no
+// transport, no I/O) lets the cmd layer pick a transport — currently
+// just stdio — and lets tests exercise individual tool handlers
+// directly.
+//
+// Versions are passed in by the caller rather than read from
+// debug.ReadBuildInfo here, so this package stays free of
+// build-info plumbing. The cmd/version.go helpers own that
+// resolution and feed the resolved strings to NewServer.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// PingToolName is the registered name of the health-check tool. Exposed
+// as a constant so tests and the README/docs reference a single source
+// of truth.
+const PingToolName = "ping"
+
+// NewServer constructs an MCP server for crdb-sql. binaryVersion is the
+// crdb-sql binary version string (typically cmd.Version), and
+// parserVersion is the resolved cockroachdb-parser module version
+// (typically the result of cmd.parserVersion). Both are reported
+// verbatim — by the server handshake (binaryVersion) and by the `ping`
+// tool (parserVersion) — so callers should resolve them before invoking
+// NewServer.
+//
+// The returned server has no transport bound; callers wire it to stdio
+// (or, in the future, sse/http) themselves.
+func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
+	s := server.NewMCPServer(
+		"crdb-sql",
+		binaryVersion,
+		server.WithToolCapabilities(false /* listChanged */),
+	)
+	s.AddTool(
+		mcp.NewTool(
+			PingToolName,
+			mcp.WithDescription(`Health check. Returns {"ok": true, "parser_version": "<v>"} so clients can confirm the server is alive and see which cockroachdb-parser version it was built against.`),
+		),
+		pingHandler(parserVersion),
+	)
+	return s
+}
+
+// pingHandler returns the handler for the `ping` tool. The parser
+// version is captured at construction time and embedded in every
+// response, so a single server instance always reports a stable
+// version for the lifetime of the process.
+func pingHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		payload := pingResult{OK: true, ParserVersion: parserVersion}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			// json.Marshal of a struct with only string/bool fields cannot
+			// fail in practice, but surface any future regression as a
+			// tool-level error rather than a panic.
+			return mcp.NewToolResultError(fmt.Sprintf("encode ping result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(body)), nil
+	}
+}
+
+// pingResult is the JSON shape returned by the `ping` tool. Field tags
+// are the contract: clients (including Claude Code) read `ok` and
+// `parser_version` by name, so renames here are breaking changes.
+type pingResult struct {
+	OK            bool   `json:"ok"`
+	ParserVersion string `json:"parser_version"`
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPingHandler exercises the ping tool handler directly, bypassing
+// the MCP transport. The handler must always return ok=true and echo
+// back the parser version it was constructed with — that's the contract
+// clients (and the README's verification step) rely on.
+func TestPingHandler(t *testing.T) {
+	tests := []struct {
+		name                  string
+		parserVersion         string
+		expectedParserVersion string
+	}{
+		{
+			name:                  "stamped semver",
+			parserVersion:         "v0.26.2",
+			expectedParserVersion: "v0.26.2",
+		},
+		{
+			name:                  "dev fallback string",
+			parserVersion:         "unknown",
+			expectedParserVersion: "unknown",
+		},
+		{
+			name:                  "empty version is passed through verbatim",
+			parserVersion:         "",
+			expectedParserVersion: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := pingHandler(tc.parserVersion)
+			res, err := handler(context.Background(), mcpgo.CallToolRequest{})
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.False(t, res.IsError, "ping must not report a tool-level error")
+			require.Len(t, res.Content, 1, "ping should emit a single content block")
+
+			text, ok := res.Content[0].(mcpgo.TextContent)
+			require.True(t, ok, "ping content should be TextContent, got %T", res.Content[0])
+
+			// Pin the exact wire shape — round-tripping through pingResult
+			// would mask a json-tag rename (e.g. parser_version ->
+			// parserVersion), which is the contract change pingResult's
+			// doc warns about.
+			expectedJSON, err := json.Marshal(map[string]any{
+				"ok":             true,
+				"parser_version": tc.expectedParserVersion,
+			})
+			require.NoError(t, err)
+			require.JSONEq(t, string(expectedJSON), text.Text)
+		})
+	}
+}
+
+// TestNewServerRegistersPing locks in that NewServer wires the ping
+// tool under its documented name. A future refactor that forgets to
+// call AddTool — or renames the tool — would silently break MCP
+// clients; this test surfaces it without speaking the protocol.
+func TestNewServerRegistersPing(t *testing.T) {
+	s := NewServer("v1.2.3", "v0.26.2")
+	require.NotNil(t, s)
+	tools := s.ListTools()
+	require.Contains(t, tools, PingToolName)
+	require.NotNil(t, tools[PingToolName].Handler,
+		"ping must be registered with a non-nil handler")
+	require.NotEmpty(t, tools[PingToolName].Tool.Description,
+		"ping description is part of the user-facing contract")
+}


### PR DESCRIPTION
## Summary

Stand up the Model Context Protocol surface so the tier-1 issues
(#10/#17/#19/#20/#24) have a place to register real SQL tools without
each one re-litigating the server wiring.

- New `crdb-sql mcp` subcommand runs an mcp-go server on stdio and
  registers a single `ping` health-check tool returning
  `{"ok": true, "parser_version": "<v>"}`.
- New `internal/mcp` package owns server construction; transport stays
  in the cmd layer. Versions are passed in by the caller, so the
  package stays free of build-info plumbing and reuses the existing
  `parserVersion(Version)` resolver from `cmd/version.go` (same
  hard-fail-on-stamped-build behavior as `version`).
- README gains a "Use as an MCP server" section with the exact
  `claude mcp add` invocation (the leading `--` is required so the
  `mcp` arg isn't parsed by the `claude` CLI).

Verified end-to-end by piping a hand-rolled JSON-RPC
initialize/tools/call sequence at `bin/crdb-sql mcp` and confirming
the `ping` response matches the README example.

Resolves: #9