### PR TITLE
cli: add JSON output envelope and --output flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,12 +16,31 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
 )
+
+// rootState is the per-invocation container for cobra-resolved global
+// state that subcommands need to read. It is populated by the root
+// command's PersistentPreRunE (which runs after flag parsing, before
+// any subcommand RunE) and read by subcommand RunE closures via the
+// pointer captured at construction time.
+//
+// Lifecycle: one instance per newRootCmd call, discarded when Execute
+// returns. This is what keeps tests independent — package globals would
+// leak the previous test's --output value into the next.
+type rootState struct {
+	// outputFormat is the validated --output value. Subcommands read it
+	// after PersistentPreRunE has run; reading it earlier yields the
+	// zero value.
+	outputFormat output.Format
+}
 
 // newRootCmd builds a fresh root command with all subcommands attached.
 // Construct one per Execute call (and per test) so cobra's parsed-flag
 // state never leaks across invocations.
 func newRootCmd() *cobra.Command {
+	state := &rootState{}
 	root := &cobra.Command{
 		Use:   "crdb-sql",
 		Short: "Agent-friendly SQL tooling for CockroachDB",
@@ -36,11 +55,30 @@ round-tripping through a live cluster.`,
 		// these without updating that caller.
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			raw, err := cmd.Flags().GetString(outputFlag)
+			if err != nil {
+				return err
+			}
+			f, err := output.ParseFormat(raw)
+			if err != nil {
+				return err
+			}
+			state.outputFormat = f
+			return nil
+		},
 	}
-	root.AddCommand(newVersionCmd())
+	root.PersistentFlags().StringP(outputFlag, "o", string(output.FormatText),
+		`output format: "text" or "json"`)
+	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }
+
+// outputFlag is the name of the persistent --output flag. It is shared
+// between the root command's flag registration and PersistentPreRunE
+// lookup so the two stay in sync.
+const outputFlag = "output"
 
 // Execute runs the root command against process arguments and returns
 // whatever cobra surfaces. It does not print the error or call

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"runtime/debug"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -22,6 +23,8 @@ import (
 	// "unknown" — see TestParserVersionFrom for the synthetic-BuildInfo
 	// coverage that exercises the real resolution branches.
 	_ "github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
 // parserModulePath is the import path we look up in build info to
@@ -44,7 +47,7 @@ const devVersion = "dev"
 // Release tooling owns this value; do not mutate it from runtime code.
 var Version = devVersion
 
-func newVersionCmd() *cobra.Command {
+func newVersionCmd(state *rootState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print binary and parser versions",
@@ -54,25 +57,32 @@ embedded Go build info, so it reflects whatever go.mod (including any
 replace directive) selected at build time.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			// baseEnv is the partial context used on both the
+			// success path and the JSON-mode error path. The error
+			// path needs ConnectionStatus populated so agents see a
+			// well-formed envelope even when ParserVersion / Data
+			// resolution fails.
+			baseEnv := output.Envelope{
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
 			parser, err := parserVersion(Version)
 			if err != nil {
-				return err
+				return r.RenderError(baseEnv, err)
 			}
-			// Suppress EPIPE: it's the normal outcome when a downstream
-			// consumer closes stdout early (e.g. piping into `head -n1`
-			// of a future longer-output subcommand). Surfacing it as a
-			// non-zero exit with a stderr "broken pipe" message is
-			// hostile for a tool meant to be piped. Partial output is
-			// acceptable for `version` (the user has already seen at
-			// least one useful line by the time the pipe closes). The
-			// EPIPE check is Linux/macOS only; Windows is not a
-			// supported target so we don't guard for ERROR_BROKEN_PIPE.
-			out := cmd.OutOrStdout()
-			_, werr := fmt.Fprintf(out, "crdb-sql: %s\ncockroachdb-parser: %s\n", Version, parser)
-			if werr != nil && !errors.Is(werr, syscall.EPIPE) {
+			data, err := json.Marshal(struct {
+				BinaryVersion string `json:"binary_version"`
+			}{BinaryVersion: Version})
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			env := baseEnv
+			env.ParserVersion = parser
+			env.Data = data
+			return r.Render(env, func(w io.Writer) error {
+				_, werr := fmt.Fprintf(w, "crdb-sql: %s\ncockroachdb-parser: %s\n", Version, parser)
 				return werr
-			}
-			return nil
+			})
 		},
 	}
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -7,11 +7,14 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"runtime/debug"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
 // TestVersionCmd exercises the `version` subcommand end-to-end through
@@ -42,6 +45,55 @@ func TestVersionCmd(t *testing.T) {
 	parserLine := extractLine(got, "cockroachdb-parser: ")
 	require.NotEmpty(t, parserLine,
 		"version output missing cockroachdb-parser line; got:\n%s", got)
+}
+
+// TestVersionCmdJSON exercises --output json end-to-end. The
+// parser_version is checked for shape (see TestVersionCmd's note on
+// why it resolves to "unknown" under go test); binary_version inside
+// data is pinned to "dev" since release stamping happens via -ldflags.
+func TestVersionCmdJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"version", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	// JSON mode contract: stdout is the single source of truth.
+	// Anything on stderr would force agents to merge two streams.
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+	require.NotContains(t, stdout.String(), "crdb-sql: ",
+		"JSON mode must not also emit text-mode lines")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.ParserVersion, "parser_version must be populated")
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Equal(t, output.TierUnset, env.Tier, "version has no tier")
+	require.Empty(t, env.Errors)
+
+	var data struct {
+		BinaryVersion string `json:"binary_version"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &data))
+	require.Equal(t, "dev", data.BinaryVersion)
+}
+
+// TestRootRejectsBadOutput locks in the PersistentPreRunE validation:
+// any --output value other than text/json must fail with a message
+// naming the valid choices.
+func TestRootRejectsBadOutput(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"version", "--output", "xml"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, `"text"`)
+	require.ErrorContains(t, err, `"json"`)
 }
 
 // TestVersionCmdRejectsExtraArgs locks in the cobra.NoArgs contract on

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package output defines the shared response shape every crdb-sql
+// subcommand emits when --output=json, plus the renderer that switches
+// between text and JSON.
+//
+// The Envelope describes the analysis context — which tier produced the
+// result, which parser version was used, whether a cluster was reached —
+// and carries a uniform Errors list for agent consumption. Subcommand-
+// specific payload lives in Data so the envelope itself never needs to
+// learn about new commands. The schema is derived from the JSON
+// error-output example in docs/design_doc.md (search "Error output");
+// fields like statement_type that are subcommand-specific live in Data
+// rather than in the envelope itself.
+package output
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ErrRendered is returned by Renderer.RenderError after it has emitted
+// an envelope describing the failure. main.go uses errors.Is to
+// recognize this sentinel and suppress its default "Error: ..." stderr
+// print, while still exiting with a non-zero status. This preserves the
+// JSON-mode contract that stdout is the single source of truth and keeps
+// agents from having to parse stderr.
+var ErrRendered = errors.New("output: error already rendered as envelope")
+
+// Tier identifies which analysis tier produced a response. The names
+// and order match the "Three analysis tiers" section in
+// docs/design_doc.md:
+//
+//	zero_config — Tier 1, expression type checking (zero-config).
+//	schema_file — Tier 2, name resolution (requires schema files).
+//	connected   — Tier 3, connected validation.
+//
+// TierUnset is the zero value and indicates the command has no tier
+// semantics (e.g. version).
+type Tier string
+
+// Tier values.
+const (
+	TierUnset      Tier = ""
+	TierZeroConfig Tier = "zero_config"
+	TierSchemaFile Tier = "schema_file"
+	TierConnected  Tier = "connected"
+)
+
+// ConnectionStatus reports whether the command reached a live cluster.
+// Commands that never connect (version, parse, format) report
+// ConnectionDisconnected.
+type ConnectionStatus string
+
+// ConnectionStatus values.
+const (
+	ConnectionDisconnected ConnectionStatus = "disconnected"
+	ConnectionConnected    ConnectionStatus = "connected"
+)
+
+// Envelope is the response contract every crdb-sql subcommand returns
+// under --output=json.
+//
+// Lifecycle: built fresh by the subcommand's RunE, marshalled once by
+// Renderer.Render, then discarded. No long-lived state.
+//
+// Field discipline:
+//   - Tier uses omitempty so commands without tier semantics (e.g.
+//     version) omit the field rather than emitting a misleading empty
+//     string. This relies on TierUnset being the empty-string zero
+//     value.
+//   - ParserVersion and ConnectionStatus are always emitted so agents
+//     can rely on their presence.
+//   - Errors uses omitempty so a clean run produces no errors key
+//     rather than a noisy "errors": null.
+//   - Data is json.RawMessage so each subcommand controls its own
+//     payload marshalling and this package never depends on subcommand
+//     types.
+type Envelope struct {
+	Tier             Tier             `json:"tier,omitempty"`
+	ParserVersion    string           `json:"parser_version"`
+	ConnectionStatus ConnectionStatus `json:"connection_status"`
+	Errors           []Error          `json:"errors,omitempty"`
+	Data             json.RawMessage  `json:"data,omitempty"`
+}
+
+// Severity is the severity level of a structured Error. Values use the
+// PostgreSQL frontend/backend protocol severity strings (uppercase) so
+// wire output matches what agents see from a live cluster. Defining the
+// set as named constants prevents subcommands from drifting between
+// "ERROR"/"error"/"Error" as more error producers come online.
+type Severity string
+
+// Severity values.
+const (
+	SeverityError   Severity = "ERROR"
+	SeverityWarning Severity = "WARNING"
+	SeverityNotice  Severity = "NOTICE"
+	SeverityFatal   Severity = "FATAL"
+	SeverityPanic   Severity = "PANIC"
+)
+
+// Error is the per-error schema agents consume; the fields are derived
+// from the JSON example in docs/design_doc.md (search "Error output"). Code,
+// Severity, and Message are required (every error has them); Position,
+// Category, Context, and Suggestions are optional so early subcommands
+// can populate only what they have. Richer enrichment lands with later
+// issues.
+type Error struct {
+	Code        string         `json:"code"`
+	Severity    Severity       `json:"severity"`
+	Message     string         `json:"message"`
+	Position    *Position      `json:"position,omitempty"`
+	Category    string         `json:"category,omitempty"`
+	Context     map[string]any `json:"context,omitempty"`
+	Suggestions []Suggestion   `json:"suggestions,omitempty"`
+}
+
+// Position is a 1-based line/column with a 0-based byte offset, matching
+// the convention used by the CockroachDB parser.
+type Position struct {
+	Line       int `json:"line"`
+	Column     int `json:"column"`
+	ByteOffset int `json:"byte_offset"`
+}
+
+// Suggestion is a structured fix proposal: replace bytes [Range.Start,
+// Range.End) with Replacement. Confidence is in [0, 1]; Reason is a
+// machine-readable label (e.g. "levenshtein_distance_1").
+type Suggestion struct {
+	Replacement string  `json:"replacement"`
+	Range       Range   `json:"range"`
+	Confidence  float64 `json:"confidence"`
+	Reason      string  `json:"reason"`
+}
+
+// Range is a half-open byte range [Start, End) into the original input.
+type Range struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}

--- a/internal/output/envelope_test.go
+++ b/internal/output/envelope_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnvelopeMarshal pins the on-the-wire JSON layout. Downstream
+// agents key off these field names; an accidental rename or omitempty
+// change must fail this test rather than ship as a silent breaking
+// change.
+func TestEnvelopeMarshal(t *testing.T) {
+	tests := []struct {
+		name         string
+		envelope     Envelope
+		expectedJSON string
+	}{
+		{
+			name: "minimal version-style envelope omits tier and errors",
+			envelope: Envelope{
+				ParserVersion:    "v0.26.2",
+				ConnectionStatus: ConnectionDisconnected,
+				Data:             json.RawMessage(`{"binary_version":"dev"}`),
+			},
+			expectedJSON: `{
+  "parser_version": "v0.26.2",
+  "connection_status": "disconnected",
+  "data": {
+    "binary_version": "dev"
+  }
+}`,
+		},
+		{
+			name: "tier emitted when set",
+			envelope: Envelope{
+				Tier:             TierSchemaFile,
+				ParserVersion:    "v0.26.2",
+				ConnectionStatus: ConnectionDisconnected,
+			},
+			expectedJSON: `{
+  "tier": "schema_file",
+  "parser_version": "v0.26.2",
+  "connection_status": "disconnected"
+}`,
+		},
+		{
+			name: "errors-only envelope",
+			envelope: Envelope{
+				ParserVersion:    "v0.26.2",
+				ConnectionStatus: ConnectionDisconnected,
+				Errors: []Error{{
+					Code:     "42703",
+					Severity: SeverityError,
+					Message:  `column "nme" does not exist`,
+					Position: &Position{Line: 1, Column: 8, ByteOffset: 7},
+					Category: "unknown_column",
+					Suggestions: []Suggestion{{
+						Replacement: "name",
+						Range:       Range{Start: 7, End: 10},
+						Confidence:  0.9,
+						Reason:      "levenshtein_distance_1",
+					}},
+				}},
+			},
+			expectedJSON: `{
+  "parser_version": "v0.26.2",
+  "connection_status": "disconnected",
+  "errors": [
+    {
+      "code": "42703",
+      "severity": "ERROR",
+      "message": "column \"nme\" does not exist",
+      "position": {
+        "line": 1,
+        "column": 8,
+        "byte_offset": 7
+      },
+      "category": "unknown_column",
+      "suggestions": [
+        {
+          "replacement": "name",
+          "range": {
+            "start": 7,
+            "end": 10
+          },
+          "confidence": 0.9,
+          "reason": "levenshtein_distance_1"
+        }
+      ]
+    }
+  ]
+}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.MarshalIndent(tc.envelope, "", "  ")
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedJSON, string(got))
+		})
+	}
+}
+
+// TestParseFormat covers the validation contract: only "text" and
+// "json" pass; anything else returns an error naming both valid
+// choices.
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expected       Format
+		expectedErrSub string
+	}{
+		{name: "text", input: "text", expected: FormatText},
+		{name: "json", input: "json", expected: FormatJSON},
+		{name: "case sensitive: TEXT rejected", input: "TEXT", expectedErrSub: `invalid --output "TEXT"`},
+		{name: "unknown format rejected", input: "xml", expectedErrSub: `"text"`},
+		{name: "empty rejected", input: "", expectedErrSub: `"json"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseFormat(tc.input)
+			if tc.expectedErrSub != "" {
+				require.ErrorContains(t, err, tc.expectedErrSub)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestRendererText delegates to the supplied text closure and ignores
+// the envelope.
+func TestRendererText(t *testing.T) {
+	var buf bytes.Buffer
+	r := Renderer{Format: FormatText, Out: &buf}
+	err := r.Render(Envelope{ParserVersion: "v0.26.2"}, func(w io.Writer) error {
+		_, err := w.Write([]byte("hello\n"))
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", buf.String())
+}
+
+// fakeWriter is a stub io.Writer that returns a fixed error from Write.
+// Used to drive the EPIPE-suppression and write-error branches without
+// touching real OS pipes (which would be racy under `go test`).
+type fakeWriter struct {
+	err error
+}
+
+func (w fakeWriter) Write(_ []byte) (int, error) { return 0, w.err }
+
+// TestRendererSuppressesEPIPE pins the contract that EPIPE from the
+// downstream writer is silently dropped (downstream consumer closed
+// stdout early, e.g. `crdb-sql foo | head -n1`) but unrelated write
+// errors propagate. Both formats share the same suppression site, so
+// both are exercised here.
+func TestRendererSuppressesEPIPE(t *testing.T) {
+	otherErr := errors.New("disk full")
+
+	tests := []struct {
+		name         string
+		writeErr     error
+		expectedErr  error
+		expectedNoOp bool
+	}{
+		{name: "no error", writeErr: nil, expectedNoOp: true},
+		{name: "bare EPIPE suppressed", writeErr: syscall.EPIPE, expectedNoOp: true},
+		{name: "wrapped EPIPE suppressed", writeErr: fmt.Errorf("write: %w", syscall.EPIPE), expectedNoOp: true},
+		{name: "unrelated write error propagates", writeErr: otherErr, expectedErr: otherErr},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+"/json", func(t *testing.T) {
+			r := Renderer{Format: FormatJSON, Out: fakeWriter{err: tc.writeErr}}
+			err := r.Render(Envelope{ParserVersion: "v0.26.2"}, nil)
+			if tc.expectedNoOp {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+		t.Run(tc.name+"/text", func(t *testing.T) {
+			r := Renderer{Format: FormatText, Out: fakeWriter{err: tc.writeErr}}
+			err := r.Render(Envelope{}, func(w io.Writer) error {
+				_, werr := w.Write([]byte("hi\n"))
+				return werr
+			})
+			if tc.expectedNoOp {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// TestRendererPropagatesMarshalError pins that envelope-marshal failures
+// are NOT swallowed by the EPIPE filter — they're a programming error in
+// the subcommand (handed Renderer un-marshalable Data) and must surface
+// so the regression is caught.
+func TestRendererPropagatesMarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	r := Renderer{Format: FormatJSON, Out: &buf}
+	// Invalid JSON in RawMessage causes MarshalIndent to fail.
+	err := r.Render(Envelope{Data: json.RawMessage("not json")}, nil)
+	require.ErrorContains(t, err, "marshal envelope")
+	require.Empty(t, buf.String(), "no partial output should be written when marshalling fails")
+}
+
+// TestRendererRejectsUnsupportedFormat covers the defensive default
+// branch that fires only if a caller bypasses ParseFormat (e.g.
+// constructing a Renderer with Format="xml" directly).
+func TestRendererRejectsUnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	r := Renderer{Format: Format("xml"), Out: &buf}
+	err := r.Render(Envelope{}, nil)
+	require.ErrorContains(t, err, `unsupported output format "xml"`)
+}
+
+// TestRenderError covers the four key contract points of RenderError:
+// JSON success returns ErrRendered with a well-formed error envelope,
+// text mode passes the failure through unchanged, a write failure
+// during rendering preserves the original failure via errors.Join, and
+// pre-existing errors on the envelope are retained (append semantics).
+func TestRenderError(t *testing.T) {
+	origFailure := errors.New("parser module missing")
+
+	t.Run("json mode returns ErrRendered with error envelope", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatJSON, Out: &buf}
+		env := Envelope{
+			ParserVersion:    "v0.26.2",
+			ConnectionStatus: ConnectionDisconnected,
+			Data:             json.RawMessage(`{"binary_version":"dev"}`),
+		}
+		err := r.RenderError(env, origFailure)
+		require.ErrorIs(t, err, ErrRendered)
+
+		var got Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Len(t, got.Errors, 1)
+		require.Equal(t, "internal_error", got.Errors[0].Code)
+		require.Equal(t, SeverityError, got.Errors[0].Severity)
+		require.Equal(t, origFailure.Error(), got.Errors[0].Message)
+		require.Empty(t, got.Data, "Data must be cleared on error path")
+		require.Equal(t, "v0.26.2", got.ParserVersion,
+			"envelope context fields should be preserved")
+	})
+
+	t.Run("text mode returns original failure unchanged", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatText, Out: &buf}
+		err := r.RenderError(Envelope{}, origFailure)
+		require.ErrorIs(t, err, origFailure)
+		require.Empty(t, buf.String(), "text mode must not write anything")
+	})
+
+	t.Run("write failure preserves original via errors.Join", func(t *testing.T) {
+		writeErr := errors.New("disk full")
+		r := Renderer{Format: FormatJSON, Out: fakeWriter{err: writeErr}}
+		err := r.RenderError(Envelope{}, origFailure)
+		require.ErrorIs(t, err, origFailure, "original failure must be preserved")
+		require.ErrorContains(t, err, "render error envelope")
+		require.False(t, errors.Is(err, ErrRendered),
+			"must not return ErrRendered when rendering itself failed")
+	})
+
+	t.Run("pre-existing errors preserved via append", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatJSON, Out: &buf}
+		existing := Error{
+			Code:     "42703",
+			Severity: SeverityWarning,
+			Message:  "column not found",
+		}
+		env := Envelope{
+			ConnectionStatus: ConnectionDisconnected,
+			Errors:           []Error{existing},
+		}
+		err := r.RenderError(env, origFailure)
+		require.ErrorIs(t, err, ErrRendered)
+
+		var got Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Len(t, got.Errors, 2, "must have both pre-existing and new error")
+		require.Equal(t, "42703", got.Errors[0].Code)
+		require.Equal(t, "internal_error", got.Errors[1].Code)
+	})
+}
+
+// TestSeverityValues pins the wire string for every Severity constant.
+// Agents key off these literals (they match the PostgreSQL fe/be
+// protocol severity names); a typo here would silently change the
+// envelope contract.
+func TestSeverityValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity Severity
+		expected string
+	}{
+		{name: "error", severity: SeverityError, expected: "ERROR"},
+		{name: "warning", severity: SeverityWarning, expected: "WARNING"},
+		{name: "notice", severity: SeverityNotice, expected: "NOTICE"},
+		{name: "fatal", severity: SeverityFatal, expected: "FATAL"},
+		{name: "panic", severity: SeverityPanic, expected: "PANIC"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, string(tc.severity))
+		})
+	}
+}
+
+// TestRendererJSON marshals the envelope and ignores the text closure.
+// The trailing newline is part of the contract: terminals expect
+// well-formed lines.
+func TestRendererJSON(t *testing.T) {
+	var buf bytes.Buffer
+	r := Renderer{Format: FormatJSON, Out: &buf}
+	err := r.Render(
+		Envelope{ParserVersion: "v0.26.2", ConnectionStatus: ConnectionDisconnected},
+		func(io.Writer) error {
+			t.Fatal("text closure must not run in JSON mode")
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")),
+		"renderer must end JSON output with a newline; got %q", buf.String())
+
+	var got Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Equal(t, "v0.26.2", got.ParserVersion)
+	require.Equal(t, ConnectionDisconnected, got.ConnectionStatus)
+}

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package output
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"syscall"
+)
+
+// Format selects how a subcommand serializes its result.
+//
+//	text — human-readable, subcommand-defined layout (default).
+//	json — Envelope marshalled as indented JSON.
+type Format string
+
+// Format values.
+const (
+	FormatText Format = "text"
+	FormatJSON Format = "json"
+)
+
+// ParseFormat validates a user-supplied --output value. Only "text" and
+// "json" are accepted; any other value (including empty) produces an
+// error that names the valid choices, so cobra's surfaced message is
+// actionable.
+func ParseFormat(s string) (Format, error) {
+	switch Format(s) {
+	case FormatText:
+		return FormatText, nil
+	case FormatJSON:
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("invalid --output %q: valid choices are %q, %q", s, FormatText, FormatJSON)
+	}
+}
+
+// Renderer writes a subcommand's result in the selected format.
+//
+// For FormatText, textFn owns the output: it receives the configured
+// writer and produces whatever lines the subcommand wants (the envelope
+// is ignored). For FormatJSON, the envelope is marshalled as indented
+// JSON so piped output stays human-readable; agents that want compact
+// form can pipe through `jq -c`. A trailing newline is appended so the
+// output is a well-formed line on terminals.
+//
+// EPIPE handling: write failures with errno EPIPE are suppressed (return
+// nil) because they are the normal outcome when a downstream consumer
+// closes stdout early (e.g. piping into `head -n1`). Surfacing them as a
+// non-zero exit with a "broken pipe" message is hostile for a tool meant
+// to be piped, and partial output is acceptable. Marshal errors and the
+// unsupported-format error are NOT subject to EPIPE filtering — they are
+// propagated unchanged. On Windows the native broken-pipe error has a
+// different value (ERROR_BROKEN_PIPE), so this check would not fire
+// there; Windows is not a supported target, so we don't add a separate
+// branch.
+type Renderer struct {
+	Format Format
+	Out    io.Writer
+}
+
+// Render dispatches on r.Format. textFn must be non-nil for FormatText;
+// it is ignored for FormatJSON.
+//
+// textFn contract (FormatText only): Render passes textFn's returned
+// error through suppressEPIPE, so any error that wraps syscall.EPIPE
+// will be silently dropped — even if it did not originate from a write
+// to r.Out. To avoid accidental suppression, textFn should perform only
+// writes (fmt.Fprintf, w.Write, etc.) and return their errors directly.
+// Pre-write work (formatting, lookups) should happen before calling
+// Render so that textFn's error space is limited to write failures.
+func (r Renderer) Render(env Envelope, textFn func(io.Writer) error) error {
+	switch r.Format {
+	case FormatJSON:
+		buf, err := json.MarshalIndent(env, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal envelope: %w", err)
+		}
+		_, err = r.Out.Write(append(buf, '\n'))
+		return suppressEPIPE(err)
+	case FormatText:
+		return suppressEPIPE(textFn(r.Out))
+	default:
+		// Defensive: ParseFormat should have rejected this earlier.
+		return fmt.Errorf("unsupported output format %q", r.Format)
+	}
+}
+
+// RenderError is the JSON-mode error path. It appends a single Error
+// describing failure to env, renders the envelope, and returns
+// ErrRendered so the caller (and main.go) know the failure has already
+// been surfaced as structured output and should not be reprinted to
+// stderr. In text mode it returns failure unchanged so cobra/main.go's
+// existing "Error: ..." path runs.
+//
+// The envelope's Data field is cleared because the partial result that
+// motivated env (parser version, connection status) is still meaningful
+// context, but any subcommand payload would be misleading on the error
+// path. ParserVersion and ConnectionStatus may be empty if the failure
+// happened before they were resolved; that is acceptable, since the
+// errors entry is the load-bearing field for agents in this case.
+//
+// If marshalling the error envelope itself fails, both the original
+// failure and the marshal/write error are joined (via errors.Join) so
+// main.go's stderr fallback shows both causes. The joined error is NOT
+// wrapped in ErrRendered so main.go prints it.
+//
+// EPIPE edge case: if the downstream consumer has already closed the
+// pipe, Render succeeds (EPIPE is suppressed) and RenderError returns
+// ErrRendered even though nothing reached stdout. This is intentional:
+// the consumer abandoned the pipe, so no output channel remains and
+// the best we can do is exit non-zero.
+func (r Renderer) RenderError(env Envelope, failure error) error {
+	if r.Format != FormatJSON {
+		return failure
+	}
+	env.Errors = append(env.Errors, Error{
+		Code:     "internal_error",
+		Severity: SeverityError,
+		Message:  failure.Error(),
+	})
+	env.Data = nil
+	if err := r.Render(env, nil); err != nil {
+		return errors.Join(failure, fmt.Errorf("render error envelope: %w", err))
+	}
+	return ErrRendered
+}
+
+// suppressEPIPE returns nil if err is a syscall.EPIPE (broken pipe from
+// a downstream consumer closing stdout early); otherwise it returns err
+// unchanged. See the Renderer doc for rationale.
+func suppressEPIPE(err error) error {
+	if err == nil || errors.Is(err, syscall.EPIPE) {
+		return nil
+	}
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -10,18 +10,35 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/spilchen/sql-ai-tools/cmd"
+	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
 		// cmd.Execute() suppresses cobra's own error printing
 		// (SilenceErrors on rootCmd) so that this is the single
-		// place errors reach the user.
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		// place errors reach the user. output.ErrRendered means
+		// the failure was already surfaced as a JSON envelope on
+		// stdout; suppress the stderr "Error: ..." line so agents
+		// see exactly one structured response, but still exit
+		// non-zero so shell callers notice.
+		//
+		// Edge case: when the error envelope itself fails to
+		// marshal, RenderError returns the joined error (not
+		// ErrRendered), so this branch prints it to stderr as a
+		// fallback. At that point the JSON contract is already
+		// broken, so a stderr line is the least-bad option.
+		if !errors.Is(err, output.ErrRendered) {
+			// Write error intentionally ignored: stderr is the last
+			// resort and there is no further channel to report a
+			// failure to write to it.
+			fmt.Fprintln(os.Stderr, "Error:", err) //nolint:errcheck
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Define a shared `output.Envelope` response shape (`internal/output/`) so every
  later subcommand emits consistent JSON for agent consumption: `tier`,
  `parser_version`, `connection_status`, `errors[]`, and a `json.RawMessage`
  `data` field for command-specific payload.
- Add a global `--output text|json` persistent flag on root, validated once in
  `PersistentPreRunE` via `output.ParseFormat`.
- Wire the `version` subcommand as the first consumer. Text mode is unchanged;
  JSON mode emits the envelope with `connection_status=disconnected` and
  `binary_version` inside `data`.
- Add `Renderer.RenderError` + `ErrRendered` sentinel so JSON-mode failures
  emit a well-formed error envelope on stdout and suppress the stderr
  `"Error: ..."` line.
- EPIPE suppression scoped to write sites only (marshal errors propagate).

Resolves #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)