### PR TITLE
cli: add parse subcommand and parse_sql MCP tool

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+)
+
+// newParseCmd builds the `crdb-sql parse` subcommand. It reads SQL from
+// the -e flag, a positional file argument, or stdin, parses it with the
+// CockroachDB parser, and emits a per-statement classification
+// containing the statement type (DDL/DML/DCL/TCL), the statement tag
+// (e.g. "SELECT", "ALTER TABLE"), and the original SQL text.
+//
+// This is a Tier 1 (zero-config) command: it works offline with no
+// schema files or cluster connection.
+func newParseCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "parse [file]",
+		Short: "Classify SQL statements",
+		Long: `Parse SQL and classify each statement. Input is read from the -e flag
+(inline SQL), a positional file argument, or stdin. For each statement
+the output includes the statement type (DDL, DML, DCL, or TCL), the
+statement tag (e.g. SELECT, ALTER TABLE), and the original SQL text.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			baseEnv := output.Envelope{
+				Tier:             output.TierZeroConfig,
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
+
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.ParserVersion = parserVer
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			stmts, err := sqlparse.Classify(sql)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			data, err := json.Marshal(stmts)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				for _, s := range stmts {
+					if _, werr := fmt.Fprintf(w, "%s\t%s\t%s\n", s.StatementType, s.Tag, s.SQL); werr != nil {
+						return werr
+					}
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to parse")
+
+	return cmd
+}

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+)
+
+// TestParseCmdText exercises the parse subcommand's text output path
+// end-to-end. The input is piped via stdin; the output is tab-separated
+// TYPE\tTAG\tSQL per line.
+func TestParseCmdText(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"parse"})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "DML\tSELECT\tSELECT 1")
+}
+
+// TestParseCmdJSON exercises --output json end-to-end, verifying the
+// envelope shape and the data payload for a multi-statement input.
+func TestParseCmdJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader("SELECT 1; CREATE TABLE t (a INT)"))
+	root.SetArgs([]string{"parse", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var stmts []sqlparse.ClassifiedStatement
+	require.NoError(t, json.Unmarshal(env.Data, &stmts))
+	require.Len(t, stmts, 2)
+
+	require.Equal(t, sqlparse.StatementTypeDML, stmts[0].StatementType)
+	require.Equal(t, "SELECT", stmts[0].Tag)
+
+	require.Equal(t, sqlparse.StatementTypeDDL, stmts[1].StatementType)
+	require.Equal(t, "CREATE TABLE", stmts[1].Tag)
+}
+
+// TestParseCmdExprFlag verifies the -e flag path.
+func TestParseCmdExprFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"parse", "-e", "BEGIN", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var stmts []sqlparse.ClassifiedStatement
+	require.NoError(t, json.Unmarshal(env.Data, &stmts))
+	require.Len(t, stmts, 1)
+	require.Equal(t, sqlparse.StatementTypeTCL, stmts[0].StatementType)
+}
+
+// TestParseCmdFileArg verifies reading SQL from a file argument.
+func TestParseCmdFileArg(t *testing.T) {
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("DROP TABLE t"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"parse", sqlFile, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var stmts []sqlparse.ClassifiedStatement
+	require.NoError(t, json.Unmarshal(env.Data, &stmts))
+	require.Len(t, stmts, 1)
+	require.Equal(t, sqlparse.StatementTypeDDL, stmts[0].StatementType)
+	require.Equal(t, "DROP TABLE", stmts[0].Tag)
+}
+
+// TestParseCmdParseErrorText verifies that invalid SQL in text mode
+// surfaces as a non-nil error from Execute.
+func TestParseCmdParseErrorText(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"parse"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestParseCmdParseErrorJSON verifies that invalid SQL in JSON mode
+// produces an envelope with errors and nil data.
+func TestParseCmdParseErrorJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"parse", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Nil(t, env.Data)
+}
+
+// TestParseCmdEmptyInput verifies that empty stdin produces an error.
+func TestParseCmdEmptyInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"parse"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestParseCmdConflictingInput verifies that -e and a file arg together
+// produce an error.
+func TestParseCmdConflictingInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"parse", "-e", "SELECT 1", "somefile.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot use -e flag and file argument together")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ round-tripping through a live cluster.`,
 	root.PersistentFlags().StringP(outputFlag, "o", string(output.FormatText),
 		`output format: "text" or "json"`)
 	root.AddCommand(newVersionCmd(state))
+	root.AddCommand(newParseCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,12 +5,12 @@
 
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
-// Today the server only registers the `ping` health-check tool; future
-// issues will hang real SQL-aware tools (validate_sql, format_sql, …)
-// off the same NewServer constructor. Keeping construction pure (no
-// transport, no I/O) lets the cmd layer pick a transport — currently
-// just stdio — and lets tests exercise individual tool handlers
-// directly.
+// The server registers a health-check tool (ping) and a SQL
+// classification tool (parse_sql); future issues will add more
+// SQL-aware tools (validate_sql, format_sql, …) to the same
+// NewServer constructor. Keeping construction pure (no transport,
+// no I/O) lets the cmd layer pick a transport — currently just
+// stdio — and lets tests exercise individual tool handlers directly.
 //
 // Versions are passed in by the caller rather than read from
 // debug.ReadBuildInfo here, so this package stays free of
@@ -25,12 +25,16 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 )
 
-// PingToolName is the registered name of the health-check tool. Exposed
-// as a constant so tests and the README/docs reference a single source
-// of truth.
-const PingToolName = "ping"
+// Tool name constants are exposed so tests and docs reference a single
+// source of truth.
+const (
+	PingToolName     = "ping"
+	ParseSQLToolName = "parse_sql"
+)
 
 // NewServer constructs an MCP server for crdb-sql. binaryVersion is the
 // crdb-sql binary version string (typically cmd.Version), and
@@ -54,6 +58,14 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 			mcp.WithDescription(`Health check. Returns {"ok": true, "parser_version": "<v>"} so clients can confirm the server is alive and see which cockroachdb-parser version it was built against.`),
 		),
 		pingHandler(parserVersion),
+	)
+	s.AddTool(
+		mcp.NewTool(
+			ParseSQLToolName,
+			mcp.WithDescription("Parse and classify SQL statements. Returns statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input."),
+			mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
+		),
+		parseSQLHandler(parserVersion),
 	)
 	return s
 }
@@ -82,4 +94,44 @@ func pingHandler(parserVersion string) server.ToolHandlerFunc {
 type pingResult struct {
 	OK            bool   `json:"ok"`
 	ParserVersion string `json:"parser_version"`
+}
+
+// parseSQLHandler returns the handler for the `parse_sql` tool. It
+// delegates to sqlparse.Classify for the actual parsing, so the MCP
+// and CLI layers share one implementation.
+func parseSQLHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		raw, exists := req.GetArguments()["sql"]
+		if !exists {
+			return mcp.NewToolResultError("sql parameter is required"), nil
+		}
+		sql, ok := raw.(string)
+		if !ok {
+			return mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw)), nil
+		}
+		if sql == "" {
+			return mcp.NewToolResultError("sql parameter must not be empty"), nil
+		}
+
+		stmts, err := sqlparse.Classify(sql)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("parse error: %v", err)), nil
+		}
+
+		result := parseSQLResult{
+			ParserVersion: parserVersion,
+			Statements:    stmts,
+		}
+		body, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(body)), nil
+	}
+}
+
+// parseSQLResult is the JSON shape returned by the `parse_sql` tool.
+type parseSQLResult struct {
+	ParserVersion string                         `json:"parser_version"`
+	Statements    []sqlparse.ClassifiedStatement `json:"statements"`
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -67,17 +67,94 @@ func TestPingHandler(t *testing.T) {
 	}
 }
 
-// TestNewServerRegistersPing locks in that NewServer wires the ping
-// tool under its documented name. A future refactor that forgets to
-// call AddTool — or renames the tool — would silently break MCP
-// clients; this test surfaces it without speaking the protocol.
-func TestNewServerRegistersPing(t *testing.T) {
+// TestNewServerRegistersTools locks in that NewServer wires all tools
+// under their documented names. A future refactor that forgets to call
+// AddTool — or renames a tool — would silently break MCP clients; this
+// test surfaces it without speaking the protocol.
+func TestNewServerRegistersTools(t *testing.T) {
 	s := NewServer("v1.2.3", "v0.26.2")
 	require.NotNil(t, s)
 	tools := s.ListTools()
-	require.Contains(t, tools, PingToolName)
-	require.NotNil(t, tools[PingToolName].Handler,
-		"ping must be registered with a non-nil handler")
-	require.NotEmpty(t, tools[PingToolName].Tool.Description,
-		"ping description is part of the user-facing contract")
+
+	for _, name := range []string{PingToolName, ParseSQLToolName} {
+		require.Contains(t, tools, name)
+		require.NotNil(t, tools[name].Handler,
+			"%s must be registered with a non-nil handler", name)
+		require.NotEmpty(t, tools[name].Tool.Description,
+			"%s description is part of the user-facing contract", name)
+	}
+}
+
+// TestParseSQLHandler exercises the parse_sql tool handler directly,
+// bypassing the MCP transport.
+func TestParseSQLHandler(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              map[string]any
+		expectedErr       bool
+		expectedStmtCount int
+		expectedType      string
+		expectedTag       string
+	}{
+		{
+			name:              "single DML",
+			args:              map[string]any{"sql": "SELECT 1"},
+			expectedStmtCount: 1,
+			expectedType:      "DML",
+			expectedTag:       "SELECT",
+		},
+		{
+			name:              "multi-statement",
+			args:              map[string]any{"sql": "SELECT 1; BEGIN"},
+			expectedStmtCount: 2,
+		},
+		{
+			name:        "parse error",
+			args:        map[string]any{"sql": "SELECTT 1"},
+			expectedErr: true,
+		},
+		{
+			name:        "empty sql",
+			args:        map[string]any{"sql": ""},
+			expectedErr: true,
+		},
+		{
+			name:        "missing sql param",
+			args:        map[string]any{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := parseSQLHandler("v0.26.2")
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			require.False(t, res.IsError)
+			require.Len(t, res.Content, 1)
+
+			text, ok := res.Content[0].(mcpgo.TextContent)
+			require.True(t, ok)
+
+			var result parseSQLResult
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
+			require.Equal(t, "v0.26.2", result.ParserVersion)
+			require.Len(t, result.Statements, tc.expectedStmtCount)
+
+			if tc.expectedType != "" {
+				require.Equal(t, tc.expectedType, string(result.Statements[0].StatementType))
+				require.Equal(t, tc.expectedTag, result.Statements[0].Tag)
+			}
+		})
+	}
 }

--- a/internal/sqlinput/reader.go
+++ b/internal/sqlinput/reader.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package sqlinput resolves SQL text from the three input sources every
+// SQL-consuming subcommand supports: an inline -e expression, a
+// positional file argument, or standard input. The resolution logic
+// lives here so validate, format, parse, and future subcommands share
+// one implementation and one set of error messages.
+package sqlinput
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ReadSQL resolves SQL input from three sources in priority order:
+//
+//  1. expr — the -e / --expression flag value (inline SQL).
+//  2. args — a single positional argument treated as a file path.
+//  3. stdin — standard input, read until EOF.
+//
+// If expr is non-empty, args must be empty (returning an error
+// otherwise). If both expr and args are empty, stdin is consumed. An
+// error is returned when the resolved input is empty after trimming
+// whitespace.
+//
+// stdin is an io.Reader rather than *os.File so callers can inject a
+// bytes.Buffer or strings.Reader in tests. The cobra command passes
+// cmd.InOrStdin().
+func ReadSQL(expr string, args []string, stdin io.Reader) (string, error) {
+	if expr != "" {
+		if len(args) > 0 {
+			return "", fmt.Errorf("cannot use -e flag and file argument together")
+		}
+		return expr, nil
+	}
+
+	if len(args) > 0 {
+		data, err := os.ReadFile(args[0])
+		if err != nil {
+			return "", fmt.Errorf("read SQL file: %w", err)
+		}
+		sql := string(data)
+		if strings.TrimSpace(sql) == "" {
+			return "", fmt.Errorf("no SQL input provided; file %q is empty", args[0])
+		}
+		return sql, nil
+	}
+
+	if stdin == nil {
+		return "", fmt.Errorf("no SQL input provided; use -e, pass a file, or pipe to stdin")
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	sql := string(data)
+	if strings.TrimSpace(sql) == "" {
+		return "", fmt.Errorf("no SQL input provided; use -e, pass a file, or pipe to stdin")
+	}
+	return sql, nil
+}

--- a/internal/sqlinput/reader_test.go
+++ b/internal/sqlinput/reader_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlinput
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSQL(t *testing.T) {
+	// Write a temp file for the file-arg test cases.
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("SELECT 42"), 0644))
+
+	emptyFile := filepath.Join(dir, "empty.sql")
+	require.NoError(t, os.WriteFile(emptyFile, []byte("   \n"), 0644))
+
+	tests := []struct {
+		name        string
+		expr        string
+		args        []string
+		stdin       string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:     "inline via -e flag",
+			expr:     "SELECT 1",
+			expected: "SELECT 1",
+		},
+		{
+			name:     "file argument",
+			args:     []string{sqlFile},
+			expected: "SELECT 42",
+		},
+		{
+			name:     "stdin",
+			stdin:    "SELECT 99",
+			expected: "SELECT 99",
+		},
+		{
+			name:     "-e takes priority over stdin",
+			expr:     "SELECT 1",
+			stdin:    "SELECT 2",
+			expected: "SELECT 1",
+		},
+		{
+			name:        "conflict -e and file arg",
+			expr:        "SELECT 1",
+			args:        []string{sqlFile},
+			expectedErr: "cannot use -e flag and file argument together",
+		},
+		{
+			name:        "file not found",
+			args:        []string{filepath.Join(dir, "nonexistent.sql")},
+			expectedErr: "read SQL file",
+		},
+		{
+			name:        "empty file rejected",
+			args:        []string{emptyFile},
+			expectedErr: "is empty",
+		},
+		{
+			name:        "empty stdin rejected",
+			stdin:       "",
+			expectedErr: "no SQL input provided",
+		},
+		{
+			name:        "whitespace-only stdin rejected",
+			stdin:       "   \n\t  ",
+			expectedErr: "no SQL input provided",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdin *strings.Reader
+			if tc.stdin != "" || (tc.expr == "" && len(tc.args) == 0) {
+				stdin = strings.NewReader(tc.stdin)
+			}
+
+			got, err := ReadSQL(tc.expr, tc.args, stdin)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/internal/sqlparse/classify.go
+++ b/internal/sqlparse/classify.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package sqlparse wraps the cockroachdb-parser module to provide
+// SQL parsing utilities consumed by both the CLI and MCP layers.
+// The primary entry point is Classify, which parses a SQL string
+// and returns a per-statement classification (DDL/DML/DCL/TCL),
+// the statement tag (e.g. "SELECT", "ALTER TABLE"), and the
+// original SQL text.
+package sqlparse
+
+import (
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// StatementType is the human-readable classification for a SQL
+// statement. Values correspond to the tree.StatementType enum in
+// cockroachdb-parser with the "Type" prefix stripped.
+type StatementType string
+
+// StatementType constants.
+const (
+	StatementTypeDDL     StatementType = "DDL"
+	StatementTypeDML     StatementType = "DML"
+	StatementTypeDCL     StatementType = "DCL"
+	StatementTypeTCL     StatementType = "TCL"
+	StatementTypeUnknown StatementType = "UNKNOWN"
+)
+
+// ClassifiedStatement is the per-statement result of parsing and
+// classifying a SQL string. It is the JSON-serializable shape
+// embedded in both the CLI envelope's Data field and the MCP tool
+// result.
+type ClassifiedStatement struct {
+	StatementType StatementType `json:"statement_type"`
+	Tag           string        `json:"tag"`
+	SQL           string        `json:"sql"`
+}
+
+// Classify parses sql using the CockroachDB parser and returns one
+// ClassifiedStatement per parsed statement. Parse errors are returned
+// as a Go error; the caller decides how to surface them (as
+// output.Error entries in CLI mode, or as a tool-level error in MCP
+// mode).
+//
+// An empty input returns an empty slice with no error.
+func Classify(sql string) ([]ClassifiedStatement, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ClassifiedStatement, len(stmts))
+	for i, stmt := range stmts {
+		result[i] = ClassifiedStatement{
+			StatementType: mapStatementType(stmt.AST.StatementType()),
+			Tag:           stmt.AST.StatementTag(),
+			SQL:           stmt.SQL,
+		}
+	}
+	return result, nil
+}
+
+// mapStatementType converts a tree.StatementType enum value to its
+// human-readable string constant.
+func mapStatementType(t tree.StatementType) StatementType {
+	switch t {
+	case tree.TypeDDL:
+		return StatementTypeDDL
+	case tree.TypeDML:
+		return StatementTypeDML
+	case tree.TypeDCL:
+		return StatementTypeDCL
+	case tree.TypeTCL:
+		return StatementTypeTCL
+	default:
+		return StatementTypeUnknown
+	}
+}

--- a/internal/sqlparse/classify_test.go
+++ b/internal/sqlparse/classify_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlparse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedLen  int
+		expectedType StatementType
+		expectedTag  string
+		expectedErr  string
+	}{
+		{
+			name:         "SELECT is DML",
+			input:        "SELECT 1",
+			expectedLen:  1,
+			expectedType: StatementTypeDML,
+			expectedTag:  "SELECT",
+		},
+		{
+			name:         "INSERT is DML",
+			input:        "INSERT INTO t VALUES (1)",
+			expectedLen:  1,
+			expectedType: StatementTypeDML,
+			expectedTag:  "INSERT",
+		},
+		{
+			name:         "UPDATE is DML",
+			input:        "UPDATE t SET a = 1",
+			expectedLen:  1,
+			expectedType: StatementTypeDML,
+			expectedTag:  "UPDATE",
+		},
+		{
+			name:         "DELETE is DML",
+			input:        "DELETE FROM t",
+			expectedLen:  1,
+			expectedType: StatementTypeDML,
+			expectedTag:  "DELETE",
+		},
+		{
+			name:         "CREATE TABLE is DDL",
+			input:        "CREATE TABLE t (a INT)",
+			expectedLen:  1,
+			expectedType: StatementTypeDDL,
+			expectedTag:  "CREATE TABLE",
+		},
+		{
+			name:         "ALTER TABLE is DDL",
+			input:        "ALTER TABLE t ADD COLUMN b INT",
+			expectedLen:  1,
+			expectedType: StatementTypeDDL,
+			expectedTag:  "ALTER TABLE",
+		},
+		{
+			name:         "DROP TABLE is DDL",
+			input:        "DROP TABLE t",
+			expectedLen:  1,
+			expectedType: StatementTypeDDL,
+			expectedTag:  "DROP TABLE",
+		},
+		{
+			name:         "GRANT is DCL",
+			input:        "GRANT SELECT ON TABLE t TO u",
+			expectedLen:  1,
+			expectedType: StatementTypeDCL,
+			expectedTag:  "GRANT",
+		},
+		{
+			name:         "BEGIN is TCL",
+			input:        "BEGIN",
+			expectedLen:  1,
+			expectedType: StatementTypeTCL,
+			expectedTag:  "BEGIN",
+		},
+		{
+			name:         "COMMIT is TCL",
+			input:        "COMMIT",
+			expectedLen:  1,
+			expectedType: StatementTypeTCL,
+			expectedTag:  "COMMIT",
+		},
+		{
+			name:        "multi-statement input",
+			input:       "SELECT 1; CREATE TABLE t (a INT)",
+			expectedLen: 2,
+		},
+		{
+			name:        "empty input returns empty slice",
+			input:       "",
+			expectedLen: 0,
+		},
+		{
+			name:        "parse error",
+			input:       "SELECTT 1",
+			expectedErr: "syntax error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := Classify(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, stmts, tc.expectedLen)
+
+			if tc.expectedLen > 0 && tc.expectedType != "" {
+				require.Equal(t, tc.expectedType, stmts[0].StatementType)
+				require.Equal(t, tc.expectedTag, stmts[0].Tag)
+				require.NotEmpty(t, stmts[0].SQL)
+			}
+		})
+	}
+}
+
+func TestClassifyMultiStatementDetails(t *testing.T) {
+	stmts, err := Classify("SELECT 1; CREATE TABLE t (a INT)")
+	require.NoError(t, err)
+	require.Len(t, stmts, 2)
+
+	require.Equal(t, StatementTypeDML, stmts[0].StatementType)
+	require.Equal(t, "SELECT", stmts[0].Tag)
+
+	require.Equal(t, StatementTypeDDL, stmts[1].StatementType)
+	require.Equal(t, "CREATE TABLE", stmts[1].Tag)
+}


### PR DESCRIPTION
## Summary

Implements issue #3: a Tier 1 (zero-config) statement classifier that
reads SQL from `-e`, a file argument, or stdin and returns
`statement_type` (DDL/DML/DCL/TCL), `tag`, and original SQL per
statement.

- `internal/sqlparse`: wraps cockroachdb-parser for statement
  classification, shared by both CLI and MCP layers.
- `internal/sqlinput`: shared SQL input reader (`-e`, file arg, stdin)
  for reuse by future subcommands (validate, format).
- `cmd/parse.go`: cobra subcommand with text and JSON output modes.
- `internal/mcp/server.go`: registers `parse_sql` MCP tool with split
  input validation (missing param, wrong type, empty).

```
echo "SELECT 1; CREATE TABLE t (a INT)" | crdb-sql parse --output json
```

Resolves #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)