### PR TITLE
release: add goreleaser config and release CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    tags: ['v*']
+
+# Cancel superseded snapshot runs on the same ref. Cancellation is scoped
+# to pull_request events so tag pushes (including a force-pushed tag, which
+# would re-use the same ref) cannot cancel an in-flight release mid-upload
+# and leave behind a half-populated draft.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    name: snapshot build (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # goreleaser needs full history to compute the snapshot version.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run goreleaser (snapshot)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --snapshot --clean --skip=publish
+
+      - name: Enforce binary size cap
+        run: scripts/check-binary-size.sh
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-snapshot
+          path: dist/
+          retention-days: 7
+          # Promote the goreleaser/size-check defense to a hard error: an
+          # empty dist/ at this point means an earlier step's failure was
+          # masked.
+          if-no-files-found: error
+
+  release:
+    name: tagged release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run goreleaser (release)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enforce binary size cap
+        run: scripts/check-binary-size.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 /bin/
+/dist/
 
 # Go test/coverage artifacts
 *.test

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,72 @@
+# goreleaser v2 config for crdb-sql.
+#
+# Builds are driven from CI (see .github/workflows/release.yml) but the file
+# is also runnable locally:
+#
+#   goreleaser release --snapshot --clean --skip=publish
+#
+# A separate workflow step (not goreleaser) enforces the 50 MiB binary cap;
+# keeping that gate outside this file keeps the size policy visible in CI.
+
+version: 2
+
+project_name: crdb-sql
+
+before:
+  hooks:
+    # Read-only: prime the module cache without mutating go.mod/go.sum.
+    # `go mod tidy` would risk a dirty-tree failure mid-release if any
+    # transitive checksum drifted; tidy assertions belong in CI lint.
+    - go mod download
+
+builds:
+  - id: crdb-sql
+    main: .
+    binary: crdb-sql
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    # -s -w strips the symbol table and DWARF; combined with -trimpath this
+    # makes builds reproducible and trims roughly a third off the binary.
+    # The -X stamp targets cmd.Version — do not rename the package path
+    # without updating that file in lockstep.
+    ldflags:
+      - -s -w -X github.com/spilchen/sql-ai-tools/cmd.Version={{.Version}}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+snapshot:
+  # PR snapshots get a stable, identifiable name like
+  # "crdb-sql_0.0.1-snapshot-abc1234_linux_amd64.tar.gz". incpatch bumps the
+  # last released tag so snapshots sort after it.
+  version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"
+
+changelog:
+  use: github
+  filters:
+    exclude:
+      - "^chore:"
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+release:
+  # Draft so a human reviews the artifacts and notes before publishing.
+  draft: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ All workflows go through the Makefile:
 - `make fmt-check` — fail if any file is not gofmt-clean
 - `make vet` — run `go vet ./...`
 - `make tools` — install pinned dev tools into `bin/` (currently `golangci-lint`)
-- `make lint` — run `fmt-check`, `vet`, then pinned `golangci-lint run` (the CI gate)
+- `make lint` — run `fmt-check`, `vet`, `tidy-check` (`go mod tidy -diff`), then pinned `golangci-lint run` (the CI gate)
 - `make clean` — remove `bin/` (binary and installed tools)
 
 The pinned `golangci-lint` version lives in the `Makefile` as

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOLANGCI_LINT           := $(BIN_DIR)/golangci-lint
 
 .DEFAULT_GOAL := help
 
-.PHONY: help build test fmt fmt-check vet lint clean tools
+.PHONY: help build test fmt fmt-check vet lint clean tools tidy-check
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -35,6 +35,29 @@ fmt-check: ## Fail if any source file is not gofmt-clean.
 vet: ## Run go vet.
 	go vet $(GO_PKGS)
 
+# `go mod tidy -diff` writes the diff to stdout and exits 1 when go.mod /
+# go.sum need updating (its documented "tidy needed" signal). It also
+# exits non-zero on real tool failures (network outage, proxy 5xx,
+# unknown flag), but those write to stderr with empty stdout. Capture
+# stdout and stderr separately so we can route the actionable
+# "run go mod tidy" message to the common case and reserve "failed" for
+# genuine tool errors. Merging the streams (`2>&1`) would conflate the
+# two and either hide the remediation hint or rubber-stamp a real failure.
+tidy-check: ## Fail if go.mod / go.sum are not tidy.
+	@errfile=$$(mktemp) || { echo "tidy-check: mktemp failed"; exit 1; }; \
+	trap 'rm -f "$$errfile"' EXIT INT TERM; \
+	diff=$$(go mod tidy -diff 2>"$$errfile"); rc=$$?; \
+	err=$$(cat "$$errfile"); \
+	if [ -n "$$diff" ]; then \
+		echo "go mod tidy would change files:"; echo "$$diff"; \
+		echo "Run 'go mod tidy' and commit the result."; \
+		exit 1; \
+	fi; \
+	if [ $$rc -ne 0 ]; then \
+		echo "go mod tidy -diff failed (exit $$rc):"; echo "$$err"; \
+		exit $$rc; \
+	fi
+
 # Install or refresh the pinned golangci-lint into bin/.
 # Re-installs if the binary is missing or its version doesn't match GOLANGCI_LINT_VERSION.
 tools: $(GOLANGCI_LINT) ## Install pinned dev tools into bin/.
@@ -47,7 +70,7 @@ $(GOLANGCI_LINT):
 			| sh -s -- -b $(BIN_DIR) $(GOLANGCI_LINT_VERSION); \
 	fi
 
-lint: fmt-check vet $(GOLANGCI_LINT) ## Run gofmt check, go vet, and pinned golangci-lint (CI gate).
+lint: fmt-check vet tidy-check $(GOLANGCI_LINT) ## Run gofmt check, go vet, tidy check, and pinned golangci-lint (CI gate).
 	$(GOLANGCI_LINT) run $(GO_PKGS)
 
 clean: ## Remove build artifacts and installed tools.

--- a/scripts/check-binary-size.sh
+++ b/scripts/check-binary-size.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Enforce the release binary size cap. Invoked by .github/workflows/release.yml
+# after goreleaser builds, but also runnable locally after
+# `goreleaser release --snapshot --clean --skip=publish`.
+#
+# Fails (non-zero exit + ::error annotation) when:
+#   - dist/ is missing entirely (goreleaser never ran)
+#   - no crdb-sql binaries are found under dist/<target>/
+#   - any binary is zero bytes (build produced empty output)
+#   - any binary exceeds MAX_BYTES (default 50 MiB)
+#
+# Each failure mode emits a distinct message so CI logs point at the real
+# cause instead of a generic "size check failed".
+#
+# Usage:
+#   scripts/check-binary-size.sh                 # 50 MiB cap, dist/ in CWD
+#   MAX_BYTES=$((30*1024*1024)) scripts/check-binary-size.sh
+set -euo pipefail
+
+MAX_BYTES="${MAX_BYTES:-$((50 * 1024 * 1024))}"
+
+# Reject non-numeric MAX_BYTES up front. Without this guard, a typo or unit
+# suffix (e.g. MAX_BYTES=50M) makes the `-gt` test below fail with exit 2
+# inside an `if`, which `set -e` does NOT catch — the size cap silently
+# becomes a no-op.
+if ! [[ "$MAX_BYTES" =~ ^[0-9]+$ ]]; then
+  echo "::error::MAX_BYTES must be a positive integer (got: $MAX_BYTES)"
+  exit 2
+fi
+
+if [ ! -d dist ]; then
+  echo "::error::dist/ directory missing — goreleaser did not run"
+  exit 1
+fi
+
+# goreleaser lays out per-target dirs like dist/crdb-sql_linux_amd64_v1/.
+# Use find + mapfile so an empty match is detectable up front (a bash glob
+# would expand literally and downstream commands would fail with a less
+# actionable message). `-L` follows symlinks so a symlinked dist/ or a
+# symlinked binary is still counted instead of silently skipped.
+#
+# Run find through temp files so we can inspect both its exit code AND its
+# stderr. Process substitution `<(...)` would discard `find`'s exit code,
+# and `set -o pipefail` does not apply across it. Without checking BOTH,
+# an unreadable target dir (perm flip, symlink loop, transient I/O error)
+# could let `find` exit 1 with a partial stdout list — sometimes with
+# stderr output, sometimes without (e.g. `-L` symlink-loop behavior is
+# platform-dependent) — and `mapfile` would happily read whatever made it
+# through. The script would then size-check a SUBSET of the binaries with
+# no warning, silently bypassing the cap for any binary in the affected
+# target.
+#
+# Both mktemp calls are guarded so a failure produces a structured
+# annotation rather than the raw `mktemp:` stderr that `set -e` would
+# otherwise dump. Trap covers EXIT/INT/TERM so Ctrl-C in CI doesn't leak
+# temp files. Single registration — if you add another temp file, append
+# to this trap rather than re-registering.
+find_errs=$(mktemp) || { echo "::error::failed to create temp file for find stderr"; exit 1; }
+find_out=$(mktemp) || { echo "::error::failed to create temp file for find output"; rm -f "$find_errs"; exit 1; }
+trap 'rm -f "$find_errs" "$find_out"' EXIT INT TERM
+
+find_rc=0
+find -L dist -mindepth 2 -maxdepth 2 -type f -name crdb-sql >"$find_out" 2>"$find_errs" || find_rc=$?
+if [ "$find_rc" -ne 0 ]; then
+  echo "::error::find failed (exit $find_rc) while enumerating dist/:"
+  cat "$find_errs"
+  exit 1
+fi
+if [ -s "$find_errs" ]; then
+  echo "::error::find emitted errors while enumerating dist/:"
+  cat "$find_errs"
+  exit 1
+fi
+mapfile -t bins < "$find_out"
+if [ "${#bins[@]}" -eq 0 ]; then
+  echo "::error::no crdb-sql binaries found under dist/*/ — goreleaser layout changed or build produced nothing"
+  exit 1
+fi
+
+fail=0
+for f in "${bins[@]}"; do
+  # `wc -c < file` is POSIX and works on both GNU coreutils (Linux CI) and
+  # BSD (macOS local runs); `stat -c%s` is GNU-only.
+  # Guard the redirect: if $f became unreadable between find and wc (race
+  # with a parallel `--clean`, perm flip), the bare redirect would let
+  # set -e abort with a useless `integer expression expected` and no file
+  # context. Catch the failure and emit a structured annotation instead.
+  if ! sz=$(wc -c < "$f" 2>/dev/null); then
+    echo "::error file=$f::could not read binary"
+    fail=1
+    continue
+  fi
+  sz=$(printf '%s' "$sz" | tr -d '[:space:]')
+  printf '%s  %d bytes\n' "$f" "$sz"
+  if [ "$sz" -eq 0 ]; then
+    echo "::error file=$f::zero-byte binary — build produced empty output"
+    fail=1
+  elif [ "$sz" -gt "$MAX_BYTES" ]; then
+    echo "::error file=$f::binary $sz bytes exceeds $MAX_BYTES bytes cap"
+    fail=1
+  fi
+done
+exit "$fail"


### PR DESCRIPTION
## Summary

Resolves #31. Adds a complete goreleaser-based release pipeline for `crdb-sql` and a CI workflow that exercises it on PRs (snapshot) and tags (full release).

This PR contains two commits, each independently meaningful:

### `release: add goreleaser config and release workflow`

- **`.goreleaser.yaml`** — builds linux/darwin × amd64/arm64 with `CGO_ENABLED=0`, `-trimpath`, and `-s -w -X github.com/spilchen/sql-ai-tools/cmd.Version={{.Version}}` (matches the stamping contract in `cmd/version.go`). Produces `tar.gz` archives plus SHA256 checksums. Snapshot version template uses `incpatch` so PR snapshots sort after the last released tag. Releases are drafted (not auto-published) so a human reviews artifacts and notes first.
- **`.github/workflows/release.yml`** — two jobs sharing a `setup-go` step:
  - `snapshot`: runs on PRs to `main`, executes `goreleaser release --snapshot --clean --skip=publish`, enforces the size cap, uploads `dist/` as an artifact for review.
  - `release`: runs on `push` of tags matching `v*` with `contents: write`, executes `goreleaser release --clean`, enforces the size cap.
  - Concurrency cancellation scoped to `pull_request` events so a force-pushed tag cannot cancel an in-flight release.
- **`scripts/check-binary-size.sh`** — enforces the 50 MiB binary cap (raised from the design doc's 10–30 MB target since the current build is already ~34 MB; tracked as a follow-up to shrink). Each failure mode emits a distinct `::error::` annotation: missing `dist/`, no binaries found, `find` enumeration error, unreadable binary, zero-byte binary, oversized binary, non-numeric `MAX_BYTES`. Portable across Linux CI and macOS local runs (`wc -c < file` instead of GNU `stat -c%s`).

### `build: add tidy-check to make lint`

Independent fix that landed alongside the release work. Wires `go mod tidy -diff` into `make lint` so missing or stale `go.sum` entries fail at PR time rather than biting a clean release build later. Captures stdout and stderr separately so the actionable "Run `go mod tidy` and commit the result" message is reachable for the common "developer forgot to tidy" case, while genuine tool failures (network outage, proxy 5xx) report the underlying error.

## Out of scope

- Homebrew tap, Docker image, SBOM, signing — not requested by #31; deferred to keep this PR reviewable.
- Windows builds — design doc and issue both omit Windows.
- Shrinking the binary below 50 MB toward the design's 30 MB target — follow-up once the subcommand surface stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)