### PR TITLE
build: run go mod tidy to fix lint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mark3labs/mcp-go v0.48.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/mod v0.21.0
 )
 
 require (
@@ -63,7 +64,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.6.0 // indirect
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
-	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect


### PR DESCRIPTION
Two small CI fixes:

- **build: run go mod tidy to fix lint** — `golang.org/x/mod` was listed as
  indirect but is directly imported. The `tidy-check` target added in PR #49
  now catches this.
- **ci: run snapshot build on main pushes instead of PRs** — the goreleaser
  snapshot job rarely catches issues on PRs since the config changes
  infrequently. Running on main pushes still validates before tagging while
  saving CI minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>