### PR TITLE
cli: add format subcommand for canonical SQL pretty-printing

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newFormatCmd builds the `crdb-sql format` subcommand. It reads SQL
+// from the -e flag, a positional file argument, or stdin, parses it
+// with the CockroachDB parser, and re-emits it in canonical
+// pretty-printed form using tree.DefaultPrettyCfg.
+//
+// This is a Tier 1 (zero-config) command: it works offline with no
+// schema files or cluster connection.
+func newFormatCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "format [file]",
+		Short: "Pretty-print SQL statements",
+		Long: `Parse SQL and re-emit it in canonical pretty-printed form using the
+CockroachDB parser's built-in formatter. Input is read from the -e flag
+(inline SQL), a positional file argument, or stdin.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			baseEnv := output.Envelope{
+				Tier:             output.TierZeroConfig,
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
+
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.ParserVersion = parserVer
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			formatted, err := sqlformat.Format(sql)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			data, err := json.Marshal(struct {
+				FormattedSQL string `json:"formatted_sql"`
+			}{FormattedSQL: formatted})
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				_, werr := fmt.Fprintln(w, formatted)
+				return werr
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to format")
+
+	return cmd
+}

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// TestFormatCmdText exercises the format subcommand's text output path
+// end-to-end. The input is piped via stdin; the output is the
+// pretty-printed SQL followed by a newline.
+func TestFormatCmdText(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("select  id,name  from  users"))
+	root.SetArgs([]string{"format"})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "SELECT id, name FROM users")
+}
+
+// TestFormatCmdJSON exercises --output json end-to-end, verifying the
+// envelope shape and the data payload.
+func TestFormatCmdJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader("select 1"))
+	root.SetArgs([]string{"format", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var payload struct {
+		FormattedSQL string `json:"formatted_sql"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Equal(t, "SELECT 1", payload.FormattedSQL)
+}
+
+// TestFormatCmdExprFlag verifies the -e flag path.
+func TestFormatCmdExprFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "select  1"})
+
+	require.NoError(t, root.Execute())
+	require.Contains(t, stdout.String(), "SELECT 1")
+}
+
+// TestFormatCmdFileArg verifies reading SQL from a file argument.
+func TestFormatCmdFileArg(t *testing.T) {
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("select  1"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", sqlFile})
+
+	require.NoError(t, root.Execute())
+	require.Contains(t, stdout.String(), "SELECT 1")
+}
+
+// TestFormatCmdParseErrorText verifies that invalid SQL in text mode
+// surfaces as a non-nil error from Execute.
+func TestFormatCmdParseErrorText(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"format"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestFormatCmdParseErrorJSON verifies that invalid SQL in JSON mode
+// produces an envelope with errors and nil data.
+func TestFormatCmdParseErrorJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"format", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Nil(t, env.Data)
+}
+
+// TestFormatCmdEmptyInput verifies that empty stdin produces an error.
+func TestFormatCmdEmptyInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"format"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestFormatCmdConflictingInput verifies that -e and a file arg together
+// produce an error.
+func TestFormatCmdConflictingInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "SELECT 1", "somefile.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot use -e flag and file argument together")
+}

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -90,6 +90,42 @@ func TestFormatCmdFileArg(t *testing.T) {
 	require.Contains(t, stdout.String(), "SELECT 1")
 }
 
+// TestFormatCmdMultiStatement verifies that multi-statement input is
+// formatted with semicolon-newline separators in both text and JSON.
+func TestFormatCmdMultiStatement(t *testing.T) {
+	t.Run("text", func(t *testing.T) {
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetIn(strings.NewReader("select 1; select 2"))
+		root.SetArgs([]string{"format"})
+
+		require.NoError(t, root.Execute())
+		require.Equal(t, "SELECT 1;\nSELECT 2\n", stdout.String())
+	})
+
+	t.Run("json", func(t *testing.T) {
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetIn(strings.NewReader("select 1; select 2"))
+		root.SetArgs([]string{"format", "--output", "json"})
+
+		require.NoError(t, root.Execute())
+
+		var env output.Envelope
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+		var payload struct {
+			FormattedSQL string `json:"formatted_sql"`
+		}
+		require.NoError(t, json.Unmarshal(env.Data, &payload))
+		require.Equal(t, "SELECT 1;\nSELECT 2", payload.FormattedSQL)
+	})
+}
+
 // TestFormatCmdParseErrorText verifies that invalid SQL in text mode
 // surfaces as a non-nil error from Execute.
 func TestFormatCmdParseErrorText(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ round-tripping through a live cluster.`,
 		`output format: "text" or "json"`)
 	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newParseCmd(state))
+	root.AddCommand(newFormatCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/internal/sqlformat/format.go
+++ b/internal/sqlformat/format.go
@@ -10,6 +10,7 @@
 package sqlformat
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
@@ -19,8 +20,8 @@ import (
 // Format parses sql using the CockroachDB parser and returns the
 // pretty-printed canonical form. Multiple statements in the input
 // are separated by ";\n" in the output. An empty input returns an
-// empty string with no error. Parse errors are returned as a Go
-// error; the caller decides how to surface them.
+// empty string with no error. Parse or formatting errors are
+// returned as a Go error; the caller decides how to surface them.
 func Format(sql string) (string, error) {
 	stmts, err := parser.Parse(sql)
 	if err != nil {
@@ -38,7 +39,7 @@ func Format(sql string) (string, error) {
 		}
 		pretty, err := cfg.Pretty(stmt.AST)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("format statement %d: %w", i+1, err)
 		}
 		buf.WriteString(pretty)
 	}

--- a/internal/sqlformat/format.go
+++ b/internal/sqlformat/format.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package sqlformat wraps the cockroachdb-parser module to provide
+// SQL pretty-printing. The primary entry point is Format, which parses
+// a SQL string and re-emits it in CockroachDB's canonical
+// pretty-printed form using tree.DefaultPrettyCfg.
+package sqlformat
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// Format parses sql using the CockroachDB parser and returns the
+// pretty-printed canonical form. Multiple statements in the input
+// are separated by ";\n" in the output. An empty input returns an
+// empty string with no error. Parse errors are returned as a Go
+// error; the caller decides how to surface them.
+func Format(sql string) (string, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return "", err
+	}
+	if len(stmts) == 0 {
+		return "", nil
+	}
+
+	cfg := tree.DefaultPrettyCfg()
+	var buf strings.Builder
+	for i, stmt := range stmts {
+		if i > 0 {
+			buf.WriteString(";\n")
+		}
+		pretty, err := cfg.Pretty(stmt.AST)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(pretty)
+	}
+	return buf.String(), nil
+}

--- a/internal/sqlformat/format_test.go
+++ b/internal/sqlformat/format_test.go
@@ -34,8 +34,9 @@ func TestFormat(t *testing.T) {
 			expectedOutput: "SELECT 1;\nSELECT 2",
 		},
 		{
-			name:  "complex DDL wraps lines",
-			input: "CREATE TABLE t (a INT PRIMARY KEY, b TEXT NOT NULL, c FLOAT)",
+			name:           "complex DDL wraps lines",
+			input:          "CREATE TABLE t (a INT PRIMARY KEY, b TEXT NOT NULL, c FLOAT)",
+			expectedOutput: "CREATE TABLE t (\n\ta INT8 PRIMARY KEY, b STRING NOT NULL, c FLOAT8\n)",
 		},
 		{
 			name:           "empty input",
@@ -57,16 +58,7 @@ func TestFormat(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
-			if tc.expectedOutput != "" {
-				require.Equal(t, tc.expectedOutput, got)
-			}
-
-			// For the complex DDL case, verify multi-line output.
-			if tc.name == "complex DDL wraps lines" {
-				require.Contains(t, got, "CREATE TABLE")
-				require.Contains(t, got, "\n")
-			}
+			require.Equal(t, tc.expectedOutput, got)
 		})
 	}
 }

--- a/internal/sqlformat/format_test.go
+++ b/internal/sqlformat/format_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlformat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput string
+		expectedErr    string
+	}{
+		{
+			name:           "passes through clean SQL",
+			input:          "SELECT 1",
+			expectedOutput: "SELECT 1",
+		},
+		{
+			name:           "canonicalizes whitespace and casing",
+			input:          "select  id,name  from  users",
+			expectedOutput: "SELECT id, name FROM users",
+		},
+		{
+			name:           "multi-statement separated by semicolon-newline",
+			input:          "SELECT 1; SELECT 2",
+			expectedOutput: "SELECT 1;\nSELECT 2",
+		},
+		{
+			name:  "complex DDL wraps lines",
+			input: "CREATE TABLE t (a INT PRIMARY KEY, b TEXT NOT NULL, c FLOAT)",
+		},
+		{
+			name:           "empty input",
+			input:          "",
+			expectedOutput: "",
+		},
+		{
+			name:        "parse error",
+			input:       "SELECTT 1",
+			expectedErr: "syntax error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Format(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.expectedOutput != "" {
+				require.Equal(t, tc.expectedOutput, got)
+			}
+
+			// For the complex DDL case, verify multi-line output.
+			if tc.name == "complex DDL wraps lines" {
+				require.Contains(t, got, "CREATE TABLE")
+				require.Contains(t, got, "\n")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `crdb-sql format` subcommand that pretty-prints SQL using CockroachDB's canonical formatter (`tree.DefaultPrettyCfg().Pretty()`).
- Reads input from `-e` flag, positional file argument, or stdin; supports both text and JSON (`--output json`) output modes.
- Core logic lives in new `internal/sqlformat` package; command wiring follows the established `parse` subcommand pattern.

### Commits

- **cli: add parse subcommand and parse\_sql MCP tool** — adds the `parse` command, `sqlinput` reader, and `parse_sql` MCP tool (dependencies for `format`).
- **cli: add format subcommand for canonical SQL pretty-printing** — the main implementation.
- **cli: address review feedback for format subcommand** — wraps `Pretty` errors with statement index, fixes table-driven tests, adds multi-statement command-level test.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)