### PR TITLE
cli: add validate subcommand for parser error diagnostics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newParseCmd(state))
 	root.AddCommand(newFormatCmd(state))
+	root.AddCommand(newValidateCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newValidateCmd builds the `crdb-sql validate` subcommand. It reads
+// SQL from the -e flag, a positional file argument, or stdin, parses
+// it with the CockroachDB parser, and reports whether the SQL is
+// syntactically valid. On parse failure the error is surfaced as a
+// structured envelope entry with SQLSTATE code, severity, message,
+// and source position.
+//
+// This is a Tier 1 (zero-config) command: it works offline with no
+// schema files or cluster connection.
+func newValidateCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "validate [file]",
+		Short: "Check SQL for syntax errors",
+		Long: `Parse SQL and report whether it is syntactically valid. On failure,
+the error includes the SQLSTATE code, severity, message, and source
+position (line/column/byte offset). Input is read from the -e flag
+(inline SQL), a positional file argument, or stdin.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			baseEnv := output.Envelope{
+				Tier:             output.TierZeroConfig,
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
+
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.ParserVersion = parserVer
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			// Trim surrounding whitespace so trailing newlines from
+			// stdin/file do not skew position reporting.
+			sql = strings.TrimSpace(sql)
+
+			if _, parseErr := parser.Parse(sql); parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
+			}
+
+			data, err := json.Marshal(struct {
+				Valid bool `json:"valid"`
+			}{Valid: true})
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				_, werr := fmt.Fprintln(w, "Valid.")
+				return werr
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to validate")
+
+	return cmd
+}
+
+// renderParseError enriches a parser error with SQLSTATE code and
+// position, then renders it through the standard envelope path. It
+// bypasses Renderer.RenderError (which uses a generic
+// "internal_error" code) so that agents receive the real SQLSTATE.
+func renderParseError(r output.Renderer, env output.Envelope, parseErr error, sql string) error {
+	diagErr := diag.FromParseError(parseErr, sql)
+	env.Errors = []output.Error{diagErr}
+	env.Data = nil
+
+	if err := r.Render(env, func(w io.Writer) error {
+		pos := diagErr.Position
+		if pos != nil {
+			_, werr := fmt.Fprintf(w, "%d:%d: %s [%s]\n", pos.Line, pos.Column, diagErr.Message, diagErr.Code)
+			return werr
+		}
+		_, werr := fmt.Fprintf(w, "%s [%s]\n", diagErr.Message, diagErr.Code)
+		return werr
+	}); err != nil {
+		return err
+	}
+	return output.ErrRendered
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// TestValidateCmdTextSuccess verifies that valid SQL in text mode
+// prints "Valid." to stdout.
+func TestValidateCmdTextSuccess(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"validate"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
+}
+
+// TestValidateCmdJSONSuccess verifies that valid SQL in JSON mode
+// produces an envelope with {"valid": true} data and no errors.
+func TestValidateCmdJSONSuccess(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"validate", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var payload struct {
+		Valid bool `json:"valid"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.True(t, payload.Valid)
+}
+
+// TestValidateCmdTextError verifies that invalid SQL in text mode
+// outputs a formatted error line with position and SQLSTATE code.
+func TestValidateCmdTextError(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT FROM"))
+	root.SetArgs([]string{"validate"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, "1:12:")
+	require.Contains(t, got, "syntax error")
+	require.Contains(t, got, "42601")
+}
+
+// TestValidateCmdJSONError verifies that invalid SQL in JSON mode
+// produces an envelope with structured errors and nil data.
+func TestValidateCmdJSONError(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT FROM"))
+	root.SetArgs([]string{"validate", "--output", "json"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Nil(t, env.Data)
+
+	diagErr := env.Errors[0]
+	require.Equal(t, "42601", diagErr.Code)
+	require.Equal(t, output.SeverityError, diagErr.Severity)
+	require.Contains(t, diagErr.Message, "syntax error")
+	require.NotNil(t, diagErr.Position)
+	require.Equal(t, 1, diagErr.Position.Line)
+	require.Equal(t, 12, diagErr.Position.Column)
+	require.Equal(t, 11, diagErr.Position.ByteOffset)
+}
+
+// TestValidateCmdExprFlag verifies the -e flag path.
+func TestValidateCmdExprFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "-e", "SELECT 1"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
+}
+
+// TestValidateCmdFileArg verifies reading SQL from a file argument.
+func TestValidateCmdFileArg(t *testing.T) {
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("SELECT 1"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", sqlFile})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
+}
+
+// TestValidateCmdEmptyInput verifies that empty stdin produces an error.
+func TestValidateCmdEmptyInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"validate"})
+
+	require.Error(t, root.Execute())
+}
+
+// TestValidateCmdConflictingInput verifies that -e and a file arg
+// together produce an error.
+func TestValidateCmdConflictingInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "-e", "SELECT 1", "somefile.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot use -e flag and file argument together")
+}
+
+// TestValidateCmdMultiStatementSuccess verifies that multiple valid
+// statements are all accepted.
+func TestValidateCmdMultiStatementSuccess(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT 1; SELECT 2"))
+	root.SetArgs([]string{"validate"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
+}
+
+// TestValidateCmdMultiStatementError verifies that an error in a later
+// statement reports the correct position relative to the full input.
+func TestValidateCmdMultiStatementError(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT 1;\nSELECT FROM"))
+	root.SetArgs([]string{"validate", "--output", "json"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+
+	pos := env.Errors[0].Position
+	require.NotNil(t, pos)
+	require.Equal(t, 2, pos.Line)
+	require.Equal(t, 12, pos.Column)
+	require.Equal(t, 21, pos.ByteOffset)
+}

--- a/internal/diag/error.go
+++ b/internal/diag/error.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package diag converts CockroachDB parser errors into the structured
+// output.Error type that the CLI envelope exposes to agents. The
+// enrichment has two layers:
+//
+//   - Position extraction (position.go): parses the pgerror Detail
+//     caret string to compute a 1-based line/column/byte_offset
+//     relative to the full SQL input.
+//
+//   - Error mapping (this file): extracts the SQLSTATE code, severity,
+//     and human-readable message from the parser's error chain via
+//     pgerror, then attaches the position.
+package diag
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// FromParseError converts a Go error returned by parser.Parse into a
+// structured output.Error with SQLSTATE code, severity, message, and
+// source position. fullSQL is the complete SQL input; it is used to
+// compute position relative to the full input when the parser
+// operated on a per-statement fragment.
+//
+// The returned Error always has Code, Severity, and Message populated.
+// Position is nil when the error lacks the expected pgerror Detail
+// format (e.g. non-parser errors passed by mistake).
+func FromParseError(err error, fullSQL string) output.Error {
+	code := pgerror.GetPGCode(err).String()
+
+	sev := pgerror.GetSeverity(err)
+	if sev == "" {
+		sev = string(output.SeverityError)
+	}
+
+	flat := pgerror.Flatten(err)
+
+	// Flatten may join multiple detail annotations with "\n--\n".
+	// The parser's PopulateErrorDetails is always the first block.
+	detail := flat.Detail
+	if sep := strings.Index(detail, "\n--\n"); sep >= 0 {
+		detail = detail[:sep]
+	}
+
+	return output.Error{
+		Code:     code,
+		Severity: output.Severity(sev),
+		Message:  err.Error(),
+		Position: ExtractPosition(detail, fullSQL),
+	}
+}

--- a/internal/diag/error_test.go
+++ b/internal/diag/error_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func TestFromParseError(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		expectedCode     string
+		expectedSeverity output.Severity
+		expectedMsgSub   string
+		expectedPos      *output.Position
+	}{
+		{
+			name:             "syntax error at EOF",
+			sql:              "SELECT FROM",
+			expectedCode:     "42601",
+			expectedSeverity: output.SeverityError,
+			expectedMsgSub:   "syntax error",
+			expectedPos: &output.Position{
+				Line:       1,
+				Column:     12,
+				ByteOffset: 11,
+			},
+		},
+		{
+			name:             "misspelled keyword",
+			sql:              "SELECTT 1",
+			expectedCode:     "42601",
+			expectedSeverity: output.SeverityError,
+			expectedMsgSub:   "syntax error",
+			expectedPos: &output.Position{
+				Line:       1,
+				Column:     1,
+				ByteOffset: 0,
+			},
+		},
+		{
+			name:             "multi-statement error on second",
+			sql:              "SELECT 1;\nSELECT FROM",
+			expectedCode:     "42601",
+			expectedSeverity: output.SeverityError,
+			expectedMsgSub:   "syntax error",
+			expectedPos: &output.Position{
+				Line:       2,
+				Column:     12,
+				ByteOffset: 21,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parser.Parse(tc.sql)
+			require.Error(t, err)
+
+			diagErr := FromParseError(err, tc.sql)
+			require.Equal(t, tc.expectedCode, diagErr.Code)
+			require.Equal(t, tc.expectedSeverity, diagErr.Severity)
+			require.Contains(t, diagErr.Message, tc.expectedMsgSub)
+
+			if tc.expectedPos == nil {
+				require.Nil(t, diagErr.Position)
+			} else {
+				require.NotNil(t, diagErr.Position)
+				require.Equal(t, *tc.expectedPos, *diagErr.Position)
+			}
+		})
+	}
+}

--- a/internal/diag/position.go
+++ b/internal/diag/position.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"strings"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// detailPrefix is the fixed header that PopulateErrorDetails (in the
+// CockroachDB parser) prepends to every Detail string. The remainder
+// is the statement SQL through the end of the line containing the
+// error token, followed by a caret line.
+const detailPrefix = "source SQL:\n"
+
+// ExtractPosition parses a pgerror Detail string produced by the
+// CockroachDB parser's PopulateErrorDetails and computes a 1-based
+// line/column Position relative to fullSQL.
+//
+// The Detail format is:
+//
+//	source SQL:\n<stmt_sql_up_to_error_line>\n<spaces>^
+//
+// For multi-statement input the Detail contains only the failing
+// statement's SQL fragment. ExtractPosition locates that fragment
+// within fullSQL via strings.LastIndex and adjusts the offset.
+// LastIndex is used because the parser processes statements
+// left-to-right and fails on the last attempted one; if the same
+// fragment appears earlier (e.g. inside a valid statement), the
+// last occurrence is the correct match.
+//
+// Returns nil when detail is empty, lacks the expected prefix, or
+// does not contain a caret line.
+func ExtractPosition(detail, fullSQL string) *output.Position {
+	if !strings.HasPrefix(detail, detailPrefix) {
+		return nil
+	}
+	body := detail[len(detailPrefix):]
+
+	lastNL := strings.LastIndex(body, "\n")
+	if lastNL < 0 {
+		return nil
+	}
+	caretLine := body[lastNL+1:]
+	stmtFragment := body[:lastNL]
+
+	caretCol := caretColumn(caretLine)
+	if caretCol < 0 {
+		return nil
+	}
+
+	// The stmtFragment may be multi-line (parser preserves newlines).
+	// The caret column is relative to the last line of stmtFragment.
+	lastStmtNL := strings.LastIndex(stmtFragment, "\n")
+	var stmtByteOffset int
+	if lastStmtNL < 0 {
+		stmtByteOffset = caretCol
+	} else {
+		stmtByteOffset = lastStmtNL + 1 + caretCol
+	}
+
+	// Locate the fragment in the full input so multi-statement
+	// positions are reported relative to the complete SQL string.
+	stmtOffset := strings.LastIndex(fullSQL, stmtFragment)
+	if stmtOffset < 0 {
+		return nil
+	}
+	fullByteOffset := stmtOffset + stmtByteOffset
+
+	line, col := lineColumn(fullSQL, fullByteOffset)
+	return &output.Position{
+		Line:       line,
+		Column:     col,
+		ByteOffset: fullByteOffset,
+	}
+}
+
+// caretColumn returns the 0-based column indicated by a caret line
+// (e.g. "       ^"). It counts leading spaces before the '^'. Returns
+// -1 if the line does not contain a caret.
+func caretColumn(line string) int {
+	idx := strings.IndexByte(line, '^')
+	if idx < 0 {
+		return -1
+	}
+	return idx
+}
+
+// lineColumn converts a 0-based byte offset within sql into a 1-based
+// line and column. The column counts bytes from the last newline (or
+// start of string), not runes, matching the CockroachDB parser's
+// convention.
+func lineColumn(sql string, byteOffset int) (line, col int) {
+	if byteOffset > len(sql) {
+		byteOffset = len(sql)
+	}
+	prefix := sql[:byteOffset]
+	line = strings.Count(prefix, "\n") + 1
+	lastNL := strings.LastIndex(prefix, "\n")
+	if lastNL < 0 {
+		col = byteOffset + 1
+	} else {
+		col = byteOffset - lastNL
+	}
+	return line, col
+}

--- a/internal/diag/position_test.go
+++ b/internal/diag/position_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func TestExtractPosition(t *testing.T) {
+	tests := []struct {
+		name     string
+		detail   string
+		fullSQL  string
+		expected *output.Position
+	}{
+		{
+			name:    "error at EOF of single-line statement",
+			detail:  "source SQL:\nSELECT FROM\n           ^",
+			fullSQL: "SELECT FROM",
+			expected: &output.Position{
+				Line:       1,
+				Column:     12,
+				ByteOffset: 11,
+			},
+		},
+		{
+			name:    "error at start of statement",
+			detail:  "source SQL:\nSELECTT 1\n^",
+			fullSQL: "SELECTT 1",
+			expected: &output.Position{
+				Line:       1,
+				Column:     1,
+				ByteOffset: 0,
+			},
+		},
+		{
+			name:    "error mid-token",
+			detail:  "source SQL:\nCREATE TABL foo (id INT)\n       ^",
+			fullSQL: "CREATE TABL foo (id INT)",
+			expected: &output.Position{
+				Line:       1,
+				Column:     8,
+				ByteOffset: 7,
+			},
+		},
+		{
+			name:    "multi-statement error on second statement",
+			detail:  "source SQL:\nSELECT FROM\n           ^",
+			fullSQL: "SELECT 1;\nSELECT FROM",
+			expected: &output.Position{
+				Line:       2,
+				Column:     12,
+				ByteOffset: 21,
+			},
+		},
+		{
+			name:    "multi-statement error on second statement same line",
+			detail:  "source SQL:\nSELECT FROM\n           ^",
+			fullSQL: "SELECT 1; SELECT FROM",
+			expected: &output.Position{
+				Line:       1,
+				Column:     22,
+				ByteOffset: 21,
+			},
+		},
+		{
+			name:    "multi-line statement fragment",
+			detail:  "source SQL:\nSELECT\n  1\n  FROM\n      ^",
+			fullSQL: "SELECT\n  1\n  FROM",
+			expected: &output.Position{
+				Line:       3,
+				Column:     7,
+				ByteOffset: 17,
+			},
+		},
+		{
+			name:    "fragment appears in earlier valid statement",
+			detail:  "source SQL:\nSELECT 1 FROM\n             ^",
+			fullSQL: "SELECT 1 FROM t; SELECT 1 FROM",
+			expected: &output.Position{
+				Line:       1,
+				Column:     31,
+				ByteOffset: 30,
+			},
+		},
+		{
+			name:     "fragment not found in full SQL",
+			detail:   "source SQL:\nNOT HERE\n        ^",
+			fullSQL:  "SELECT 1",
+			expected: nil,
+		},
+		{
+			name:     "empty detail",
+			detail:   "",
+			fullSQL:  "SELECT 1",
+			expected: nil,
+		},
+		{
+			name:     "malformed detail without prefix",
+			detail:   "some other error text",
+			fullSQL:  "SELECT 1",
+			expected: nil,
+		},
+		{
+			name:     "detail missing caret",
+			detail:   "source SQL:\nSELECT FROM\nno caret here",
+			fullSQL:  "SELECT FROM",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractPosition(tc.detail, tc.fullSQL)
+			if tc.expected == nil {
+				require.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				require.Equal(t, *tc.expected, *got)
+			}
+		})
+	}
+}
+
+func TestLineColumn(t *testing.T) {
+	tests := []struct {
+		name         string
+		sql          string
+		byteOffset   int
+		expectedLine int
+		expectedCol  int
+	}{
+		{
+			name:         "start of single-line input",
+			sql:          "SELECT 1",
+			byteOffset:   0,
+			expectedLine: 1,
+			expectedCol:  1,
+		},
+		{
+			name:         "middle of single-line input",
+			sql:          "SELECT 1",
+			byteOffset:   7,
+			expectedLine: 1,
+			expectedCol:  8,
+		},
+		{
+			name:         "start of second line",
+			sql:          "SELECT 1;\nSELECT 2",
+			byteOffset:   10,
+			expectedLine: 2,
+			expectedCol:  1,
+		},
+		{
+			name:         "middle of second line",
+			sql:          "SELECT 1;\nSELECT 2",
+			byteOffset:   17,
+			expectedLine: 2,
+			expectedCol:  8,
+		},
+		{
+			name:         "offset beyond input clamped",
+			sql:          "SELECT 1",
+			byteOffset:   100,
+			expectedLine: 1,
+			expectedCol:  9,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			line, col := lineColumn(tc.sql, tc.byteOffset)
+			require.Equal(t, tc.expectedLine, line, "line")
+			require.Equal(t, tc.expectedCol, col, "column")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `crdb-sql validate` subcommand that parses SQL and surfaces
  syntax errors as structured envelope entries with SQLSTATE codes
  (`42601`), severity, human-readable messages, and precise source
  positions (line/column/byte offset).
- New `internal/diag` package provides the error enrichment layer:
  `ExtractPosition` parses the pgerror Detail caret string,
  `FromParseError` maps pgerror fields to `output.Error`.
- Valid SQL returns `{"valid": true}` (JSON) or `Valid.` (text);
  invalid SQL returns structured errors with position info.

Example:
```
$ crdb-sql validate --output json -e "SELECT FROM"
{
  "errors": [{
    "code": "42601",
    "severity": "ERROR",
    "message": "at or near \"EOF\": syntax error",
    "position": {"line": 1, "column": 12, "byte_offset": 11}
  }]
}
```

Resolves: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)