### PR TITLE
sqlparse,sqlformat: run fidelity corpus through classify and format

### DIFF
--- a/internal/sqlformat/fidelity_test.go
+++ b/internal/sqlformat/fidelity_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package sqlformat_test holds the fidelity test that asserts the
+// curated corpus of canonical CockroachDB SQL formats without error
+// and that the formatted output preserves statement count and
+// classification when re-parsed. See package testcorpus for the
+// corpus enumeration and pragma infrastructure.
+package sqlformat_test
+
+import (
+	"testing"
+
+	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/testcorpus"
+	"github.com/stretchr/testify/require"
+)
+
+// corpusDir points at the shared corpus owned by sqlparse; the
+// relative path works because go test sets CWD to the package
+// directory.
+const corpusDir = "../sqlparse/testdata/corpus"
+
+// TestFidelityFormat verifies that every corpus file formats without
+// error and that the formatted output preserves statement count and
+// classification when re-parsed through sqlparse.Classify.
+func TestFidelityFormat(t *testing.T) {
+	testcorpus.ForEachFile(t, corpusDir, func(t *testing.T, sql string) {
+		formatted, err := sqlformat.Format(sql)
+		require.NoError(t, err)
+		require.NotEmpty(t, formatted)
+
+		original, err := sqlparse.Classify(sql)
+		require.NoError(t, err)
+
+		roundTripped, err := sqlparse.Classify(formatted)
+		require.NoError(t, err)
+		require.Equal(t, len(original), len(roundTripped),
+			"formatted output should produce same number of statements")
+
+		for i := range original {
+			require.Equal(t, original[i].StatementType, roundTripped[i].StatementType,
+				"statement %d: StatementType changed after formatting", i)
+			require.Equal(t, original[i].Tag, roundTripped[i].Tag,
+				"statement %d: Tag changed after formatting", i)
+		}
+	})
+}

--- a/internal/sqlparse/fidelity_test.go
+++ b/internal/sqlparse/fidelity_test.go
@@ -5,9 +5,7 @@
 
 // Package sqlparse_test holds the fidelity test suite that asserts a
 // curated corpus of canonical CockroachDB SQL parses cleanly with the
-// vendored cockroachdb-parser. It exists as a test-only package; the
-// production sqlparse API will be defined by whichever later issue
-// (validate / format / extract) first needs a wrapper.
+// vendored cockroachdb-parser.
 //
 // Corpus files live under testdata/corpus/*.sql and may contain
 // multiple statements separated by ';'. A file may begin with an
@@ -15,130 +13,53 @@
 //
 //	-- minparser: vMAJOR.MINOR.PATCH
 //
-// When present, the test skips the file unless currentParserVersion
-// is >= the pragma's version. This lets us land coverage for SQL
-// introduced in future parser releases without breaking older builds.
+// When present, the test skips the file unless the pinned parser
+// version is >= the pragma's version. This lets us land coverage for
+// SQL introduced in future parser releases without breaking older
+// builds. See package testcorpus for the pragma implementation.
 package sqlparse_test
 
 import (
-	"bufio"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
-	"golang.org/x/mod/semver"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/testcorpus"
+	"github.com/stretchr/testify/require"
 )
-
-// currentParserVersion is the cockroachdb-parser module version this
-// build is pinned against. It must be kept in lockstep with the
-// `replace` directive in go.mod (currently
-// github.com/spilchen/cockroachdb-parser v0.26.2).
-//
-// It is hardcoded rather than read from debug.ReadBuildInfo because
-// `go test` binaries do not populate BuildInfo.Deps — the same
-// constraint observed by the version subcommand (see
-// cmd/version.go). Bump this constant in the same commit that bumps
-// the replace directive.
-const currentParserVersion = "v0.26.2"
 
 // corpusDir is resolved relative to the package directory; `go test`
 // runs with CWD set to the package, which makes this the conventional
 // Go testdata layout.
 const corpusDir = "testdata/corpus"
 
-// minParserPragma is the leading-comment marker that gates a corpus
-// file on a minimum parser version. The parser is whitespace-
-// tolerant; anything not matching is treated as a regular comment.
-const minParserPragma = "-- minparser:"
-
 func TestFidelity(t *testing.T) {
-	entries, err := os.ReadDir(corpusDir)
-	if err != nil {
-		t.Fatalf("read corpus dir %q: %v", corpusDir, err)
-	}
-
-	var sqlFiles []string
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
-			continue
+	testcorpus.ForEachFile(t, corpusDir, func(t *testing.T, sql string) {
+		stmts, err := parser.Parse(sql)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
 		}
-		sqlFiles = append(sqlFiles, e.Name())
-	}
-	if len(sqlFiles) == 0 {
-		t.Fatalf("no .sql files found under %q; corpus must not be empty", corpusDir)
-	}
-
-	for _, name := range sqlFiles {
-		path := filepath.Join(corpusDir, name)
-		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatalf("read %q: %v", path, err)
-			}
-
-			minVer, err := extractMinParserPragma(string(data))
-			if err != nil {
-				t.Fatalf("invalid pragma in %q: %v", path, err)
-			}
-			if minVer != "" && semver.Compare(currentParserVersion, minVer) < 0 {
-				t.Skipf("requires parser %s, have %s", minVer, currentParserVersion)
-			}
-
-			stmts, err := parser.Parse(string(data))
-			if err != nil {
-				t.Fatalf("parse %q: %v", path, err)
-			}
-			if len(stmts) == 0 {
-				t.Fatalf("%q parsed to zero statements; corpus files must contain at least one statement", path)
-			}
-		})
-	}
+		if len(stmts) == 0 {
+			t.Fatal("parsed to zero statements; corpus files must contain at least one statement")
+		}
+	})
 }
 
-// extractMinParserPragma scans the leading `--` comment block of a
-// corpus file for a `-- minparser: vX.Y.Z` line and returns the
-// version string. It returns ("", nil) when no pragma is present
-// (the common case). A pragma whose value fails semver.IsValid is
-// reported as an error so typos surface loudly rather than silently
-// widening coverage.
-//
-// Only leading comments are inspected: scanning stops at the first
-// line that is neither blank nor a `--` comment. A pragma buried
-// inside the SQL body is intentionally ignored.
-func extractMinParserPragma(content string) (string, error) {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		if !strings.HasPrefix(line, "--") {
-			return "", nil
-		}
-		if !strings.HasPrefix(line, minParserPragma) {
-			continue
-		}
-		v := strings.TrimSpace(strings.TrimPrefix(line, minParserPragma))
-		if !semver.IsValid(v) {
-			return "", &pragmaError{value: v}
-		}
-		return v, nil
-	}
-	if err := scanner.Err(); err != nil {
-		return "", err
-	}
-	return "", nil
-}
+// TestFidelityClassify verifies that every corpus file classifies
+// cleanly through sqlparse.Classify and that each resulting statement
+// carries a non-empty StatementType, Tag, and SQL field. This
+// complements TestFidelity, which only asserts that the raw parser
+// accepts the corpus without error.
+func TestFidelityClassify(t *testing.T) {
+	testcorpus.ForEachFile(t, corpusDir, func(t *testing.T, sql string) {
+		stmts, err := sqlparse.Classify(sql)
+		require.NoError(t, err)
+		require.NotEmpty(t, stmts)
 
-// pragmaError reports a malformed minparser pragma value. It carries
-// the offending string so the test failure tells the author exactly
-// what to fix.
-type pragmaError struct {
-	value string
-}
-
-func (e *pragmaError) Error() string {
-	return "minparser pragma value is not valid semver: " + e.value
+		for i, stmt := range stmts {
+			require.NotEmpty(t, stmt.StatementType, "statement %d has empty StatementType", i)
+			require.NotEmpty(t, stmt.Tag, "statement %d has empty Tag", i)
+			require.NotEmpty(t, stmt.SQL, "statement %d has empty SQL", i)
+		}
+	})
 }

--- a/internal/testcorpus/testcorpus.go
+++ b/internal/testcorpus/testcorpus.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package testcorpus provides shared infrastructure for fidelity tests
+// that run the curated SQL corpus through various parser and formatter
+// APIs. It owns the parser-version constant, the `-- minparser:`
+// pragma extraction, and the corpus-enumeration loop so that each
+// fidelity test only needs to supply its assertion callback.
+package testcorpus
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/semver"
+)
+
+// CurrentParserVersion is the cockroachdb-parser module version this
+// build is pinned against. It must be kept in lockstep with the
+// `replace` directive in go.mod (currently
+// github.com/spilchen/cockroachdb-parser v0.26.2).
+//
+// It is hardcoded rather than read from debug.ReadBuildInfo because
+// `go test` binaries do not populate BuildInfo.Deps — the same
+// constraint observed by the version subcommand (see
+// cmd/version.go). Bump this constant in the same commit that bumps
+// the replace directive.
+const CurrentParserVersion = "v0.26.2"
+
+// minParserPragma is the leading-comment marker that gates a corpus
+// file on a minimum parser version. The pragma extraction trims
+// whitespace after the colon, so both `-- minparser: v0.26.2` and
+// `-- minparser:v0.26.2` are accepted.
+const minParserPragma = "-- minparser:"
+
+// ForEachFile enumerates .sql files in corpusDir, creating a subtest
+// per file. For each file it extracts the optional `-- minparser:`
+// pragma and skips the subtest when CurrentParserVersion is below the
+// required minimum. The file's content is passed to fn as a string.
+//
+// corpusDir is resolved relative to the calling package's directory
+// since `go test` sets CWD to the package under test.
+func ForEachFile(t *testing.T, corpusDir string, fn func(t *testing.T, sql string)) {
+	t.Helper()
+
+	entries, err := os.ReadDir(corpusDir)
+	if err != nil {
+		t.Fatalf("read corpus dir %q: %v", corpusDir, err)
+	}
+
+	var sqlFiles []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		sqlFiles = append(sqlFiles, e.Name())
+	}
+	if len(sqlFiles) == 0 {
+		t.Fatalf("no .sql files found under %q; corpus must not be empty", corpusDir)
+	}
+
+	for _, name := range sqlFiles {
+		path := filepath.Join(corpusDir, name)
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %q: %v", path, err)
+			}
+
+			minVer, err := extractMinParserPragma(string(data))
+			if err != nil {
+				t.Fatalf("invalid pragma in %q: %v", path, err)
+			}
+			if minVer != "" && semver.Compare(CurrentParserVersion, minVer) < 0 {
+				t.Skipf("requires parser %s, have %s", minVer, CurrentParserVersion)
+			}
+
+			fn(t, string(data))
+		})
+	}
+}
+
+// extractMinParserPragma scans the leading `--` comment block of a
+// corpus file for a `-- minparser: vX.Y.Z` line and returns the
+// version string. It returns ("", nil) when no pragma is present
+// (the common case). A pragma whose value fails semver.IsValid is
+// reported as an error so typos surface loudly rather than silently
+// widening coverage.
+//
+// Only leading comments are inspected: scanning stops at the first
+// line that is neither blank nor a `--` comment. A pragma buried
+// inside the SQL body is intentionally ignored.
+func extractMinParserPragma(content string) (string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "--") {
+			return "", nil
+		}
+		if !strings.HasPrefix(line, minParserPragma) {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(line, minParserPragma))
+		if !semver.IsValid(v) {
+			return "", &pragmaError{value: v}
+		}
+		return v, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// pragmaError reports a malformed minparser pragma value. It carries
+// the offending string so the test failure tells the author exactly
+// what to fix.
+type pragmaError struct {
+	value string
+}
+
+func (e *pragmaError) Error() string {
+	return "minparser pragma value is not valid semver: " + e.value
+}


### PR DESCRIPTION
## Summary

- Add `TestFidelityClassify` in `internal/sqlparse/` — runs each corpus file through `sqlparse.Classify`, asserting no errors and that every statement has populated `StatementType`, `Tag`, and `SQL` fields.
- Add `TestFidelityFormat` in `internal/sqlformat/` — runs each corpus file through `sqlformat.Format`, asserting no errors and non-empty output, then round-trips by classifying both original and formatted output and comparing statement count, `StatementType`, and `Tag`.
- Extract shared corpus infrastructure into `internal/testcorpus/` — `CurrentParserVersion` constant, `ForEachFile` helper (corpus enumeration, pragma extraction, version gating), consolidating ~70 lines that were previously duplicated.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>