### PR TITLE
catalog: add schema loader for CREATE TABLE files

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// newDescribeCmd builds the `crdb-sql describe` subcommand. It loads
+// one or more schema files (--schema), parses them with the
+// CockroachDB parser, and describes the named table's columns, primary
+// key, and indexes.
+//
+// This is a Tier 2 (schema-file) command: it works offline but
+// requires at least one --schema file.
+func newDescribeCmd(state *rootState) *cobra.Command {
+	var schemaFiles []string
+
+	cmd := &cobra.Command{
+		Use:   "describe TABLE",
+		Short: "Describe a table from schema files",
+		Long: `Load CREATE TABLE definitions from one or more --schema files and
+print the named table's columns, primary key, and indexes.
+
+Schema files are plain SQL containing CREATE TABLE statements. You can
+obtain one from a running CockroachDB cluster with:
+
+  cockroach sql -e 'SHOW CREATE ALL TABLES' > schema.sql
+
+Then describe any table:
+
+  crdb-sql describe users --schema schema.sql`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			baseEnv := output.Envelope{
+				Tier:             output.TierSchemaFile,
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
+
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.ParserVersion = parserVer
+
+			if len(schemaFiles) == 0 {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("at least one --schema file is required"))
+			}
+
+			cat, err := catalog.LoadFiles(schemaFiles)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			for _, w := range cat.Warnings() {
+				baseEnv.Errors = append(baseEnv.Errors, output.Error{
+					Code:     "schema_warning",
+					Severity: output.SeverityWarning,
+					Message:  w,
+				})
+			}
+
+			tableName := args[0]
+			tbl, ok := cat.Table(tableName)
+			if !ok {
+				available := cat.TableNames()
+				if len(available) == 0 {
+					return r.RenderError(baseEnv,
+						fmt.Errorf("table %q not found; schema files contain no tables", tableName))
+				}
+				return r.RenderError(baseEnv,
+					fmt.Errorf("table %q not found; available tables: %s",
+						tableName, strings.Join(available, ", ")))
+			}
+
+			data, err := json.Marshal(tbl)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				return renderTableText(w, tbl)
+			})
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&schemaFiles, "schema", nil,
+		"schema SQL file(s) to load (repeatable)")
+
+	return cmd
+}
+
+func renderTableText(w io.Writer, tbl catalog.Table) error {
+	if _, err := fmt.Fprintf(w, "Table: %s\n\nColumns:\n", tbl.Name); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "  NAME\tTYPE\tNULLABLE\tDEFAULT"); err != nil {
+		return err
+	}
+	for _, col := range tbl.Columns {
+		def := "-"
+		if col.Default != nil {
+			def = *col.Default
+		}
+		if _, err := fmt.Fprintf(tw, "  %s\t%s\t%t\t%s\n",
+			col.Name, col.Type, col.Nullable, def); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(tbl.PrimaryKey) > 0 {
+		if _, err := fmt.Fprintf(w, "\nPrimary Key: %s\n",
+			strings.Join(tbl.PrimaryKey, ", ")); err != nil {
+			return err
+		}
+	}
+
+	if len(tbl.Indexes) > 0 {
+		if _, err := fmt.Fprintln(w, "\nIndexes:"); err != nil {
+			return err
+		}
+		tw = tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+		if _, err := fmt.Fprintln(tw, "  NAME\tCOLUMNS\tUNIQUE"); err != nil {
+			return err
+		}
+		for _, idx := range tbl.Indexes {
+			if _, err := fmt.Fprintf(tw, "  %s\t%s\t%t\n",
+				idx.Name, strings.Join(idx.Columns, ", "), idx.Unique); err != nil {
+				return err
+			}
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -1,0 +1,280 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func writeSchemaFile(t *testing.T, sql string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "schema.sql")
+	require.NoError(t, os.WriteFile(path, []byte(sql), 0644))
+	return path
+}
+
+const testSchema = `
+CREATE TABLE users (
+	id INT8 PRIMARY KEY,
+	email VARCHAR(255) NOT NULL UNIQUE,
+	name STRING,
+	created_at TIMESTAMPTZ DEFAULT now()
+);
+`
+
+func TestDescribeCmdTextOutput(t *testing.T) {
+	schema := writeSchemaFile(t, testSchema)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "users", "--schema", schema})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "Table: users")
+	require.Contains(t, got, "id")
+	require.Contains(t, got, "INT8")
+	require.Contains(t, got, "email")
+	require.Contains(t, got, "VARCHAR(255)")
+	require.Contains(t, got, "Primary Key: id")
+	require.Contains(t, got, "users_email_key")
+}
+
+func TestDescribeCmdJSONOutput(t *testing.T) {
+	schema := writeSchemaFile(t, testSchema)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"describe", "users", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "users", tbl.Name)
+	require.Len(t, tbl.Columns, 4)
+	require.Equal(t, []string{"id"}, tbl.PrimaryKey)
+}
+
+func TestDescribeCmdJSONColumns(t *testing.T) {
+	schema := writeSchemaFile(t, testSchema)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "users", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+
+	id := tbl.Columns[0]
+	require.Equal(t, "id", id.Name)
+	require.Equal(t, "INT8", id.Type)
+	require.False(t, id.Nullable)
+	require.Nil(t, id.Default)
+
+	email := tbl.Columns[1]
+	require.Equal(t, "email", email.Name)
+	require.Equal(t, "VARCHAR(255)", email.Type)
+	require.False(t, email.Nullable)
+
+	name := tbl.Columns[2]
+	require.Equal(t, "name", name.Name)
+	require.True(t, name.Nullable)
+
+	createdAt := tbl.Columns[3]
+	require.Equal(t, "created_at", createdAt.Name)
+	require.NotNil(t, createdAt.Default)
+	require.Equal(t, "now()", *createdAt.Default)
+}
+
+func TestDescribeCmdJSONIndexes(t *testing.T) {
+	schema := writeSchemaFile(t, testSchema)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "users", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+
+	require.Len(t, tbl.Indexes, 1)
+	require.Equal(t, "users_email_key", tbl.Indexes[0].Name)
+	require.Equal(t, []string{"email"}, tbl.Indexes[0].Columns)
+	require.True(t, tbl.Indexes[0].Unique)
+}
+
+func TestDescribeCmdMissingSchemaFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "users", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "--schema")
+}
+
+func TestDescribeCmdTableNotFound(t *testing.T) {
+	schema := writeSchemaFile(t, `CREATE TABLE orders (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "users", "--schema", schema, "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "users")
+	require.Contains(t, env.Errors[0].Message, "orders")
+}
+
+func TestDescribeCmdMultipleSchemaFiles(t *testing.T) {
+	schema1 := writeSchemaFile(t, `CREATE TABLE a (id INT8 PRIMARY KEY)`)
+	schema2 := writeSchemaFile(t, `CREATE TABLE b (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "b", "--schema", schema1, "--schema", schema2, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "b", tbl.Name)
+}
+
+func TestDescribeCmdPrimaryKeyImpliesNotNull(t *testing.T) {
+	schema := writeSchemaFile(t, `CREATE TABLE t (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "t", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.False(t, tbl.Columns[0].Nullable)
+}
+
+func TestDescribeCmdInlineUniqueSynthesizesName(t *testing.T) {
+	schema := writeSchemaFile(t, `CREATE TABLE t (id INT8 PRIMARY KEY, code STRING UNIQUE)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "t", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Len(t, tbl.Indexes, 1)
+	require.Equal(t, "t_code_key", tbl.Indexes[0].Name)
+}
+
+func TestDescribeCmdWarningsInJSONOutput(t *testing.T) {
+	schema := writeSchemaFile(t, `
+		SELECT 1;
+		CREATE TABLE t (id INT8 PRIMARY KEY);
+	`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "t", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotNil(t, env.Data)
+
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	require.Contains(t, env.Errors[0].Message, "skipped 1 non-CREATE TABLE")
+}
+
+func TestDescribeCmdParseError(t *testing.T) {
+	schema := writeSchemaFile(t, `CREAT TABLE bad (id INT8)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"describe", "bad", "--schema", schema, "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "parse schema file")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newParseCmd(state))
 	root.AddCommand(newFormatCmd(state))
 	root.AddCommand(newValidateCmd(state))
+	root.AddCommand(newDescribeCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package catalog provides a lightweight in-memory representation of a
+// SQL schema loaded from CREATE TABLE DDL files. The primary entry
+// point is LoadFiles, which parses one or more .sql files using the
+// CockroachDB parser and builds a Catalog mapping table names to their
+// columns, primary key, and indexes.
+//
+// The catalog is the foundation for Tier 2 (schema-aware) analysis:
+// name resolution, column type lookup, and "did you mean?" suggestions
+// all read from this structure. It is built once, then read-only — no
+// concurrent access is expected, so no synchronization is needed.
+package catalog
+
+import "strings"
+
+// Catalog is the in-memory representation of a SQL schema loaded from
+// one or more DDL files. It holds an ordered list of tables (preserving
+// file order for deterministic output) and a case-insensitive name
+// index for O(1) lookup.
+//
+// Lifecycle: built once by LoadFiles, then read-only.
+type Catalog struct {
+	tables   []Table
+	byName   map[string]int // lowercased name → index in tables
+	warnings []string
+}
+
+// Table returns the table definition with the given name, or false if
+// the catalog contains no such table. Lookup is case-insensitive.
+func (c *Catalog) Table(name string) (Table, bool) {
+	i, ok := c.byName[strings.ToLower(name)]
+	if !ok {
+		return Table{}, false
+	}
+	return c.tables[i], true
+}
+
+// Warnings returns any non-fatal issues encountered during loading,
+// such as skipped statement types or duplicate table definitions. The
+// catalog is still usable when warnings are present.
+func (c *Catalog) Warnings() []string {
+	return c.warnings
+}
+
+// TableNames returns the names of all loaded tables in the order they
+// were encountered across the input files.
+func (c *Catalog) TableNames() []string {
+	names := make([]string, len(c.tables))
+	for i, t := range c.tables {
+		names[i] = t.Name
+	}
+	return names
+}
+
+// Table is the parsed metadata for a single CREATE TABLE statement.
+type Table struct {
+	Name       string   `json:"name"`
+	Columns    []Column `json:"columns"`
+	PrimaryKey []string `json:"primary_key"`
+	Indexes    []Index  `json:"indexes"`
+}
+
+// Column is one column extracted from a CREATE TABLE definition.
+type Column struct {
+	Name     string  `json:"name"`
+	Type     string  `json:"type"`
+	Nullable bool    `json:"nullable"`
+	Default  *string `json:"default,omitempty"`
+}
+
+// Index is a secondary index (including UNIQUE constraints) on a table.
+type Index struct {
+	Name    string   `json:"name"`
+	Columns []string `json:"columns"`
+	Unique  bool     `json:"unique"`
+}

--- a/internal/catalog/loader.go
+++ b/internal/catalog/loader.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// maxSchemaFileSize is the largest schema file LoadFiles will read.
+// Schema DDL files are typically small; a 100 MB limit prevents
+// accidental OOM from passing a full database dump.
+const maxSchemaFileSize = 100 << 20
+
+// LoadFiles parses the SQL content of each file and builds a Catalog
+// from the CREATE TABLE statements found. Non-CREATE TABLE statements
+// are skipped with a warning. If multiple files define the same table
+// name, the last definition wins and a warning is recorded.
+func LoadFiles(paths []string) (*Catalog, error) {
+	cat := &Catalog{byName: make(map[string]int)}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read schema file %s: %w", path, err)
+		}
+		if int64(len(data)) > maxSchemaFileSize {
+			return nil, fmt.Errorf("schema file %s is too large (%d bytes, max %d)",
+				path, len(data), maxSchemaFileSize)
+		}
+
+		stmts, err := parser.Parse(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("parse schema file %s: %w", path, err)
+		}
+
+		var skippedTags []string
+		for _, stmt := range stmts {
+			ct, ok := stmt.AST.(*tree.CreateTable)
+			if !ok || ct.As() {
+				skippedTags = append(skippedTags, stmt.AST.StatementTag())
+				continue
+			}
+			tableName := ct.Table.Table()
+			if tableName == "" {
+				continue
+			}
+			tbl := extractTable(ct)
+			key := strings.ToLower(tbl.Name)
+			if idx, exists := cat.byName[key]; exists {
+				cat.warnings = append(cat.warnings,
+					fmt.Sprintf("%s: table %q defined more than once; using last definition", path, tbl.Name))
+				cat.tables[idx] = tbl
+			} else {
+				cat.byName[key] = len(cat.tables)
+				cat.tables = append(cat.tables, tbl)
+			}
+		}
+
+		if len(skippedTags) > 0 {
+			cat.warnings = append(cat.warnings,
+				fmt.Sprintf("%s: skipped %d non-CREATE TABLE statement(s): %s",
+					path, len(skippedTags), strings.Join(skippedTags, ", ")))
+		}
+	}
+
+	return cat, nil
+}
+
+// extractTable converts a parsed CREATE TABLE AST into the catalog's
+// Table representation. It handles two known parser edge cases:
+//
+//  1. A column with an inline PRIMARY KEY constraint has
+//     PrimaryKey.IsPrimaryKey set but Nullability left at SilentNull.
+//     The loader forces such columns to not-null.
+//
+//  2. A column with an inline UNIQUE constraint has no synthesized
+//     index name. The loader generates one as <table>_<column>_key,
+//     matching CockroachDB's naming convention.
+func extractTable(ct *tree.CreateTable) Table {
+	tableName := ct.Table.Table()
+
+	var columns []Column
+	var pkCols []string
+	var indexes []Index
+
+	for _, def := range ct.Defs {
+		switch d := def.(type) {
+		case *tree.ColumnTableDef:
+			col := extractColumn(d)
+			columns = append(columns, col)
+
+			if d.PrimaryKey.IsPrimaryKey {
+				pkCols = append(pkCols, col.Name)
+			}
+
+			if d.Unique.IsUnique && !d.Unique.WithoutIndex {
+				name := string(d.Unique.ConstraintName)
+				if name == "" {
+					name = tableName + "_" + col.Name + "_key"
+				}
+				indexes = append(indexes, Index{
+					Name:    name,
+					Columns: []string{col.Name},
+					Unique:  true,
+				})
+			}
+
+		case *tree.UniqueConstraintTableDef:
+			cols := indexElemColumns(d.Columns)
+			if d.PrimaryKey {
+				pkCols = cols
+			} else {
+				indexes = append(indexes, Index{
+					Name:    string(d.Name),
+					Columns: cols,
+					Unique:  true,
+				})
+			}
+
+		case *tree.IndexTableDef:
+			indexes = append(indexes, Index{
+				Name:    string(d.Name),
+				Columns: indexElemColumns(d.Columns),
+				Unique:  false,
+			})
+		}
+	}
+
+	// PK columns are implicitly NOT NULL in SQL. Inline PKs are
+	// handled in extractColumn, but table-level PRIMARY KEY (a, b)
+	// constraints are resolved after all columns are collected.
+	if len(pkCols) > 0 {
+		pkSet := make(map[string]struct{}, len(pkCols))
+		for _, pk := range pkCols {
+			pkSet[pk] = struct{}{}
+		}
+		for i := range columns {
+			if _, ok := pkSet[columns[i].Name]; ok {
+				columns[i].Nullable = false
+			}
+		}
+	}
+
+	if columns == nil {
+		columns = []Column{}
+	}
+	if pkCols == nil {
+		pkCols = []string{}
+	}
+	if indexes == nil {
+		indexes = []Index{}
+	}
+
+	return Table{
+		Name:       tableName,
+		Columns:    columns,
+		PrimaryKey: pkCols,
+		Indexes:    indexes,
+	}
+}
+
+func extractColumn(col *tree.ColumnTableDef) Column {
+	nullable := !col.PrimaryKey.IsPrimaryKey && col.Nullable.Nullability != tree.NotNull
+
+	c := Column{
+		Name:     string(col.Name),
+		Type:     col.Type.SQLString(),
+		Nullable: nullable,
+	}
+
+	if col.HasDefaultExpr() {
+		s := tree.AsString(col.DefaultExpr.Expr)
+		c.Default = &s
+	}
+
+	return c
+}
+
+func indexElemColumns(elems tree.IndexElemList) []string {
+	cols := make([]string, len(elems))
+	for i, elem := range elems {
+		cols[i] = string(elem.Column)
+	}
+	return cols
+}

--- a/internal/catalog/loader_test.go
+++ b/internal/catalog/loader_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeSQL(t *testing.T, sql string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "schema.sql")
+	require.NoError(t, os.WriteFile(path, []byte(sql), 0644))
+	return path
+}
+
+func TestLoadFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		tableName string
+		wantTable Table
+		wantErr   string
+		wantNames []string
+	}{
+		{
+			name: "basic columns",
+			sql: `CREATE TABLE users (
+				id INT8,
+				name TEXT,
+				active BOOL
+			)`,
+			tableName: "users",
+			wantTable: Table{
+				Name: "users",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: true},
+					{Name: "name", Type: "STRING", Nullable: true},
+					{Name: "active", Type: "BOOL", Nullable: true},
+				},
+				PrimaryKey: []string{},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "inline primary key forces not null",
+			sql: `CREATE TABLE items (
+				id INT8 PRIMARY KEY,
+				label TEXT
+			)`,
+			tableName: "items",
+			wantTable: Table{
+				Name: "items",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "label", Type: "STRING", Nullable: true},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "composite table-level primary key implies not null",
+			sql: `CREATE TABLE kv (
+				region TEXT,
+				id INT8,
+				val TEXT,
+				PRIMARY KEY (region, id)
+			)`,
+			tableName: "kv",
+			wantTable: Table{
+				Name: "kv",
+				Columns: []Column{
+					{Name: "region", Type: "STRING", Nullable: false},
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "val", Type: "STRING", Nullable: true},
+				},
+				PrimaryKey: []string{"region", "id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "inline unique synthesizes index name",
+			sql: `CREATE TABLE accounts (
+				id INT8 PRIMARY KEY,
+				email TEXT UNIQUE
+			)`,
+			tableName: "accounts",
+			wantTable: Table{
+				Name: "accounts",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "email", Type: "STRING", Nullable: true},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes: []Index{
+					{Name: "accounts_email_key", Columns: []string{"email"}, Unique: true},
+				},
+			},
+		},
+		{
+			name: "named unique constraint preserves name",
+			sql: `CREATE TABLE users (
+				id INT8 PRIMARY KEY,
+				email TEXT CONSTRAINT uq_email UNIQUE
+			)`,
+			tableName: "users",
+			wantTable: Table{
+				Name: "users",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "email", Type: "STRING", Nullable: true},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes: []Index{
+					{Name: "uq_email", Columns: []string{"email"}, Unique: true},
+				},
+			},
+		},
+		{
+			name: "table-level unique constraint",
+			sql: `CREATE TABLE orders (
+				store_id INT8,
+				order_num INT8,
+				UNIQUE (store_id, order_num)
+			)`,
+			tableName: "orders",
+			wantTable: Table{
+				Name: "orders",
+				Columns: []Column{
+					{Name: "store_id", Type: "INT8", Nullable: true},
+					{Name: "order_num", Type: "INT8", Nullable: true},
+				},
+				PrimaryKey: []string{},
+				Indexes: []Index{
+					{Name: "", Columns: []string{"store_id", "order_num"}, Unique: true},
+				},
+			},
+		},
+		{
+			name: "explicit index",
+			sql: `CREATE TABLE events (
+				id INT8 PRIMARY KEY,
+				ts TIMESTAMPTZ,
+				INDEX idx_ts (ts)
+			)`,
+			tableName: "events",
+			wantTable: Table{
+				Name: "events",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "ts", Type: "TIMESTAMPTZ", Nullable: true},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes: []Index{
+					{Name: "idx_ts", Columns: []string{"ts"}, Unique: false},
+				},
+			},
+		},
+		{
+			name: "default expressions",
+			sql: `CREATE TABLE records (
+				id INT8 PRIMARY KEY,
+				count INT8 DEFAULT 0,
+				created_at TIMESTAMPTZ DEFAULT now()
+			)`,
+			tableName: "records",
+			wantTable: Table{
+				Name: "records",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "count", Type: "INT8", Nullable: true, Default: strPtr("0")},
+					{Name: "created_at", Type: "TIMESTAMPTZ", Nullable: true, Default: strPtr("now()")},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "explicit null and not null",
+			sql: `CREATE TABLE t (
+				a INT8 NULL,
+				b INT8 NOT NULL
+			)`,
+			tableName: "t",
+			wantTable: Table{
+				Name: "t",
+				Columns: []Column{
+					{Name: "a", Type: "INT8", Nullable: true},
+					{Name: "b", Type: "INT8", Nullable: false},
+				},
+				PrimaryKey: []string{},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "non-create-table statements skipped",
+			sql: `
+				SELECT 1;
+				ALTER TABLE foo ADD COLUMN bar INT8;
+				CREATE TABLE t (id INT8 PRIMARY KEY);
+				INSERT INTO t VALUES (1);
+			`,
+			tableName: "t",
+			wantTable: Table{
+				Name: "t",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "multiple tables in one file",
+			sql: `
+				CREATE TABLE a (id INT8 PRIMARY KEY);
+				CREATE TABLE b (id INT8 PRIMARY KEY);
+			`,
+			tableName: "b",
+			wantNames: []string{"a", "b"},
+			wantTable: Table{
+				Name: "b",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name:    "empty file",
+			sql:     "",
+			wantErr: "",
+		},
+		{
+			name:    "parse error",
+			sql:     "CREAT TABLE bad (id INT8);",
+			wantErr: "parse schema file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeSQL(t, tc.sql)
+			cat, err := LoadFiles([]string{path})
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.wantNames != nil {
+				require.Equal(t, tc.wantNames, cat.TableNames())
+			}
+
+			if tc.tableName == "" {
+				require.Empty(t, cat.TableNames())
+				return
+			}
+
+			tbl, ok := cat.Table(tc.tableName)
+			require.True(t, ok, "table %q not found in catalog", tc.tableName)
+			require.Equal(t, tc.wantTable, tbl)
+		})
+	}
+}
+
+func TestLoadFilesMultipleFiles(t *testing.T) {
+	path1 := writeSQL(t, `CREATE TABLE a (id INT8 PRIMARY KEY)`)
+	path2 := writeSQL(t, `CREATE TABLE b (id INT8 PRIMARY KEY)`)
+
+	cat, err := LoadFiles([]string{path1, path2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, cat.TableNames())
+
+	_, ok := cat.Table("a")
+	require.True(t, ok)
+	_, ok = cat.Table("b")
+	require.True(t, ok)
+}
+
+func TestLoadFilesDuplicateTableLastWins(t *testing.T) {
+	path1 := writeSQL(t, `CREATE TABLE t (old_col INT8)`)
+	path2 := writeSQL(t, `CREATE TABLE t (new_col TEXT)`)
+
+	cat, err := LoadFiles([]string{path1, path2})
+	require.NoError(t, err)
+	require.Equal(t, []string{"t"}, cat.TableNames())
+
+	tbl, ok := cat.Table("t")
+	require.True(t, ok)
+	require.Equal(t, "new_col", tbl.Columns[0].Name)
+
+	require.Len(t, cat.Warnings(), 1)
+	require.Contains(t, cat.Warnings()[0], "defined more than once")
+}
+
+func TestLoadFilesFileNotFound(t *testing.T) {
+	_, err := LoadFiles([]string{"/nonexistent/schema.sql"})
+	require.ErrorContains(t, err, "read schema file")
+}
+
+func TestLoadFilesCaseInsensitiveLookup(t *testing.T) {
+	path := writeSQL(t, `CREATE TABLE Users (id INT8 PRIMARY KEY)`)
+	cat, err := LoadFiles([]string{path})
+	require.NoError(t, err)
+
+	_, ok := cat.Table("users")
+	require.True(t, ok)
+	_, ok = cat.Table("USERS")
+	require.True(t, ok)
+	_, ok = cat.Table("Users")
+	require.True(t, ok)
+}
+
+func TestLoadFilesSkippedStatementsWarning(t *testing.T) {
+	path := writeSQL(t, `
+		SELECT 1;
+		CREATE TABLE t (id INT8 PRIMARY KEY);
+		ALTER TABLE t ADD COLUMN name STRING;
+	`)
+
+	cat, err := LoadFiles([]string{path})
+	require.NoError(t, err)
+	require.Equal(t, []string{"t"}, cat.TableNames())
+
+	require.Len(t, cat.Warnings(), 1)
+	require.Contains(t, cat.Warnings()[0], "skipped 2 non-CREATE TABLE")
+	require.Contains(t, cat.Warnings()[0], "SELECT")
+	require.Contains(t, cat.Warnings()[0], "ALTER TABLE")
+}
+
+func TestLoadFilesNoWarningsWhenAllCreateTable(t *testing.T) {
+	path := writeSQL(t, `CREATE TABLE t (id INT8 PRIMARY KEY)`)
+	cat, err := LoadFiles([]string{path})
+	require.NoError(t, err)
+	require.Empty(t, cat.Warnings())
+}
+
+func TestLoadFilesFileTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "huge.sql")
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(maxSchemaFileSize+1))
+	require.NoError(t, f.Close())
+
+	_, err = LoadFiles([]string{path})
+	require.ErrorContains(t, err, "too large")
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary

- Add `internal/catalog` package with a lightweight in-memory catalog that parses CREATE TABLE DDL files using the CockroachDB parser, extracting columns (name, type, nullable, default), primary key, and indexes.
- Add `crdb-sql describe TABLE --schema FILE` subcommand (Tier 2) to expose loaded table metadata in text and JSON formats.
- Handle parser edge cases: inline PK columns forced NOT NULL, table-level PK columns retroactively marked NOT NULL, inline UNIQUE constraints get synthesized index names.
- Surface warnings for skipped non-CREATE TABLE statements and duplicate table definitions.
- File size guard rejects schema files over 100 MB.

Resolves #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>