### PR TITLE
cmd: run fidelity corpus through validate command

### DIFF
--- a/cmd/validate_fidelity_test.go
+++ b/cmd/validate_fidelity_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// This file holds the fidelity test that asserts the curated corpus
+// of canonical CockroachDB SQL validates without error through the
+// full validate command pipeline. Unlike TestFidelity in sqlparse
+// (which exercises the raw parser), this test covers the CLI command
+// stack — input handling, parsing, rendering — so that future validate
+// enhancements (expression type checking, name resolution) are
+// automatically tested against the corpus.
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spilchen/sql-ai-tools/internal/testcorpus"
+	"github.com/stretchr/testify/require"
+)
+
+const fidelityCorpusDir = "../internal/sqlparse/testdata/corpus"
+
+// TestFidelityValidate runs each corpus file through the validate
+// command and asserts that no errors are reported.
+func TestFidelityValidate(t *testing.T) {
+	testcorpus.ForEachFile(t, fidelityCorpusDir, func(t *testing.T, sql string) {
+		root := newRootCmd()
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(&bytes.Buffer{})
+		root.SetIn(strings.NewReader(sql))
+		root.SetArgs([]string{"validate"})
+
+		require.NoError(t, root.Execute())
+	})
+}

--- a/internal/catalog/loader.go
+++ b/internal/catalog/loader.go
@@ -27,13 +27,17 @@ func LoadFiles(paths []string) (*Catalog, error) {
 	cat := &Catalog{byName: make(map[string]int)}
 
 	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat schema file %s: %w", path, err)
+		}
+		if info.Size() > maxSchemaFileSize {
+			return nil, fmt.Errorf("schema file %s is too large (%d bytes, max %d)",
+				path, info.Size(), maxSchemaFileSize)
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("read schema file %s: %w", path, err)
-		}
-		if int64(len(data)) > maxSchemaFileSize {
-			return nil, fmt.Errorf("schema file %s is too large (%d bytes, max %d)",
-				path, len(data), maxSchemaFileSize)
 		}
 
 		stmts, err := parser.Parse(string(data))
@@ -50,6 +54,8 @@ func LoadFiles(paths []string) (*Catalog, error) {
 			}
 			tableName := ct.Table.Table()
 			if tableName == "" {
+				cat.warnings = append(cat.warnings,
+					fmt.Sprintf("%s: skipped CREATE TABLE with empty table name", path))
 				continue
 			}
 			tbl := extractTable(ct)

--- a/internal/catalog/loader_test.go
+++ b/internal/catalog/loader_test.go
@@ -23,12 +23,12 @@ func writeSQL(t *testing.T, sql string) string {
 
 func TestLoadFiles(t *testing.T) {
 	tests := []struct {
-		name      string
-		sql       string
-		tableName string
-		wantTable Table
-		wantErr   string
-		wantNames []string
+		name          string
+		sql           string
+		tableName     string
+		expectedTable Table
+		expectedErr   string
+		expectedNames []string
 	}{
 		{
 			name: "basic columns",
@@ -38,7 +38,7 @@ func TestLoadFiles(t *testing.T) {
 				active BOOL
 			)`,
 			tableName: "users",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "users",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: true},
@@ -56,7 +56,7 @@ func TestLoadFiles(t *testing.T) {
 				label TEXT
 			)`,
 			tableName: "items",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "items",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -75,7 +75,7 @@ func TestLoadFiles(t *testing.T) {
 				PRIMARY KEY (region, id)
 			)`,
 			tableName: "kv",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "kv",
 				Columns: []Column{
 					{Name: "region", Type: "STRING", Nullable: false},
@@ -93,7 +93,7 @@ func TestLoadFiles(t *testing.T) {
 				email TEXT UNIQUE
 			)`,
 			tableName: "accounts",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "accounts",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -112,7 +112,7 @@ func TestLoadFiles(t *testing.T) {
 				email TEXT CONSTRAINT uq_email UNIQUE
 			)`,
 			tableName: "users",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "users",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -132,7 +132,7 @@ func TestLoadFiles(t *testing.T) {
 				UNIQUE (store_id, order_num)
 			)`,
 			tableName: "orders",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "orders",
 				Columns: []Column{
 					{Name: "store_id", Type: "INT8", Nullable: true},
@@ -152,7 +152,7 @@ func TestLoadFiles(t *testing.T) {
 				INDEX idx_ts (ts)
 			)`,
 			tableName: "events",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "events",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -172,7 +172,7 @@ func TestLoadFiles(t *testing.T) {
 				created_at TIMESTAMPTZ DEFAULT now()
 			)`,
 			tableName: "records",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "records",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -190,7 +190,7 @@ func TestLoadFiles(t *testing.T) {
 				b INT8 NOT NULL
 			)`,
 			tableName: "t",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "t",
 				Columns: []Column{
 					{Name: "a", Type: "INT8", Nullable: true},
@@ -209,7 +209,7 @@ func TestLoadFiles(t *testing.T) {
 				INSERT INTO t VALUES (1);
 			`,
 			tableName: "t",
-			wantTable: Table{
+			expectedTable: Table{
 				Name: "t",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -224,9 +224,9 @@ func TestLoadFiles(t *testing.T) {
 				CREATE TABLE a (id INT8 PRIMARY KEY);
 				CREATE TABLE b (id INT8 PRIMARY KEY);
 			`,
-			tableName: "b",
-			wantNames: []string{"a", "b"},
-			wantTable: Table{
+			tableName:     "b",
+			expectedNames: []string{"a", "b"},
+			expectedTable: Table{
 				Name: "b",
 				Columns: []Column{
 					{Name: "id", Type: "INT8", Nullable: false},
@@ -236,14 +236,14 @@ func TestLoadFiles(t *testing.T) {
 			},
 		},
 		{
-			name:    "empty file",
-			sql:     "",
-			wantErr: "",
+			name:        "empty file",
+			sql:         "",
+			expectedErr: "",
 		},
 		{
-			name:    "parse error",
-			sql:     "CREAT TABLE bad (id INT8);",
-			wantErr: "parse schema file",
+			name:        "parse error",
+			sql:         "CREAT TABLE bad (id INT8);",
+			expectedErr: "parse schema file",
 		},
 	}
 
@@ -252,14 +252,14 @@ func TestLoadFiles(t *testing.T) {
 			path := writeSQL(t, tc.sql)
 			cat, err := LoadFiles([]string{path})
 
-			if tc.wantErr != "" {
-				require.ErrorContains(t, err, tc.wantErr)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
 				return
 			}
 			require.NoError(t, err)
 
-			if tc.wantNames != nil {
-				require.Equal(t, tc.wantNames, cat.TableNames())
+			if tc.expectedNames != nil {
+				require.Equal(t, tc.expectedNames, cat.TableNames())
 			}
 
 			if tc.tableName == "" {
@@ -269,7 +269,7 @@ func TestLoadFiles(t *testing.T) {
 
 			tbl, ok := cat.Table(tc.tableName)
 			require.True(t, ok, "table %q not found in catalog", tc.tableName)
-			require.Equal(t, tc.wantTable, tbl)
+			require.Equal(t, tc.expectedTable, tbl)
 		})
 	}
 }
@@ -306,7 +306,7 @@ func TestLoadFilesDuplicateTableLastWins(t *testing.T) {
 
 func TestLoadFilesFileNotFound(t *testing.T) {
 	_, err := LoadFiles([]string{"/nonexistent/schema.sql"})
-	require.ErrorContains(t, err, "read schema file")
+	require.ErrorContains(t, err, "stat schema file")
 }
 
 func TestLoadFilesCaseInsensitiveLookup(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `TestFidelityValidate` in `cmd/validate_fidelity_test.go` that runs each `testdata/corpus/*.sql` file through the full validate command pipeline and asserts no errors.
- Fix the schema file size guard in `catalog.LoadFiles` to stat the file before reading it into memory, so oversized files are rejected without allocating.

### Commits

- `catalog: add schema loader for CREATE TABLE files` — new `internal/catalog` package with `LoadFiles`, `Catalog`, `Table`, `Column`, `Index` types; `cmd/describe` subcommand wired up.
- `cmd: run fidelity corpus through validate command` — fidelity corpus test for validate; stat-before-read fix in loader.

Resolves #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)