### PR TITLE
sqlparse: add normalized SQL to parse output

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -22,7 +22,8 @@ import (
 // the -e flag, a positional file argument, or stdin, parses it with the
 // CockroachDB parser, and emits a per-statement classification
 // containing the statement type (DDL/DML/DCL/TCL), the statement tag
-// (e.g. "SELECT", "ALTER TABLE"), and the original SQL text.
+// (e.g. "SELECT", "ALTER TABLE"), the original SQL text, and a
+// normalized form with literal constants replaced by placeholders.
 //
 // This is a Tier 1 (zero-config) command: it works offline with no
 // schema files or cluster connection.
@@ -35,7 +36,8 @@ func newParseCmd(state *rootState) *cobra.Command {
 		Long: `Parse SQL and classify each statement. Input is read from the -e flag
 (inline SQL), a positional file argument, or stdin. For each statement
 the output includes the statement type (DDL, DML, DCL, or TCL), the
-statement tag (e.g. SELECT, ALTER TABLE), and the original SQL text.`,
+statement tag (e.g. SELECT, ALTER TABLE), the original SQL text, and a
+normalized form with literal constants replaced by placeholders.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
@@ -70,7 +72,7 @@ statement tag (e.g. SELECT, ALTER TABLE), and the original SQL text.`,
 
 			return r.Render(baseEnv, func(w io.Writer) error {
 				for _, s := range stmts {
-					if _, werr := fmt.Fprintf(w, "%s\t%s\t%s\n", s.StatementType, s.Tag, s.SQL); werr != nil {
+					if _, werr := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.StatementType, s.Tag, s.SQL, s.Normalized); werr != nil {
 						return werr
 					}
 				}

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -21,7 +21,7 @@ import (
 
 // TestParseCmdText exercises the parse subcommand's text output path
 // end-to-end. The input is piped via stdin; the output is tab-separated
-// TYPE\tTAG\tSQL per line.
+// TYPE\tTAG\tSQL\tNORMALIZED per line.
 func TestParseCmdText(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
@@ -33,7 +33,7 @@ func TestParseCmdText(t *testing.T) {
 	require.NoError(t, root.Execute())
 
 	got := stdout.String()
-	require.Contains(t, got, "DML\tSELECT\tSELECT 1")
+	require.Contains(t, got, "DML\tSELECT\tSELECT 1\tSELECT _")
 }
 
 // TestParseCmdJSON exercises --output json end-to-end, verifying the
@@ -65,6 +65,9 @@ func TestParseCmdJSON(t *testing.T) {
 
 	require.Equal(t, sqlparse.StatementTypeDDL, stmts[1].StatementType)
 	require.Equal(t, "CREATE TABLE", stmts[1].Tag)
+
+	require.NotEmpty(t, stmts[0].Normalized)
+	require.NotEmpty(t, stmts[1].Normalized)
 }
 
 // TestParseCmdExprFlag verifies the -e flag path.

--- a/internal/sqlparse/classify.go
+++ b/internal/sqlparse/classify.go
@@ -7,8 +7,9 @@
 // SQL parsing utilities consumed by both the CLI and MCP layers.
 // The primary entry point is Classify, which parses a SQL string
 // and returns a per-statement classification (DDL/DML/DCL/TCL),
-// the statement tag (e.g. "SELECT", "ALTER TABLE"), and the
-// original SQL text.
+// the statement tag (e.g. "SELECT", "ALTER TABLE"), the original
+// SQL text, and a normalized form with literal constants replaced
+// by placeholders.
 package sqlparse
 
 import (
@@ -38,6 +39,13 @@ type ClassifiedStatement struct {
 	StatementType StatementType `json:"statement_type"`
 	Tag           string        `json:"tag"`
 	SQL           string        `json:"sql"`
+	// Normalized is the SQL text with literal constants replaced by
+	// placeholders, produced by tree.FormatStatementHideConstants.
+	// Numeric constants become _ and string literals become '_'
+	// (e.g. "SELECT * FROM t WHERE id = _"). Structurally identical
+	// queries that differ only in constant values share the same
+	// normalized form.
+	Normalized string `json:"normalized"`
 }
 
 // Classify parses sql using the CockroachDB parser and returns one
@@ -59,6 +67,7 @@ func Classify(sql string) ([]ClassifiedStatement, error) {
 			StatementType: mapStatementType(stmt.AST.StatementType()),
 			Tag:           stmt.AST.StatementTag(),
 			SQL:           stmt.SQL,
+			Normalized:    tree.FormatStatementHideConstants(stmt.AST),
 		}
 	}
 	return result, nil

--- a/internal/sqlparse/classify.go
+++ b/internal/sqlparse/classify.go
@@ -42,10 +42,10 @@ type ClassifiedStatement struct {
 	// Normalized is the SQL text with literal constants (numbers,
 	// strings, booleans, NULL, etc.) replaced by placeholders,
 	// produced by tree.FormatStatementHideConstants. Constants become
-	// _ (or '_' for string literals), and long lists are shortened
-	// (e.g. "SELECT * FROM t WHERE id = _"). Structurally identical
-	// queries that differ only in constant values share the same
-	// normalized form.
+	// _ (or '_' for string literals), and long value lists are
+	// collapsed (e.g. IN (_, _, __more1_10__)). Structurally
+	// identical queries that differ only in constant values share
+	// the same normalized form.
 	Normalized string `json:"normalized"`
 }
 

--- a/internal/sqlparse/classify.go
+++ b/internal/sqlparse/classify.go
@@ -39,9 +39,10 @@ type ClassifiedStatement struct {
 	StatementType StatementType `json:"statement_type"`
 	Tag           string        `json:"tag"`
 	SQL           string        `json:"sql"`
-	// Normalized is the SQL text with literal constants replaced by
-	// placeholders, produced by tree.FormatStatementHideConstants.
-	// Numeric constants become _ and string literals become '_'
+	// Normalized is the SQL text with literal constants (numbers,
+	// strings, booleans, NULL, etc.) replaced by placeholders,
+	// produced by tree.FormatStatementHideConstants. Constants become
+	// _ (or '_' for string literals), and long lists are shortened
 	// (e.g. "SELECT * FROM t WHERE id = _"). Structurally identical
 	// queries that differ only in constant values share the same
 	// normalized form.

--- a/internal/sqlparse/classify_test.go
+++ b/internal/sqlparse/classify_test.go
@@ -163,4 +163,7 @@ func TestClassifyMultiStatementDetails(t *testing.T) {
 
 	require.Equal(t, StatementTypeDDL, stmts[1].StatementType)
 	require.Equal(t, "CREATE TABLE", stmts[1].Tag)
+
+	require.Equal(t, "SELECT _", stmts[0].Normalized)
+	require.Equal(t, "CREATE TABLE t (a INT8)", stmts[1].Normalized)
 }

--- a/internal/sqlparse/classify_test.go
+++ b/internal/sqlparse/classify_test.go
@@ -13,47 +13,53 @@ import (
 
 func TestClassify(t *testing.T) {
 	tests := []struct {
-		name         string
-		input        string
-		expectedLen  int
-		expectedType StatementType
-		expectedTag  string
-		expectedErr  string
+		name               string
+		input              string
+		expectedLen        int
+		expectedType       StatementType
+		expectedTag        string
+		expectedNormalized string
+		expectedErr        string
 	}{
 		{
-			name:         "SELECT is DML",
-			input:        "SELECT 1",
-			expectedLen:  1,
-			expectedType: StatementTypeDML,
-			expectedTag:  "SELECT",
+			name:               "SELECT is DML",
+			input:              "SELECT 1",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "SELECT",
+			expectedNormalized: "SELECT _",
 		},
 		{
-			name:         "INSERT is DML",
-			input:        "INSERT INTO t VALUES (1)",
-			expectedLen:  1,
-			expectedType: StatementTypeDML,
-			expectedTag:  "INSERT",
+			name:               "INSERT is DML",
+			input:              "INSERT INTO t VALUES (1)",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "INSERT",
+			expectedNormalized: "INSERT INTO t VALUES (_)",
 		},
 		{
-			name:         "UPDATE is DML",
-			input:        "UPDATE t SET a = 1",
-			expectedLen:  1,
-			expectedType: StatementTypeDML,
-			expectedTag:  "UPDATE",
+			name:               "UPDATE is DML",
+			input:              "UPDATE t SET a = 1",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "UPDATE",
+			expectedNormalized: "UPDATE t SET a = _",
 		},
 		{
-			name:         "DELETE is DML",
-			input:        "DELETE FROM t",
-			expectedLen:  1,
-			expectedType: StatementTypeDML,
-			expectedTag:  "DELETE",
+			name:               "DELETE is DML",
+			input:              "DELETE FROM t",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "DELETE",
+			expectedNormalized: "DELETE FROM t",
 		},
 		{
-			name:         "CREATE TABLE is DDL",
-			input:        "CREATE TABLE t (a INT)",
-			expectedLen:  1,
-			expectedType: StatementTypeDDL,
-			expectedTag:  "CREATE TABLE",
+			name:               "CREATE TABLE is DDL",
+			input:              "CREATE TABLE t (a INT)",
+			expectedLen:        1,
+			expectedType:       StatementTypeDDL,
+			expectedTag:        "CREATE TABLE",
+			expectedNormalized: "CREATE TABLE t (a INT8)",
 		},
 		{
 			name:         "ALTER TABLE is DDL",
@@ -77,18 +83,20 @@ func TestClassify(t *testing.T) {
 			expectedTag:  "GRANT",
 		},
 		{
-			name:         "BEGIN is TCL",
-			input:        "BEGIN",
-			expectedLen:  1,
-			expectedType: StatementTypeTCL,
-			expectedTag:  "BEGIN",
+			name:               "BEGIN is TCL",
+			input:              "BEGIN",
+			expectedLen:        1,
+			expectedType:       StatementTypeTCL,
+			expectedTag:        "BEGIN",
+			expectedNormalized: "BEGIN TRANSACTION",
 		},
 		{
-			name:         "COMMIT is TCL",
-			input:        "COMMIT",
-			expectedLen:  1,
-			expectedType: StatementTypeTCL,
-			expectedTag:  "COMMIT",
+			name:               "COMMIT is TCL",
+			input:              "COMMIT",
+			expectedLen:        1,
+			expectedType:       StatementTypeTCL,
+			expectedTag:        "COMMIT",
+			expectedNormalized: "COMMIT TRANSACTION",
 		},
 		{
 			name:        "multi-statement input",
@@ -104,6 +112,22 @@ func TestClassify(t *testing.T) {
 			name:        "parse error",
 			input:       "SELECTT 1",
 			expectedErr: "syntax error",
+		},
+		{
+			name:               "normalized hides string literal",
+			input:              "SELECT * FROM t WHERE name = 'alice'",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "SELECT",
+			expectedNormalized: "SELECT * FROM t WHERE name = '_'",
+		},
+		{
+			name:               "normalized hides multiple constants",
+			input:              "SELECT * FROM t WHERE id = 1 AND status = 'active'",
+			expectedLen:        1,
+			expectedType:       StatementTypeDML,
+			expectedTag:        "SELECT",
+			expectedNormalized: "SELECT * FROM t WHERE (id = _) AND (status = '_')",
 		},
 	}
 
@@ -121,6 +145,9 @@ func TestClassify(t *testing.T) {
 				require.Equal(t, tc.expectedType, stmts[0].StatementType)
 				require.Equal(t, tc.expectedTag, stmts[0].Tag)
 				require.NotEmpty(t, stmts[0].SQL)
+			}
+			if tc.expectedNormalized != "" {
+				require.Equal(t, tc.expectedNormalized, stmts[0].Normalized)
 			}
 		})
 	}

--- a/internal/sqlparse/fidelity_test.go
+++ b/internal/sqlparse/fidelity_test.go
@@ -59,7 +59,7 @@ func TestFidelity(t *testing.T) {
 
 // TestFidelityClassify verifies that every corpus file classifies
 // cleanly through sqlparse.Classify and that each resulting statement
-// carries a non-empty StatementType, Tag, and SQL field. This
+// carries a non-empty StatementType, Tag, SQL, and Normalized field. This
 // complements TestFidelity, which only asserts that the raw parser
 // accepts the corpus without error.
 func TestFidelityClassify(t *testing.T) {
@@ -72,6 +72,7 @@ func TestFidelityClassify(t *testing.T) {
 			require.NotEmpty(t, stmt.StatementType, "statement %d has empty StatementType", i)
 			require.NotEmpty(t, stmt.Tag, "statement %d has empty Tag", i)
 			require.NotEmpty(t, stmt.SQL, "statement %d has empty SQL", i)
+			require.NotEmpty(t, stmt.Normalized, "statement %d has empty Normalized", i)
 		}
 	})
 }

--- a/internal/sqlparse/fidelity_test.go
+++ b/internal/sqlparse/fidelity_test.go
@@ -60,8 +60,8 @@ func TestFidelity(t *testing.T) {
 // TestFidelityClassify verifies that every corpus file classifies
 // cleanly through sqlparse.Classify and that each resulting statement
 // carries a non-empty StatementType, Tag, SQL, and Normalized field. This
-// complements TestFidelity, which only asserts that the raw parser
-// accepts the corpus without error.
+// complements TestFidelity, which asserts that the raw parser accepts
+// the corpus and that the normalized form round-trips cleanly.
 func TestFidelityClassify(t *testing.T) {
 	testcorpus.ForEachFile(t, corpusDir, func(t *testing.T, sql string) {
 		stmts, err := sqlparse.Classify(sql)

--- a/internal/sqlparse/fidelity_test.go
+++ b/internal/sqlparse/fidelity_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 	"github.com/spilchen/sql-ai-tools/internal/testcorpus"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,17 @@ func TestFidelity(t *testing.T) {
 		}
 		if len(stmts) == 0 {
 			t.Fatal("parsed to zero statements; corpus files must contain at least one statement")
+		}
+
+		for i, stmt := range stmts {
+			normalized := tree.FormatStatementHideConstants(stmt.AST)
+			if normalized == "" {
+				t.Errorf("stmt[%d]: FormatStatementHideConstants returned empty string", i)
+				continue
+			}
+			if _, err := parser.Parse(normalized); err != nil {
+				t.Errorf("stmt[%d]: normalized form does not re-parse: %v\nnormalized: %s", i, err, normalized)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add a `normalized` field to `ClassifiedStatement` using
  `tree.FormatStatementHideConstants`, which replaces literal constants
  with placeholders (e.g. `SELECT * FROM t WHERE id = _`).
- Surface the normalized form in CLI text and JSON output, and propagate
  it automatically through the MCP `parse_sql` tool.
- Extend the fidelity corpus to validate that every corpus statement
  normalizes to re-parseable SQL.

Resolves #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>