### PR TITLE
semcheck,cmd: add expression type checking to validate

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/semcheck"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 )
 
@@ -61,8 +62,13 @@ position (line/column/byte offset). Input is read from the -e flag
 			// stdin/file do not skew position reporting.
 			sql = strings.TrimSpace(sql)
 
-			if _, parseErr := parser.Parse(sql); parseErr != nil {
+			stmts, parseErr := parser.Parse(sql)
+			if parseErr != nil {
 				return renderParseError(r, baseEnv, parseErr, sql)
+			}
+
+			if typeErrs := semcheck.CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
+				return renderDiagErrors(r, baseEnv, typeErrs)
 			}
 
 			data, err := json.Marshal(struct {
@@ -90,18 +96,29 @@ position (line/column/byte offset). Input is read from the -e flag
 // bypasses Renderer.RenderError (which uses a generic
 // "internal_error" code) so that agents receive the real SQLSTATE.
 func renderParseError(r output.Renderer, env output.Envelope, parseErr error, sql string) error {
-	diagErr := diag.FromParseError(parseErr, sql)
-	env.Errors = []output.Error{diagErr}
+	return renderDiagErrors(r, env, []output.Error{diag.FromParseError(parseErr, sql)})
+}
+
+// renderDiagErrors renders one or more diagnostic errors (parse or
+// type-check) through the standard envelope path.
+func renderDiagErrors(r output.Renderer, env output.Envelope, errs []output.Error) error {
+	env.Errors = errs
 	env.Data = nil
 
 	if err := r.Render(env, func(w io.Writer) error {
-		pos := diagErr.Position
-		if pos != nil {
-			_, werr := fmt.Fprintf(w, "%d:%d: %s [%s]\n", pos.Line, pos.Column, diagErr.Message, diagErr.Code)
-			return werr
+		for _, diagErr := range errs {
+			pos := diagErr.Position
+			if pos != nil {
+				if _, werr := fmt.Fprintf(w, "%d:%d: %s [%s]\n", pos.Line, pos.Column, diagErr.Message, diagErr.Code); werr != nil {
+					return werr
+				}
+			} else {
+				if _, werr := fmt.Fprintf(w, "%s [%s]\n", diagErr.Message, diagErr.Code); werr != nil {
+					return werr
+				}
+			}
 		}
-		_, werr := fmt.Fprintf(w, "%s [%s]\n", diagErr.Message, diagErr.Code)
-		return werr
+		return nil
 	}); err != nil {
 		return err
 	}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -172,6 +172,61 @@ func TestValidateCmdMultiStatementSuccess(t *testing.T) {
 	require.Equal(t, "Valid.\n", stdout.String())
 }
 
+// TestValidateCmdTypeErrorText verifies that a type mismatch in text
+// mode outputs an error line with the SQLSTATE code.
+func TestValidateCmdTypeErrorText(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "-e", "SELECT 1 + 'hello'"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, "unsupported binary operator")
+}
+
+// TestValidateCmdTypeErrorJSON verifies that a type mismatch in JSON
+// mode produces an envelope with a structured error and nil data.
+func TestValidateCmdTypeErrorJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json", "-e", "SELECT 1 + 'hello'"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Nil(t, env.Data)
+
+	diagErr := env.Errors[0]
+	require.NotEmpty(t, diagErr.Code)
+	require.Equal(t, output.SeverityError, diagErr.Severity)
+	require.Contains(t, diagErr.Message, "unsupported binary operator")
+	require.NotNil(t, diagErr.Position)
+	require.Equal(t, 1, diagErr.Position.Line)
+}
+
+// TestValidateCmdColumnRefNoTypeError verifies that SQL with column
+// references does not produce false-positive type errors.
+func TestValidateCmdColumnRefNoTypeError(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT a + 1 FROM t"))
+	root.SetArgs([]string{"validate"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
+}
+
 // TestValidateCmdMultiStatementError verifies that an error in a later
 // statement reports the correct position relative to the full input.
 func TestValidateCmdMultiStatementError(t *testing.T) {

--- a/internal/diag/error.go
+++ b/internal/diag/error.go
@@ -24,6 +24,33 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
+// FromTypeError converts a type-check error into a structured
+// output.Error. exprText is the formatted expression that failed
+// (used to locate the error position within fullSQL via substring
+// match). Position is nil when exprText cannot be found.
+func FromTypeError(err error, exprText string, fullSQL string) output.Error {
+	code := pgerror.GetPGCode(err).String()
+
+	sev := pgerror.GetSeverity(err)
+	if sev == "" {
+		sev = string(output.SeverityError)
+	}
+
+	var pos *output.Position
+	if exprText != "" {
+		if idx := strings.Index(fullSQL, exprText); idx >= 0 {
+			pos = PositionFromByteOffset(fullSQL, idx)
+		}
+	}
+
+	return output.Error{
+		Code:     code,
+		Severity: output.Severity(sev),
+		Message:  err.Error(),
+		Position: pos,
+	}
+}
+
 // FromParseError converts a Go error returned by parser.Parse into a
 // structured output.Error with SQLSTATE code, severity, message, and
 // source position. fullSQL is the complete SQL input; it is used to

--- a/internal/diag/position.go
+++ b/internal/diag/position.go
@@ -90,6 +90,21 @@ func caretColumn(line string) int {
 	return idx
 }
 
+// PositionFromByteOffset converts a 0-based byte offset within fullSQL
+// into a 1-based line/column Position. Returns nil if byteOffset is
+// negative.
+func PositionFromByteOffset(fullSQL string, byteOffset int) *output.Position {
+	if byteOffset < 0 {
+		return nil
+	}
+	line, col := lineColumn(fullSQL, byteOffset)
+	return &output.Position{
+		Line:       line,
+		Column:     col,
+		ByteOffset: byteOffset,
+	}
+}
+
 // lineColumn converts a 0-based byte offset within sql into a 1-based
 // line and column. The column counts bytes from the last newline (or
 // start of string), not runes, matching the CockroachDB parser's

--- a/internal/semcheck/expr.go
+++ b/internal/semcheck/expr.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package semcheck provides Tier 1 (zero-config) semantic checks that
+// operate on parsed ASTs without a schema catalog or cluster
+// connection. Currently the only check is expression type checking,
+// which detects binary-operator type mismatches in literal expressions
+// (e.g. 1 + 'hello') using MakeSemaContext(nil).
+//
+// Expressions that reference columns, functions, subqueries, or
+// placeholders are silently skipped because resolving those names
+// requires a catalog (Tier 2) or connection (Tier 3).
+package semcheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/types"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// CheckExprTypes walks every expression in stmts and type-checks
+// variable-free sub-trees using MakeSemaContext(nil). Expressions
+// containing column references, function calls, subqueries, or
+// placeholders are skipped. Returns one output.Error per type-check
+// failure; the slice is nil when all checked expressions are valid.
+func CheckExprTypes(stmts statements.Statements, fullSQL string) []output.Error {
+	semaCtx := tree.MakeSemaContext(nil)
+	var errs []output.Error
+
+	for i := range stmts {
+		stmt := stmts[i].AST
+		if stmt == nil {
+			continue
+		}
+		// SimpleStmtVisit's error is always nil here because the
+		// callback never returns one; we accumulate errors in errs.
+		_, _ = tree.SimpleStmtVisit(stmt, func(expr tree.Expr) (bool, tree.Expr, error) {
+			if isVariable(expr) {
+				return false, expr, nil
+			}
+			if containsVariable(expr) {
+				return true, expr, nil
+			}
+
+			typedExpr, err := safeTypeCheck(expr, &semaCtx)
+			if err != nil {
+				errs = append(errs, diag.FromTypeError(err, exprText(typedExpr, expr), fullSQL))
+			}
+			return false, expr, nil
+		})
+	}
+	return errs
+}
+
+// isVariable returns true if expr is a node type that requires a
+// resolver we don't have in Tier 1 (no catalog, no builtins
+// registry).
+func isVariable(expr tree.Expr) bool {
+	switch expr.(type) {
+	case *tree.UnresolvedName,
+		*tree.ColumnItem,
+		*tree.FuncExpr,
+		*tree.Subquery,
+		*tree.Placeholder,
+		*tree.IndexedVar,
+		tree.UnqualifiedStar,
+		*tree.AllColumnsSelector:
+		return true
+	}
+	return false
+}
+
+// containsVariable walks expr and returns true if any descendant is a
+// variable node.
+func containsVariable(expr tree.Expr) bool {
+	var found bool
+	v := variableDetector{found: &found}
+	tree.WalkExprConst(&v, expr)
+	return found
+}
+
+type variableDetector struct {
+	found *bool
+}
+
+func (d *variableDetector) VisitPre(expr tree.Expr) (bool, tree.Expr) {
+	if *d.found {
+		return false, expr
+	}
+	if isVariable(expr) {
+		*d.found = true
+		return false, expr
+	}
+	return true, expr
+}
+
+func (d *variableDetector) VisitPost(expr tree.Expr) tree.Expr { return expr }
+
+// safeTypeCheck type-checks expr, recovering from panics that the
+// type-checker may trigger for certain expression types (e.g.
+// GREATEST, LEAST) when the builtins registry is not populated. A
+// recovered panic is surfaced as an error so it appears in
+// diagnostics rather than being silently swallowed.
+func safeTypeCheck(expr tree.Expr, semaCtx *tree.SemaContext) (typed tree.TypedExpr, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			typed = nil
+			err = fmt.Errorf("internal: type-check panicked: %v", r)
+		}
+	}()
+	typed, err = expr.TypeCheck(context.Background(), semaCtx, types.Any)
+	return typed, err
+}
+
+// exprText returns a string representation of the expression suitable
+// for position lookup in the original SQL. It prefers the original
+// (pre-type-check) form because the type checker may reformat
+// expressions (adding casts, normalizing whitespace), making the
+// typed form less likely to match via substring search.
+func exprText(typed tree.TypedExpr, original tree.Expr) string {
+	if original != nil {
+		if s := fmt.Sprint(original); s != "" {
+			return s
+		}
+	}
+	if typed != nil {
+		if s := typed.String(); s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/semcheck/expr_test.go
+++ b/internal/semcheck/expr_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckExprTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		expectedCount int
+		expectedMsg   string
+	}{
+		{
+			name:          "valid literal arithmetic",
+			sql:           "SELECT 1 + 2",
+			expectedCount: 0,
+		},
+		{
+			name:          "type mismatch binary op",
+			sql:           "SELECT 1 + 'hello'",
+			expectedCount: 1,
+			expectedMsg:   "unsupported binary operator",
+		},
+		{
+			name:          "valid string concatenation",
+			sql:           "SELECT 'a' || 'b'",
+			expectedCount: 0,
+		},
+		{
+			name:          "column reference skipped",
+			sql:           "SELECT a + 1 FROM t",
+			expectedCount: 0,
+		},
+		{
+			name:          "function call skipped",
+			sql:           "SELECT length('hello')",
+			expectedCount: 0,
+		},
+		{
+			name:          "subquery skipped",
+			sql:           "SELECT (SELECT 1) + 'hello'",
+			expectedCount: 0,
+		},
+		{
+			name:          "GREATEST does not panic",
+			sql:           "SELECT GREATEST(1, 2)",
+			expectedCount: 0,
+		},
+		{
+			name:          "valid CAST",
+			sql:           "SELECT CAST(1 AS STRING)",
+			expectedCount: 0,
+		},
+		{
+			name:          "valid COALESCE",
+			sql:           "SELECT COALESCE(1, 2)",
+			expectedCount: 0,
+		},
+		{
+			name:          "star expression skipped",
+			sql:           "SELECT * FROM t",
+			expectedCount: 0,
+		},
+		{
+			name:          "multiple statements mixed",
+			sql:           "SELECT 1 + 2; SELECT 1 + 'x'",
+			expectedCount: 1,
+		},
+		{
+			name:          "multiple type errors in one statement",
+			sql:           "SELECT 1 + 'a', 2 + 'b'",
+			expectedCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err, "parse must succeed")
+
+			errs := CheckExprTypes(stmts, tc.sql)
+			require.Len(t, errs, tc.expectedCount)
+
+			if tc.expectedMsg != "" && tc.expectedCount > 0 {
+				require.Contains(t, errs[0].Message, tc.expectedMsg)
+			}
+		})
+	}
+}
+
+func TestCheckExprTypesPosition(t *testing.T) {
+	sql := "SELECT 1 + 'hello'"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckExprTypes(stmts, sql)
+	require.Len(t, errs, 1)
+	require.NotNil(t, errs[0].Position)
+	require.Equal(t, 1, errs[0].Position.Line)
+	require.NotEmpty(t, errs[0].Code)
+}
+
+func TestCheckExprTypesEmptyStatements(t *testing.T) {
+	errs := CheckExprTypes(nil, "")
+	require.Empty(t, errs)
+}


### PR DESCRIPTION
## Summary

Add Tier 1 (zero-config) expression type checking to `crdb-sql validate`
so that literal type mismatches like `SELECT 1 + 'hello'` are caught
without any schema files or cluster connection.

This is a multi-commit PR. Each commit is independently meaningful:

- **catalog: add schema loader for CREATE TABLE files** — parses
  CREATE TABLE DDL into a lightweight in-memory catalog for Tier 2
  schema-aware validation.
- **conn,cli: add pgx connection manager and crdb-sql ping subcommand**
  — adds pgx-based connection management and a `ping` command for
  Tier 3 connected features.
- **cmd: run fidelity corpus through validate command** — adds a
  fidelity test that runs the curated SQL corpus through the full
  validate pipeline, ensuring future enhancements don't regress.
- **semcheck,cmd: add expression type checking to validate command** —
  the core change: walks parsed ASTs and type-checks variable-free
  expressions using `MakeSemaContext(nil)`, with `recover()` for
  GREATEST/LEAST panics. Wires into validate, adds `FromTypeError`
  and `PositionFromByteOffset` helpers to diag.

Example:
```
$ crdb-sql validate -e "SELECT 1 + 'hello'"
1:8: unsupported binary operator: <int> + <string> [22023]
```

Resolves: #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)