### PR TITLE
diag: add SQLSTATE-to-category mapping for agent error switching

### DIFF
--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -99,6 +99,7 @@ func TestValidateCmdJSONError(t *testing.T) {
 	diagErr := env.Errors[0]
 	require.Equal(t, "42601", diagErr.Code)
 	require.Equal(t, output.SeverityError, diagErr.Severity)
+	require.Equal(t, "syntax_error", diagErr.Category)
 	require.Contains(t, diagErr.Message, "syntax error")
 	require.NotNil(t, diagErr.Position)
 	require.Equal(t, 1, diagErr.Position.Line)

--- a/internal/diag/category.go
+++ b/internal/diag/category.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+// Category constants match the design doc (search "Error categorization")
+// and are the wire-format strings agents receive in the JSON envelope.
+const (
+	CategorySyntaxError        = "syntax_error"
+	CategoryTypeMismatch       = "type_mismatch"
+	CategoryUnknownColumn      = "unknown_column"
+	CategoryUnknownTable       = "unknown_table"
+	CategoryUnknownFunction    = "unknown_function"
+	CategoryAmbiguousReference = "ambiguous_reference"
+)
+
+// codeCategory maps exact 5-character SQLSTATE codes to categories.
+// Entries here override the class-level fallback in classCategory.
+var codeCategory = map[string]string{
+	"42601": CategorySyntaxError,        // syntax_error
+	"42703": CategoryUnknownColumn,      // undefined_column
+	"42P01": CategoryUnknownTable,       // undefined_table
+	"42883": CategoryUnknownFunction,    // undefined_function
+	"42804": CategoryTypeMismatch,       // datatype_mismatch
+	"42702": CategoryAmbiguousReference, // ambiguous_column
+	"42725": CategoryAmbiguousReference, // ambiguous_function
+	"42P08": CategoryAmbiguousReference, // ambiguous_parameter
+	"42P09": CategoryAmbiguousReference, // ambiguous_alias
+	"42P10": CategoryUnknownColumn,      // invalid_column_reference
+}
+
+// classCategory maps the 2-character SQLSTATE class prefix to a
+// fallback category used when the exact code is not in codeCategory.
+// Class 42 ("Syntax Error or Access Rule Violation") includes
+// access-rule codes like 42501 (insufficient_privilege), but this
+// tool only sees parser-generated errors where the syntax_error
+// fallback is appropriate.
+var classCategory = map[string]string{
+	"42": CategorySyntaxError,  // Syntax Error or Access Rule Violation
+	"22": CategoryTypeMismatch, // Data Exception
+}
+
+// CategoryForCode returns the agent-facing category string for the
+// given SQLSTATE code. It tries an exact 5-character match first,
+// then falls back to a 2-character class-level match. If neither
+// matches, it returns the empty string (the Category field in
+// output.Error is omitempty, so unmapped codes simply omit the field
+// from JSON output).
+func CategoryForCode(code string) string {
+	if cat, ok := codeCategory[code]; ok {
+		return cat
+	}
+	if len(code) >= 2 {
+		if cat, ok := classCategory[code[:2]]; ok {
+			return cat
+		}
+	}
+	return ""
+}

--- a/internal/diag/category_test.go
+++ b/internal/diag/category_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCategoryForCode(t *testing.T) {
+	tests := []struct {
+		name             string
+		code             string
+		expectedCategory string
+	}{
+		// Exact code matches.
+		{name: "syntax error", code: "42601", expectedCategory: "syntax_error"},
+		{name: "undefined column", code: "42703", expectedCategory: "unknown_column"},
+		{name: "undefined table", code: "42P01", expectedCategory: "unknown_table"},
+		{name: "undefined function", code: "42883", expectedCategory: "unknown_function"},
+		{name: "datatype mismatch", code: "42804", expectedCategory: "type_mismatch"},
+		{name: "ambiguous column", code: "42702", expectedCategory: "ambiguous_reference"},
+		{name: "ambiguous function", code: "42725", expectedCategory: "ambiguous_reference"},
+		{name: "ambiguous parameter", code: "42P08", expectedCategory: "ambiguous_reference"},
+		{name: "ambiguous alias", code: "42P09", expectedCategory: "ambiguous_reference"},
+		{name: "invalid column reference", code: "42P10", expectedCategory: "unknown_column"},
+
+		// Class-level fallback.
+		{name: "unmapped class-42 falls back to syntax_error", code: "42501", expectedCategory: "syntax_error"},
+		{name: "data exception class", code: "22012", expectedCategory: "type_mismatch"},
+
+		// Unknown codes return empty.
+		{name: "unknown class returns empty", code: "99999", expectedCategory: ""},
+		{name: "empty code returns empty", code: "", expectedCategory: ""},
+		{name: "short code returns empty", code: "4", expectedCategory: ""},
+
+		// Non-SQLSTATE code from describe command.
+		{name: "schema_warning not mapped", code: "schema_warning", expectedCategory: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CategoryForCode(tc.code)
+			require.Equal(t, tc.expectedCategory, got)
+		})
+	}
+}
+
+// TestCategoryForCode_exactOverridesClass verifies that an exact code
+// entry takes precedence over the class-level fallback.
+func TestCategoryForCode_exactOverridesClass(t *testing.T) {
+	got := CategoryForCode("42703")
+	require.Equal(t, "unknown_column", got)
+}

--- a/internal/diag/error.go
+++ b/internal/diag/error.go
@@ -55,5 +55,6 @@ func FromParseError(err error, fullSQL string) output.Error {
 		Severity: output.Severity(sev),
 		Message:  err.Error(),
 		Position: ExtractPosition(detail, fullSQL),
+		Category: CategoryForCode(code),
 	}
 }

--- a/internal/diag/error_test.go
+++ b/internal/diag/error_test.go
@@ -22,6 +22,7 @@ func TestFromParseError(t *testing.T) {
 		expectedSeverity output.Severity
 		expectedMsgSub   string
 		expectedPos      *output.Position
+		expectedCategory string
 	}{
 		{
 			name:             "syntax error at EOF",
@@ -34,6 +35,7 @@ func TestFromParseError(t *testing.T) {
 				Column:     12,
 				ByteOffset: 11,
 			},
+			expectedCategory: "syntax_error",
 		},
 		{
 			name:             "misspelled keyword",
@@ -46,6 +48,7 @@ func TestFromParseError(t *testing.T) {
 				Column:     1,
 				ByteOffset: 0,
 			},
+			expectedCategory: "syntax_error",
 		},
 		{
 			name:             "multi-statement error on second",
@@ -58,6 +61,7 @@ func TestFromParseError(t *testing.T) {
 				Column:     12,
 				ByteOffset: 21,
 			},
+			expectedCategory: "syntax_error",
 		},
 	}
 
@@ -70,6 +74,8 @@ func TestFromParseError(t *testing.T) {
 			require.Equal(t, tc.expectedCode, diagErr.Code)
 			require.Equal(t, tc.expectedSeverity, diagErr.Severity)
 			require.Contains(t, diagErr.Message, tc.expectedMsgSub)
+
+			require.Equal(t, tc.expectedCategory, diagErr.Category)
 
 			if tc.expectedPos == nil {
 				require.Nil(t, diagErr.Position)


### PR DESCRIPTION
## Summary

- Add `CategoryForCode` function in `internal/diag/category.go` that maps SQLSTATE codes to agent-facing category strings (`syntax_error`, `unknown_column`, `unknown_table`, `unknown_function`, `type_mismatch`, `ambiguous_reference`) using two-level lookup: exact 5-char code first, then 2-char class prefix fallback.
- Wire into `FromParseError` so the `Category` field on `output.Error` is populated automatically for all parser-produced errors.
- Add table-driven tests covering all exact entries, class fallbacks, edge cases, and end-to-end JSON envelope verification.

### Per-commit summary

- `f1717c2` catalog: add schema loader for CREATE TABLE files
- `8b73584` conn,cli: add pgx connection manager and crdb-sql ping subcommand
- `1323273` cmd: run fidelity corpus through validate command
- `e9f4214` diag: add SQLSTATE-to-category mapping for agent error switching

Resolves #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)