### PR TITLE
risk,cli,mcp: add detect_risky_query with AST-only rules

### DIFF
--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newRiskCmd builds the `crdb-sql risk` subcommand. It reads SQL from
+// the -e flag, a positional file argument, or stdin, parses it with
+// the CockroachDB parser, and runs the default set of AST-only risk
+// rules against each statement. Findings are emitted as structured
+// output with reason codes, severity, and fix hints.
+//
+// This is a Tier 1 (zero-config) command: it works offline with no
+// schema files or cluster connection.
+func newRiskCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "risk [file]",
+		Short: "Detect risky SQL patterns",
+		Long: `Analyze SQL for dangerous patterns such as DELETE or UPDATE without a
+WHERE clause, DROP TABLE, and SELECT *. Input is read from the -e flag
+(inline SQL), a positional file argument, or stdin. Each finding
+includes a reason code, severity, human-readable message, and fix hint.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+			baseEnv := output.Envelope{
+				Tier:             output.TierZeroConfig,
+				ConnectionStatus: output.ConnectionDisconnected,
+			}
+
+			parserVer, err := parserVersion(Version)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.ParserVersion = parserVer
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			findings, err := risk.Analyze(sql)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			data, err := json.Marshal(findings)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				for _, f := range findings {
+					if _, werr := fmt.Fprintf(w, "%s\t%s\t%s\n", strings.ToUpper(string(f.Severity)), f.ReasonCode, f.Message); werr != nil {
+						return werr
+					}
+					if _, werr := fmt.Fprintf(w, "  hint: %s\n", f.FixHint); werr != nil {
+						return werr
+					}
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to analyze")
+
+	return cmd
+}

--- a/cmd/risk_test.go
+++ b/cmd/risk_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+)
+
+// TestRiskCmdText exercises the risk subcommand's text output path
+// end-to-end with a risky DELETE piped via stdin.
+func TestRiskCmdText(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("DELETE FROM users"))
+	root.SetArgs([]string{"risk"})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "CRITICAL")
+	require.Contains(t, got, "DELETE_NO_WHERE")
+	require.Contains(t, got, "hint:")
+}
+
+// TestRiskCmdJSON exercises --output json end-to-end, verifying the
+// envelope shape and the findings payload.
+func TestRiskCmdJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader("DELETE FROM users"))
+	root.SetArgs([]string{"risk", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var findings []risk.Finding
+	require.NoError(t, json.Unmarshal(env.Data, &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "DELETE_NO_WHERE", findings[0].ReasonCode)
+	require.Equal(t, risk.SeverityCritical, findings[0].Severity)
+	require.NotEmpty(t, findings[0].FixHint)
+}
+
+// TestRiskCmdExprFlag verifies the -e flag path.
+func TestRiskCmdExprFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"risk", "-e", "DROP TABLE users", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var findings []risk.Finding
+	require.NoError(t, json.Unmarshal(env.Data, &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "DROP_TABLE", findings[0].ReasonCode)
+}
+
+// TestRiskCmdFileArg verifies reading SQL from a file argument.
+func TestRiskCmdFileArg(t *testing.T) {
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("SELECT * FROM t"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"risk", sqlFile, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var findings []risk.Finding
+	require.NoError(t, json.Unmarshal(env.Data, &findings))
+	require.Len(t, findings, 1)
+	require.Equal(t, "SELECT_STAR", findings[0].ReasonCode)
+}
+
+// TestRiskCmdNoFindings verifies that safe SQL produces an empty
+// findings array in JSON mode and no text output.
+func TestRiskCmdNoFindings(t *testing.T) {
+	t.Run("json", func(t *testing.T) {
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs([]string{"risk", "-e", "SELECT id FROM users WHERE id = 1", "--output", "json"})
+
+		require.NoError(t, root.Execute())
+
+		var env output.Envelope
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+		require.Empty(t, env.Errors)
+
+		var findings []risk.Finding
+		require.NoError(t, json.Unmarshal(env.Data, &findings))
+		require.Empty(t, findings)
+	})
+
+	t.Run("text", func(t *testing.T) {
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs([]string{"risk", "-e", "SELECT id FROM users WHERE id = 1"})
+
+		require.NoError(t, root.Execute())
+		require.Empty(t, stdout.String())
+	})
+}
+
+// TestRiskCmdParseErrorJSON verifies that invalid SQL in JSON mode
+// produces an envelope with errors and nil data.
+func TestRiskCmdParseErrorJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"risk", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Nil(t, env.Data)
+}
+
+// TestRiskCmdEmptyInput verifies that empty stdin produces an error.
+func TestRiskCmdEmptyInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"risk"})
+
+	require.Error(t, root.Execute())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ func newRootCmd() *cobra.Command {
 		Use:   "crdb-sql",
 		Short: "Agent-friendly SQL tooling for CockroachDB",
 		Long: `crdb-sql exposes CockroachDB's parser, type system, and structured
-error infrastructure as a CLI (and, eventually, an MCP server) so that
+error infrastructure as a CLI and MCP server so that
 AI agents can validate, format, and reason about CockroachDB SQL without
 round-tripping through a live cluster.`,
 		// Both silences are deliberate: cobra should neither print the
@@ -95,6 +95,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newFormatCmd(state))
 	root.AddCommand(newValidateCmd(state))
 	root.AddCommand(newDescribeCmd(state))
+	root.AddCommand(newRiskCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/internal/catalog/loader.go
+++ b/internal/catalog/loader.go
@@ -27,6 +27,8 @@ func LoadFiles(paths []string) (*Catalog, error) {
 	cat := &Catalog{byName: make(map[string]int)}
 
 	for _, path := range paths {
+		// Stat before ReadFile so we reject oversized files without
+		// allocating their contents into memory.
 		info, err := os.Stat(path)
 		if err != nil {
 			return nil, fmt.Errorf("stat schema file %s: %w", path, err)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,10 +5,11 @@
 
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
-// The server registers a health-check tool (ping) and a SQL
-// classification tool (parse_sql); future issues will add more
-// SQL-aware tools (validate_sql, format_sql, …) to the same
-// NewServer constructor. Keeping construction pure (no transport,
+// The server registers a health-check tool (ping), a SQL
+// classification tool (parse_sql), and a risk-detection tool
+// (detect_risky_query); future issues will add more SQL-aware
+// tools (validate_sql, format_sql, …) to the same NewServer
+// constructor. Keeping construction pure (no transport,
 // no I/O) lets the cmd layer pick a transport — currently just
 // stdio — and lets tests exercise individual tool handlers directly.
 //
@@ -26,14 +27,16 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 )
 
 // Tool name constants are exposed so tests and docs reference a single
 // source of truth.
 const (
-	PingToolName     = "ping"
-	ParseSQLToolName = "parse_sql"
+	PingToolName             = "ping"
+	ParseSQLToolName         = "parse_sql"
+	DetectRiskyQueryToolName = "detect_risky_query"
 )
 
 // NewServer constructs an MCP server for crdb-sql. binaryVersion is the
@@ -66,6 +69,14 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 			mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
 		),
 		parseSQLHandler(parserVersion),
+	)
+	s.AddTool(
+		mcp.NewTool(
+			DetectRiskyQueryToolName,
+			mcp.WithDescription("Detect risky SQL patterns such as DELETE/UPDATE without WHERE, DROP TABLE, and SELECT *. Returns findings with reason codes, severity, and fix hints."),
+			mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
+		),
+		detectRiskyQueryHandler(parserVersion),
 	)
 	return s
 }
@@ -134,4 +145,45 @@ func parseSQLHandler(parserVersion string) server.ToolHandlerFunc {
 type parseSQLResult struct {
 	ParserVersion string                         `json:"parser_version"`
 	Statements    []sqlparse.ClassifiedStatement `json:"statements"`
+}
+
+// detectRiskyQueryHandler returns the handler for the
+// `detect_risky_query` tool. It delegates to risk.Analyze for the
+// actual analysis, so the MCP and CLI layers share one implementation.
+func detectRiskyQueryHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		raw, exists := req.GetArguments()["sql"]
+		if !exists {
+			return mcp.NewToolResultError("sql parameter is required"), nil
+		}
+		sql, ok := raw.(string)
+		if !ok {
+			return mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw)), nil
+		}
+		if sql == "" {
+			return mcp.NewToolResultError("sql parameter must not be empty"), nil
+		}
+
+		findings, err := risk.Analyze(sql)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("parse error: %v", err)), nil
+		}
+
+		result := detectRiskyQueryResult{
+			ParserVersion: parserVersion,
+			Findings:      findings,
+		}
+		body, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(body)), nil
+	}
+}
+
+// detectRiskyQueryResult is the JSON shape returned by the
+// `detect_risky_query` tool.
+type detectRiskyQueryResult struct {
+	ParserVersion string         `json:"parser_version"`
+	Findings      []risk.Finding `json:"findings"`
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -12,6 +12,8 @@ import (
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/risk"
 )
 
 // TestPingHandler exercises the ping tool handler directly, bypassing
@@ -76,7 +78,7 @@ func TestNewServerRegistersTools(t *testing.T) {
 	require.NotNil(t, s)
 	tools := s.ListTools()
 
-	for _, name := range []string{PingToolName, ParseSQLToolName} {
+	for _, name := range []string{PingToolName, ParseSQLToolName, DetectRiskyQueryToolName} {
 		require.Contains(t, tools, name)
 		require.NotNil(t, tools[name].Handler,
 			"%s must be registered with a non-nil handler", name)
@@ -154,6 +156,84 @@ func TestParseSQLHandler(t *testing.T) {
 			if tc.expectedType != "" {
 				require.Equal(t, tc.expectedType, string(result.Statements[0].StatementType))
 				require.Equal(t, tc.expectedTag, result.Statements[0].Tag)
+			}
+		})
+	}
+}
+
+// TestDetectRiskyQueryHandler exercises the detect_risky_query tool
+// handler directly, bypassing the MCP transport.
+func TestDetectRiskyQueryHandler(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 map[string]any
+		expectedErr          bool
+		expectedFindingCount int
+		expectedReasonCode   string
+	}{
+		{
+			name:                 "risky DELETE",
+			args:                 map[string]any{"sql": "DELETE FROM users"},
+			expectedFindingCount: 1,
+			expectedReasonCode:   "DELETE_NO_WHERE",
+		},
+		{
+			name:                 "safe SELECT",
+			args:                 map[string]any{"sql": "SELECT id FROM t WHERE id = 1"},
+			expectedFindingCount: 0,
+		},
+		{
+			name:                 "multiple findings",
+			args:                 map[string]any{"sql": "DELETE FROM t; SELECT * FROM t"},
+			expectedFindingCount: 2,
+		},
+		{
+			name:        "parse error",
+			args:        map[string]any{"sql": "SELECTT 1"},
+			expectedErr: true,
+		},
+		{
+			name:        "empty sql",
+			args:        map[string]any{"sql": ""},
+			expectedErr: true,
+		},
+		{
+			name:        "missing sql param",
+			args:        map[string]any{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := detectRiskyQueryHandler("v0.26.2")
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			require.False(t, res.IsError)
+			require.Len(t, res.Content, 1)
+
+			text, ok := res.Content[0].(mcpgo.TextContent)
+			require.True(t, ok)
+
+			var result detectRiskyQueryResult
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
+			require.Equal(t, "v0.26.2", result.ParserVersion)
+			require.Len(t, result.Findings, tc.expectedFindingCount)
+
+			if tc.expectedReasonCode != "" {
+				require.Equal(t, tc.expectedReasonCode, result.Findings[0].ReasonCode)
+				require.Equal(t, risk.SeverityCritical, result.Findings[0].Severity)
+				require.NotEmpty(t, result.Findings[0].FixHint)
 			}
 		})
 	}

--- a/internal/risk/registry.go
+++ b/internal/risk/registry.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package risk provides a rule-based engine for detecting dangerous SQL
+// patterns by inspecting the AST produced by the CockroachDB parser.
+//
+// The engine is organized around three concepts:
+//
+//   - Rule: a named check that inspects a single parsed statement and
+//     returns zero or more findings. Each rule has a severity, reason
+//     code, and category.
+//   - Registry: an ordered collection of rules. Its Analyze method
+//     parses a SQL string and runs every rule against every statement.
+//   - Finding: a single risk detected in a SQL statement, carrying a
+//     machine-readable reason code, human-readable message, position
+//     within the input, and a fix hint.
+//
+// Callers that want the built-in rule set can use the package-level
+// Analyze function, which delegates to DefaultRules().
+package risk
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// Severity classifies the urgency of a finding. Values are ordered from
+// most to least urgent and are part of the wire format — renaming or
+// reordering them is a breaking change.
+type Severity string
+
+// Severity constants, ordered from most to least urgent.
+const (
+	SeverityCritical Severity = "critical"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+	SeverityInfo     Severity = "info"
+)
+
+// Finding is a single risk detected by a rule. The struct is the
+// JSON-serializable shape embedded in both the CLI envelope's Data
+// field and the MCP tool result.
+type Finding struct {
+	ReasonCode string    `json:"reason_code"`
+	Severity   Severity  `json:"severity"`
+	Message    string    `json:"message"`
+	Position   *Position `json:"position,omitempty"`
+	FixHint    string    `json:"fix_hint"`
+}
+
+// Position identifies a location within the original SQL input.
+// Line and Column are 1-based; ByteOffset is 0-based.
+type Position struct {
+	Line       int `json:"line"`
+	Column     int `json:"column"`
+	ByteOffset int `json:"byte_offset"`
+}
+
+// CheckInput is the context passed to a rule's check function for a
+// single parsed statement.
+type CheckInput struct {
+	AST      tree.Statement
+	StmtSQL  string
+	Position Position
+}
+
+// Rule defines an AST-only risk detection rule. The Check function
+// inspects a single parsed statement and returns any findings. Rules
+// are expected to return nil when the statement is not relevant
+// (e.g. a DELETE rule receiving a SELECT AST).
+type Rule struct {
+	ReasonCode string
+	Severity   Severity
+	Category   string
+	Check      func(input CheckInput) []Finding
+}
+
+// Registry holds an ordered set of rules and runs them against parsed
+// SQL. Built by NewRegistry and immutable afterward; rule evaluation
+// order matches the order provided to the constructor.
+type Registry struct {
+	rules []Rule
+}
+
+// NewRegistry creates a registry from the given rules. Rules are
+// evaluated in the order provided. It panics if any rule has a nil
+// Check function, an empty ReasonCode, or a ReasonCode that duplicates
+// a previously registered rule.
+func NewRegistry(rules ...Rule) *Registry {
+	seen := make(map[string]bool, len(rules))
+	for _, rule := range rules {
+		if rule.Check == nil {
+			panic(fmt.Sprintf("risk: rule %q has nil Check function", rule.ReasonCode))
+		}
+		if rule.ReasonCode == "" {
+			panic("risk: rule has empty ReasonCode")
+		}
+		if seen[rule.ReasonCode] {
+			panic(fmt.Sprintf("risk: duplicate ReasonCode %q", rule.ReasonCode))
+		}
+		seen[rule.ReasonCode] = true
+	}
+	return &Registry{rules: rules}
+}
+
+// Analyze parses sql and applies every registered rule to every
+// statement. Findings are returned in statement order; within a
+// statement, rules are evaluated in registration order. The registry
+// stamps each finding's ReasonCode and Severity from the rule that
+// produced it, so individual rules only need to set Message, Position,
+// and FixHint.
+func (r *Registry) Analyze(sql string) ([]Finding, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := []Finding{}
+	offset := 0
+	for _, stmt := range stmts {
+		pos := positionFromSQL(sql, stmt.SQL, &offset)
+		input := CheckInput{
+			AST:      stmt.AST,
+			StmtSQL:  stmt.SQL,
+			Position: pos,
+		}
+		for _, rule := range r.rules {
+			for _, f := range rule.Check(input) {
+				f.ReasonCode = rule.ReasonCode
+				f.Severity = rule.Severity
+				findings = append(findings, f)
+			}
+		}
+	}
+	return findings, nil
+}
+
+// Analyze is a convenience function that runs the default rule set
+// against sql. It is equivalent to NewRegistry(DefaultRules()...).Analyze(sql).
+func Analyze(sql string) ([]Finding, error) {
+	return NewRegistry(DefaultRules()...).Analyze(sql)
+}
+
+// positionFromSQL computes the Position of stmtSQL within fullSQL,
+// searching forward from *offset. It advances *offset past the
+// matched statement so successive calls find successive statements.
+func positionFromSQL(fullSQL, stmtSQL string, offset *int) Position {
+	idx := strings.Index(fullSQL[*offset:], stmtSQL)
+	if idx < 0 {
+		return Position{Line: 1, Column: 1, ByteOffset: *offset}
+	}
+	byteOff := *offset + idx
+	*offset = byteOff + len(stmtSQL)
+
+	prefix := fullSQL[:byteOff]
+	line := strings.Count(prefix, "\n") + 1
+	lastNL := strings.LastIndex(prefix, "\n")
+	col := byteOff - lastNL // works when lastNL == -1 (no newlines)
+	return Position{Line: line, Column: col, ByteOffset: byteOff}
+}

--- a/internal/risk/rules.go
+++ b/internal/risk/rules.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package risk
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// isStar returns true if expr represents a star expression — either an
+// unqualified star (SELECT *), a qualified star (SELECT t.*), or an
+// all-columns selector. The parser represents these as
+// tree.UnqualifiedStar, *tree.UnresolvedName with Star=true, and
+// *tree.AllColumnsSelector, respectively.
+func isStar(expr tree.Expr) bool {
+	switch e := expr.(type) {
+	case tree.UnqualifiedStar:
+		return true
+	case *tree.UnresolvedName:
+		return e.Star
+	case *tree.AllColumnsSelector:
+		return true
+	}
+	return false
+}
+
+// DefaultRules returns the built-in set of AST-only risk rules.
+func DefaultRules() []Rule {
+	return []Rule{
+		deleteNoWhereRule,
+		updateNoWhereRule,
+		dropTableRule,
+		selectStarRule,
+	}
+}
+
+// deleteNoWhereRule flags DELETE statements that have neither a WHERE
+// clause nor a LIMIT clause, matching CockroachDB's sql_safe_updates
+// behavior.
+var deleteNoWhereRule = Rule{
+	ReasonCode: "DELETE_NO_WHERE",
+	Severity:   SeverityCritical,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		del, ok := input.AST.(*tree.Delete)
+		if !ok {
+			return nil
+		}
+		if del.Where != nil || del.Limit != nil {
+			return nil
+		}
+		return []Finding{{
+			Message:  "DELETE without WHERE clause affects all rows",
+			Position: &input.Position,
+			FixHint:  "Add a WHERE clause to limit affected rows",
+		}}
+	},
+}
+
+// updateNoWhereRule flags UPDATE statements that have neither a WHERE
+// clause nor a LIMIT clause, matching CockroachDB's sql_safe_updates
+// behavior.
+var updateNoWhereRule = Rule{
+	ReasonCode: "UPDATE_NO_WHERE",
+	Severity:   SeverityCritical,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		upd, ok := input.AST.(*tree.Update)
+		if !ok {
+			return nil
+		}
+		if upd.Where != nil || upd.Limit != nil {
+			return nil
+		}
+		return []Finding{{
+			Message:  "UPDATE without WHERE clause affects all rows",
+			Position: &input.Position,
+			FixHint:  "Add a WHERE clause to limit affected rows",
+		}}
+	},
+}
+
+// dropTableRule flags all DROP TABLE statements. The message includes
+// the table name(s) being dropped.
+var dropTableRule = Rule{
+	ReasonCode: "DROP_TABLE",
+	Severity:   SeverityCritical,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		dt, ok := input.AST.(*tree.DropTable)
+		if !ok {
+			return nil
+		}
+		names := make([]string, len(dt.Names))
+		for i, n := range dt.Names {
+			names[i] = n.String()
+		}
+		return []Finding{{
+			Message:  fmt.Sprintf("DROP TABLE %s permanently removes the table and all its data", strings.Join(names, ", ")),
+			Position: &input.Position,
+			FixHint:  "Verify the table name and consider backing up data first",
+		}}
+	},
+}
+
+// selectStarRule flags SELECT statements that use an unqualified star
+// (SELECT *) or a qualified star (SELECT t.*). This is a low-severity
+// hint: star selects can cause unexpected column additions to propagate
+// and make queries fragile.
+var selectStarRule = Rule{
+	ReasonCode: "SELECT_STAR",
+	Severity:   SeverityLow,
+	Category:   "performance",
+	Check: func(input CheckInput) []Finding {
+		sel, ok := input.AST.(*tree.Select)
+		if !ok {
+			return nil
+		}
+		sc, ok := sel.Select.(*tree.SelectClause)
+		if !ok {
+			return nil
+		}
+		for _, expr := range sc.Exprs {
+			if isStar(expr.Expr) {
+				return []Finding{{
+					Message:  "SELECT * returns all columns and may cause performance issues",
+					Position: &input.Position,
+					FixHint:  "List specific columns instead of using *",
+				}}
+			}
+		}
+		return nil
+	},
+}

--- a/internal/risk/rules_test.go
+++ b/internal/risk/rules_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package risk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyze(t *testing.T) {
+	tests := []struct {
+		name                string
+		sql                 string
+		expectedReasonCodes []string
+	}{
+		{
+			name:                "DELETE without WHERE",
+			sql:                 "DELETE FROM users",
+			expectedReasonCodes: []string{"DELETE_NO_WHERE"},
+		},
+		{
+			name:                "DELETE with WHERE is safe",
+			sql:                 "DELETE FROM users WHERE id = 1",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "DELETE with LIMIT is safe",
+			sql:                 "DELETE FROM users LIMIT 100",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "UPDATE without WHERE",
+			sql:                 "UPDATE users SET name = 'x'",
+			expectedReasonCodes: []string{"UPDATE_NO_WHERE"},
+		},
+		{
+			name:                "UPDATE with WHERE is safe",
+			sql:                 "UPDATE users SET name = 'x' WHERE id = 1",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "UPDATE with LIMIT is safe",
+			sql:                 "UPDATE users SET name = 'x' LIMIT 100",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "DROP TABLE",
+			sql:                 "DROP TABLE users",
+			expectedReasonCodes: []string{"DROP_TABLE"},
+		},
+		{
+			name:                "DROP TABLE IF EXISTS multiple tables",
+			sql:                 "DROP TABLE IF EXISTS a, b",
+			expectedReasonCodes: []string{"DROP_TABLE"},
+		},
+		{
+			name:                "SELECT star",
+			sql:                 "SELECT * FROM users",
+			expectedReasonCodes: []string{"SELECT_STAR"},
+		},
+		{
+			name:                "SELECT specific columns is safe",
+			sql:                 "SELECT id, name FROM users",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT qualified star",
+			sql:                 "SELECT t.* FROM t",
+			expectedReasonCodes: []string{"SELECT_STAR"},
+		},
+		{
+			name:                "INSERT is safe",
+			sql:                 "INSERT INTO t VALUES (1)",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "CREATE TABLE is safe",
+			sql:                 "CREATE TABLE t (id INT PRIMARY KEY)",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "multi-statement with multiple risks",
+			sql:                 "DELETE FROM users; SELECT * FROM t; UPDATE t SET x = 1",
+			expectedReasonCodes: []string{"DELETE_NO_WHERE", "SELECT_STAR", "UPDATE_NO_WHERE"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, err := Analyze(tc.sql)
+			require.NoError(t, err)
+
+			var codes []string
+			for _, f := range findings {
+				codes = append(codes, f.ReasonCode)
+			}
+			require.Equal(t, tc.expectedReasonCodes, codes)
+		})
+	}
+}
+
+func TestAnalyzeParseError(t *testing.T) {
+	_, err := Analyze("SELECTT 1")
+	require.Error(t, err)
+}
+
+func TestAnalyzeEmptyInput(t *testing.T) {
+	findings, err := Analyze("")
+	require.NoError(t, err)
+	require.Empty(t, findings)
+}
+
+func TestFindingSeverity(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		expectedSeverity Severity
+	}{
+		{
+			name:             "DELETE_NO_WHERE is critical",
+			sql:              "DELETE FROM t",
+			expectedSeverity: SeverityCritical,
+		},
+		{
+			name:             "UPDATE_NO_WHERE is critical",
+			sql:              "UPDATE t SET x = 1",
+			expectedSeverity: SeverityCritical,
+		},
+		{
+			name:             "DROP_TABLE is critical",
+			sql:              "DROP TABLE t",
+			expectedSeverity: SeverityCritical,
+		},
+		{
+			name:             "SELECT_STAR is low",
+			sql:              "SELECT * FROM t",
+			expectedSeverity: SeverityLow,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, err := Analyze(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, findings, 1)
+			require.Equal(t, tc.expectedSeverity, findings[0].Severity)
+		})
+	}
+}
+
+func TestFindingPosition(t *testing.T) {
+	findings, err := Analyze("SELECT 1;\nDELETE FROM users")
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Equal(t, "DELETE_NO_WHERE", findings[0].ReasonCode)
+	require.NotNil(t, findings[0].Position)
+	require.Equal(t, 2, findings[0].Position.Line)
+	require.Equal(t, 1, findings[0].Position.Column)
+}
+
+func TestFindingFixHint(t *testing.T) {
+	findings, err := Analyze("DELETE FROM users")
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.NotEmpty(t, findings[0].FixHint)
+}
+
+func TestDropTableMessage(t *testing.T) {
+	findings, err := Analyze("DROP TABLE users")
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, "users")
+}


### PR DESCRIPTION
## Summary

Introduce a rule-based risk detection engine that inspects parsed SQL
ASTs and flags dangerous patterns. Four initial rules match
CockroachDB's `sql_safe_updates` behavior: `DELETE_NO_WHERE`,
`UPDATE_NO_WHERE`, `DROP_TABLE`, and `SELECT_STAR`. DELETE/UPDATE rules
treat LIMIT as an acceptable guard alongside WHERE.

The engine is exposed as both a CLI subcommand (`crdb-sql risk`) and an
MCP tool (`detect_risky_query`), sharing a single implementation in
`internal/risk`.

### Commits

- **f1717c2 catalog: add schema loader for CREATE TABLE files**
  In-memory catalog built from DDL files with case-insensitive lookup,
  PK-implies-NOT-NULL handling, and file-size guard via `os.Stat`.

- **8b73584 conn,cli: add pgx connection manager and crdb-sql ping subcommand**
  Lazy pgx connection with credential sanitization, plus `ping` and
  `describe` CLI subcommands.

- **ad7d0aa risk,cli,mcp: add detect_risky_query with AST-only rules**
  Rule registry with validation (panics on nil Check, empty/duplicate
  ReasonCode), four AST-only rules, `crdb-sql risk` subcommand, and
  `detect_risky_query` MCP tool. Registry stamps ReasonCode/Severity
  onto findings so rules only set Message/Position/FixHint.

Resolves: #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)