### PR TITLE
cmd: enrich parse errors in format and parse with SQLSTATE and position

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
@@ -52,8 +54,16 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 				return r.RenderError(baseEnv, err)
 			}
 
+			sql = strings.TrimSpace(sql)
+
 			formatted, err := sqlformat.Format(sql)
 			if err != nil {
+				// Format can fail during parsing (candidate PGCODE
+				// present) or during pretty-printing (no candidate
+				// code). Only parser errors get the enriched path.
+				if pgerror.HasCandidateCode(err) {
+					return renderParseError(r, baseEnv, err, sql)
+				}
 				return r.RenderError(baseEnv, err)
 			}
 

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -127,34 +127,52 @@ func TestFormatCmdMultiStatement(t *testing.T) {
 }
 
 // TestFormatCmdParseErrorText verifies that invalid SQL in text mode
-// surfaces as a non-nil error from Execute.
+// renders an enriched diagnostic with position and SQLSTATE code.
 func TestFormatCmdParseErrorText(t *testing.T) {
 	root := newRootCmd()
-	root.SetOut(&bytes.Buffer{})
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
-	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetIn(strings.NewReader("SELECT FROM"))
 	root.SetArgs([]string{"format"})
 
-	require.Error(t, root.Execute())
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, "1:12:")
+	require.Contains(t, got, "syntax error")
+	require.Contains(t, got, "42601")
 }
 
 // TestFormatCmdParseErrorJSON verifies that invalid SQL in JSON mode
-// produces an envelope with errors and nil data.
+// produces an envelope with a structured error containing SQLSTATE
+// code, severity, category, and source position.
 func TestFormatCmdParseErrorJSON(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
-	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetIn(strings.NewReader("SELECT FROM"))
 	root.SetArgs([]string{"format", "--output", "json"})
 
 	err := root.Execute()
-	require.Error(t, err)
+	require.ErrorIs(t, err, output.ErrRendered)
 
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
-	require.NotEmpty(t, env.Errors)
+	require.Len(t, env.Errors, 1)
 	require.Nil(t, env.Data)
+
+	diagErr := env.Errors[0]
+	require.Equal(t, "42601", diagErr.Code)
+	require.Equal(t, output.SeverityError, diagErr.Severity)
+	require.Equal(t, "syntax_error", diagErr.Category)
+	require.Contains(t, diagErr.Message, "syntax error")
+	require.NotNil(t, diagErr.Position)
+	require.Equal(t, 1, diagErr.Position.Line)
+	require.Equal(t, 12, diagErr.Position.Column)
+	require.Equal(t, 11, diagErr.Position.ByteOffset)
 }
 
 // TestFormatCmdEmptyInput verifies that empty stdin produces an error.

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -54,9 +55,11 @@ statement tag (e.g. SELECT, ALTER TABLE), and the original SQL text.`,
 				return r.RenderError(baseEnv, err)
 			}
 
+			sql = strings.TrimSpace(sql)
+
 			stmts, err := sqlparse.Classify(sql)
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return renderParseError(r, baseEnv, err, sql)
 			}
 
 			data, err := json.Marshal(stmts)

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -111,34 +111,52 @@ func TestParseCmdFileArg(t *testing.T) {
 }
 
 // TestParseCmdParseErrorText verifies that invalid SQL in text mode
-// surfaces as a non-nil error from Execute.
+// renders an enriched diagnostic with position and SQLSTATE code.
 func TestParseCmdParseErrorText(t *testing.T) {
 	root := newRootCmd()
-	root.SetOut(&bytes.Buffer{})
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
-	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetIn(strings.NewReader("SELECT FROM"))
 	root.SetArgs([]string{"parse"})
 
-	require.Error(t, root.Execute())
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, "1:12:")
+	require.Contains(t, got, "syntax error")
+	require.Contains(t, got, "42601")
 }
 
 // TestParseCmdParseErrorJSON verifies that invalid SQL in JSON mode
-// produces an envelope with errors and nil data.
+// produces an envelope with a structured error containing SQLSTATE
+// code, severity, category, and source position.
 func TestParseCmdParseErrorJSON(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
 	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
-	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetIn(strings.NewReader("SELECT FROM"))
 	root.SetArgs([]string{"parse", "--output", "json"})
 
 	err := root.Execute()
-	require.Error(t, err)
+	require.ErrorIs(t, err, output.ErrRendered)
 
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
-	require.NotEmpty(t, env.Errors)
+	require.Len(t, env.Errors, 1)
 	require.Nil(t, env.Data)
+
+	diagErr := env.Errors[0]
+	require.Equal(t, "42601", diagErr.Code)
+	require.Equal(t, output.SeverityError, diagErr.Severity)
+	require.Equal(t, "syntax_error", diagErr.Category)
+	require.Contains(t, diagErr.Message, "syntax error")
+	require.NotNil(t, diagErr.Position)
+	require.Equal(t, 1, diagErr.Position.Line)
+	require.Equal(t, 12, diagErr.Position.Column)
+	require.Equal(t, 11, diagErr.Position.ByteOffset)
 }
 
 // TestParseCmdEmptyInput verifies that empty stdin produces an error.


### PR DESCRIPTION
Previously, the format and parse commands passed parse errors through
the generic RenderError path, which wrapped them as "internal_error"
with no position info. This meant agents received different error
quality depending on which command they called with the same invalid
SQL — validate returned structured errors with SQLSTATE codes and
source positions, while format and parse did not.

Wire both commands through the existing renderParseError helper so all
three commands now produce consistent enriched errors. For format, a
pgerror.HasCandidateCode guard distinguishes parse errors (which carry
an explicit PGCODE annotation) from pretty-print errors (which do
not). Both commands also now TrimSpace the input before parsing,
matching validate's behavior for consistent position reporting.

Resolves: #65

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>