### PR TITLE
mcp: expose validate_sql, format_sql, parse_sql as MCP tools

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -19,10 +19,7 @@ import (
 // can spawn the binary and discover the registered tools. The command
 // blocks until the client disconnects (stdin closes); a clean
 // disconnect returns nil, anything else surfaces as the cobra error.
-//
-// Today the only registered tool is the `ping` skeleton from
-// internal/mcp; future issues attach the real tools to the same server
-// constructor.
+// The registered tools are defined in internal/mcp.NewServer.
 func newMCPCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "mcp",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,13 +5,12 @@
 
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
-// The server registers a health-check tool (ping), a SQL
-// classification tool (parse_sql), and a risk-detection tool
-// (detect_risky_query); future issues will add more SQL-aware
-// tools (validate_sql, format_sql, …) to the same NewServer
-// constructor. Keeping construction pure (no transport,
-// no I/O) lets the cmd layer pick a transport — currently just
-// stdio — and lets tests exercise individual tool handlers directly.
+// The server registers a health-check tool (ping), three Tier 1 SQL
+// tools (parse_sql, validate_sql, format_sql) via the tools subpackage,
+// and a risk-detection tool (detect_risky_query). Keeping construction
+// pure (no transport, no I/O) lets the cmd layer pick a transport —
+// currently just stdio — and lets tests exercise individual tool
+// handlers directly.
 //
 // Versions are passed in by the caller rather than read from
 // debug.ReadBuildInfo here, so this package stays free of
@@ -27,15 +26,14 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
-	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 )
 
-// Tool name constants are exposed so tests and docs reference a single
-// source of truth.
+// Tool name constants for tools defined in this file. The three Tier 1
+// SQL tool names live in the tools subpackage.
 const (
 	PingToolName             = "ping"
-	ParseSQLToolName         = "parse_sql"
 	DetectRiskyQueryToolName = "detect_risky_query"
 )
 
@@ -43,9 +41,9 @@ const (
 // crdb-sql binary version string (typically cmd.Version), and
 // parserVersion is the resolved cockroachdb-parser module version
 // (typically the result of cmd.parserVersion). Both are reported
-// verbatim — by the server handshake (binaryVersion) and by the `ping`
-// tool (parserVersion) — so callers should resolve them before invoking
-// NewServer.
+// verbatim — binaryVersion in the server handshake, and parserVersion
+// in every tool response — so callers should resolve them before
+// invoking NewServer.
 //
 // The returned server has no transport bound; callers wire it to stdio
 // (or, in the future, sse/http) themselves.
@@ -62,14 +60,9 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 		),
 		pingHandler(parserVersion),
 	)
-	s.AddTool(
-		mcp.NewTool(
-			ParseSQLToolName,
-			mcp.WithDescription("Parse and classify SQL statements. Returns statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input."),
-			mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
-		),
-		parseSQLHandler(parserVersion),
-	)
+	s.AddTool(tools.ParseSQLTool(), tools.ParseSQLHandler(parserVersion))
+	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion))
+	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion))
 	s.AddTool(
 		mcp.NewTool(
 			DetectRiskyQueryToolName,
@@ -105,46 +98,6 @@ func pingHandler(parserVersion string) server.ToolHandlerFunc {
 type pingResult struct {
 	OK            bool   `json:"ok"`
 	ParserVersion string `json:"parser_version"`
-}
-
-// parseSQLHandler returns the handler for the `parse_sql` tool. It
-// delegates to sqlparse.Classify for the actual parsing, so the MCP
-// and CLI layers share one implementation.
-func parseSQLHandler(parserVersion string) server.ToolHandlerFunc {
-	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		raw, exists := req.GetArguments()["sql"]
-		if !exists {
-			return mcp.NewToolResultError("sql parameter is required"), nil
-		}
-		sql, ok := raw.(string)
-		if !ok {
-			return mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw)), nil
-		}
-		if sql == "" {
-			return mcp.NewToolResultError("sql parameter must not be empty"), nil
-		}
-
-		stmts, err := sqlparse.Classify(sql)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("parse error: %v", err)), nil
-		}
-
-		result := parseSQLResult{
-			ParserVersion: parserVersion,
-			Statements:    stmts,
-		}
-		body, err := json.Marshal(result)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
-		}
-		return mcp.NewToolResultText(string(body)), nil
-	}
-}
-
-// parseSQLResult is the JSON shape returned by the `parse_sql` tool.
-type parseSQLResult struct {
-	ParserVersion string                         `json:"parser_version"`
-	Statements    []sqlparse.ClassifiedStatement `json:"statements"`
 }
 
 // detectRiskyQueryHandler returns the handler for the

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -13,6 +13,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 )
 
@@ -76,88 +77,14 @@ func TestPingHandler(t *testing.T) {
 func TestNewServerRegistersTools(t *testing.T) {
 	s := NewServer("v1.2.3", "v0.26.2")
 	require.NotNil(t, s)
-	tools := s.ListTools()
+	registered := s.ListTools()
 
-	for _, name := range []string{PingToolName, ParseSQLToolName, DetectRiskyQueryToolName} {
-		require.Contains(t, tools, name)
-		require.NotNil(t, tools[name].Handler,
+	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, DetectRiskyQueryToolName} {
+		require.Contains(t, registered, name)
+		require.NotNil(t, registered[name].Handler,
 			"%s must be registered with a non-nil handler", name)
-		require.NotEmpty(t, tools[name].Tool.Description,
+		require.NotEmpty(t, registered[name].Tool.Description,
 			"%s description is part of the user-facing contract", name)
-	}
-}
-
-// TestParseSQLHandler exercises the parse_sql tool handler directly,
-// bypassing the MCP transport.
-func TestParseSQLHandler(t *testing.T) {
-	tests := []struct {
-		name              string
-		args              map[string]any
-		expectedErr       bool
-		expectedStmtCount int
-		expectedType      string
-		expectedTag       string
-	}{
-		{
-			name:              "single DML",
-			args:              map[string]any{"sql": "SELECT 1"},
-			expectedStmtCount: 1,
-			expectedType:      "DML",
-			expectedTag:       "SELECT",
-		},
-		{
-			name:              "multi-statement",
-			args:              map[string]any{"sql": "SELECT 1; BEGIN"},
-			expectedStmtCount: 2,
-		},
-		{
-			name:        "parse error",
-			args:        map[string]any{"sql": "SELECTT 1"},
-			expectedErr: true,
-		},
-		{
-			name:        "empty sql",
-			args:        map[string]any{"sql": ""},
-			expectedErr: true,
-		},
-		{
-			name:        "missing sql param",
-			args:        map[string]any{},
-			expectedErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			handler := parseSQLHandler("v0.26.2")
-			req := mcpgo.CallToolRequest{}
-			req.Params.Arguments = tc.args
-
-			res, err := handler(context.Background(), req)
-			require.NoError(t, err)
-			require.NotNil(t, res)
-
-			if tc.expectedErr {
-				require.True(t, res.IsError, "expected tool-level error")
-				return
-			}
-
-			require.False(t, res.IsError)
-			require.Len(t, res.Content, 1)
-
-			text, ok := res.Content[0].(mcpgo.TextContent)
-			require.True(t, ok)
-
-			var result parseSQLResult
-			require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
-			require.Equal(t, "v0.26.2", result.ParserVersion)
-			require.Len(t, result.Statements, tc.expectedStmtCount)
-
-			if tc.expectedType != "" {
-				require.Equal(t, tc.expectedType, string(result.Statements[0].StatementType))
-				require.Equal(t, tc.expectedTag, result.Statements[0].Tag)
-			}
-		})
 	}
 }
 

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+)
+
+// FormatSQLTool returns the MCP tool definition for format_sql.
+func FormatSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		FormatSQLToolName,
+		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format. Returns an envelope with the formatted SQL string."),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to format (may contain multiple semicolon-separated statements)")),
+	)
+}
+
+// FormatSQLHandler returns the handler for the format_sql tool. It
+// delegates to sqlformat.Format and wraps the result in the standard
+// output.Envelope used by all Tier 1 tools.
+func FormatSQLHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractSQL(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := baseEnvelope(parserVersion)
+
+		formatted, err := sqlformat.Format(sql)
+		if err != nil {
+			env.Errors = []output.Error{{
+				Code:     "internal_error",
+				Severity: output.SeverityError,
+				Message:  err.Error(),
+			}}
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(struct {
+			FormattedSQL string `json:"formatted_sql"`
+		}{FormattedSQL: formatted})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+)
+
+// ParseSQLTool returns the MCP tool definition for parse_sql.
+func ParseSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		ParseSQLToolName,
+		mcp.WithDescription("Parse and classify SQL statements. Returns an envelope with statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input."),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
+	)
+}
+
+// ParseSQLHandler returns the handler for the parse_sql tool. It
+// delegates to sqlparse.Classify and wraps the result in the standard
+// output.Envelope used by all Tier 1 tools.
+func ParseSQLHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractSQL(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := baseEnvelope(parserVersion)
+
+		stmts, err := sqlparse.Classify(sql)
+		if err != nil {
+			env.Errors = []output.Error{{
+				Code:     "internal_error",
+				Severity: output.SeverityError,
+				Message:  err.Error(),
+			}}
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(stmts)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode statements: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package tools provides MCP tool handler constructors for the Tier 1
+// SQL tools (parse_sql, validate_sql, format_sql). Each handler returns
+// the same output.Envelope JSON shape that the CLI emits under
+// --output=json, so MCP clients get structured errors, parser version,
+// and tier metadata consistent with the CLI surface.
+//
+// Tool-level errors (mcp.NewToolResultError) are reserved for
+// infrastructure problems — missing or invalid parameters. SQL errors
+// (syntax, type mismatch) are returned as successful tool results with
+// the envelope's Errors array populated, because the tool itself
+// succeeded; the SQL is simply invalid.
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// Registered MCP tool names for the Tier 1 SQL tools.
+const (
+	ParseSQLToolName    = "parse_sql"
+	ValidateSQLToolName = "validate_sql"
+	FormatSQLToolName   = "format_sql"
+)
+
+// extractSQL validates and returns the required "sql" string parameter
+// from an MCP tool request. Leading and trailing whitespace is trimmed
+// so all handlers behave consistently. On success, the returned
+// *mcp.CallToolResult is nil. On failure (missing, wrong type, empty),
+// it is a pre-built tool error that the caller should return immediately.
+func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()["sql"]
+	if !exists {
+		return "", mcp.NewToolResultError("sql parameter is required")
+	}
+	sql, ok := raw.(string)
+	if !ok {
+		return "", mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw))
+	}
+	sql = strings.TrimSpace(sql)
+	if sql == "" {
+		return "", mcp.NewToolResultError("sql parameter must not be empty")
+	}
+	return sql, nil
+}
+
+// baseEnvelope returns a pre-populated Envelope for Tier 1 (zero-config,
+// disconnected) tools.
+func baseEnvelope(parserVersion string) output.Envelope {
+	return output.Envelope{
+		Tier:             output.TierZeroConfig,
+		ParserVersion:    parserVersion,
+		ConnectionStatus: output.ConnectionDisconnected,
+	}
+}
+
+// envelopeResult marshals env as JSON and wraps it in a successful MCP
+// tool result. If marshalling fails, it returns a tool error instead.
+func envelopeResult(env output.Envelope) (*mcp.CallToolResult, error) {
+	body, err := json.Marshal(env)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(body)), nil
+}

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+)
+
+const testParserVersion = "v0.26.2"
+
+// requireEnvelope asserts that res is a successful tool result (not a
+// tool-level error), extracts the TextContent, and unmarshals it into
+// an output.Envelope.
+func requireEnvelope(t *testing.T, res *mcpgo.CallToolResult) output.Envelope {
+	t.Helper()
+	require.False(t, res.IsError, "expected successful tool result, got tool-level error")
+	require.Len(t, res.Content, 1, "expected exactly one content block")
+	text, ok := res.Content[0].(mcpgo.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &env))
+	return env
+}
+
+func TestExtractSQL(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        map[string]any
+		expectedSQL string
+		expectedErr bool
+	}{
+		{name: "valid string", args: map[string]any{"sql": "SELECT 1"}, expectedSQL: "SELECT 1"},
+		{name: "missing param", args: map[string]any{}, expectedErr: true},
+		{name: "wrong type", args: map[string]any{"sql": 42}, expectedErr: true},
+		{name: "empty string", args: map[string]any{"sql": ""}, expectedErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			sql, toolErr := extractSQL(req)
+			if tc.expectedErr {
+				require.NotNil(t, toolErr, "expected tool error")
+				require.Empty(t, sql)
+			} else {
+				require.Nil(t, toolErr, "expected no tool error")
+				require.Equal(t, tc.expectedSQL, sql)
+			}
+		})
+	}
+}
+
+func TestParseSQLHandler(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              map[string]any
+		expectedToolErr   bool
+		expectedEnvErrs   bool
+		expectedStmtCount int
+		expectedType      string
+		expectedTag       string
+	}{
+		{
+			name:              "single DML",
+			args:              map[string]any{"sql": "SELECT 1"},
+			expectedStmtCount: 1,
+			expectedType:      "DML",
+			expectedTag:       "SELECT",
+		},
+		{
+			name:              "multi-statement",
+			args:              map[string]any{"sql": "SELECT 1; BEGIN"},
+			expectedStmtCount: 2,
+		},
+		{
+			name:            "parse error returns envelope errors",
+			args:            map[string]any{"sql": "SELECTT 1"},
+			expectedEnvErrs: true,
+		},
+		{
+			name:            "missing sql param",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty sql",
+			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ParseSQLHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			var stmts []sqlparse.ClassifiedStatement
+			require.NoError(t, json.Unmarshal(env.Data, &stmts))
+			require.Len(t, stmts, tc.expectedStmtCount)
+
+			if tc.expectedType != "" {
+				require.Equal(t, tc.expectedType, string(stmts[0].StatementType))
+				require.Equal(t, tc.expectedTag, stmts[0].Tag)
+			}
+		})
+	}
+}
+
+func TestValidateSQLHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            map[string]any
+		expectedToolErr bool
+		expectedValid   bool
+		expectedEnvErrs bool
+		expectedCode    string
+	}{
+		{
+			name:          "valid SQL",
+			args:          map[string]any{"sql": "SELECT 1"},
+			expectedValid: true,
+		},
+		{
+			name:            "syntax error",
+			args:            map[string]any{"sql": "SELECT FROM"},
+			expectedEnvErrs: true,
+			expectedCode:    "42601",
+		},
+		{
+			name:            "type mismatch",
+			args:            map[string]any{"sql": "SELECT 1 + 'hello'"},
+			expectedEnvErrs: true,
+		},
+		{
+			name:          "column ref does not false-positive",
+			args:          map[string]any{"sql": "SELECT a + 1 FROM t"},
+			expectedValid: true,
+		},
+		{
+			name:          "whitespace trimmed",
+			args:          map[string]any{"sql": "  SELECT 1  \n"},
+			expectedValid: true,
+		},
+		{
+			name:            "missing sql param",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty sql",
+			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ValidateSQLHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				if tc.expectedCode != "" {
+					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				}
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			require.NotNil(t, env.Data)
+
+			if tc.expectedValid {
+				var data struct {
+					Valid bool `json:"valid"`
+				}
+				require.NoError(t, json.Unmarshal(env.Data, &data))
+				require.True(t, data.Valid)
+			}
+		})
+	}
+}
+
+func TestFormatSQLHandler(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              map[string]any
+		expectedToolErr   bool
+		expectedEnvErrs   bool
+		expectedFormatted string
+	}{
+		{
+			name:              "basic formatting",
+			args:              map[string]any{"sql": "select  1"},
+			expectedFormatted: "SELECT 1",
+		},
+		{
+			name:              "multi-statement",
+			args:              map[string]any{"sql": "select 1; select 2"},
+			expectedFormatted: "SELECT 1;\nSELECT 2",
+		},
+		{
+			name:            "parse error",
+			args:            map[string]any{"sql": "SELECTT 1"},
+			expectedEnvErrs: true,
+		},
+		{
+			name:            "missing sql param",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty sql",
+			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := FormatSQLHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			require.NotNil(t, env.Data)
+
+			var data struct {
+				FormattedSQL string `json:"formatted_sql"`
+			}
+			require.NoError(t, json.Unmarshal(env.Data, &data))
+			require.Equal(t, tc.expectedFormatted, data.FormattedSQL)
+		})
+	}
+}

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/semcheck"
+)
+
+// ValidateSQLTool returns the MCP tool definition for validate_sql.
+func ValidateSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		ValidateSQLToolName,
+		mcp.WithDescription("Validate SQL for syntax and type errors. Returns an envelope with {\"valid\": true} on success, or structured errors with SQLSTATE codes, severity, message, and source position on failure."),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to validate")),
+	)
+}
+
+// ValidateSQLHandler returns the handler for the validate_sql tool. It
+// parses the SQL, runs expression type checking, and returns the
+// standard output.Envelope used by all Tier 1 tools.
+func ValidateSQLHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractSQL(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := baseEnvelope(parserVersion)
+
+		stmts, parseErr := parser.Parse(sql)
+		if parseErr != nil {
+			env.Errors = []output.Error{diag.FromParseError(parseErr, sql)}
+			return envelopeResult(env)
+		}
+
+		if typeErrs := semcheck.CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
+			env.Errors = typeErrs
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(struct {
+			Valid bool `json:"valid"`
+		}{Valid: true})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}


### PR DESCRIPTION
Extract the SQL tool handlers into a new `internal/mcp/tools` subpackage
and add `validate_sql` and `format_sql` alongside the existing `parse_sql`.
All three tools return the standard `output.Envelope` JSON shape (`tier`,
`parser_version`, `connection_status`, `errors`, `data`) so MCP clients get
the same structured output as the CLI's `--output=json` mode.

SQL validation and parse errors are returned as successful tool results
with the envelope's `Errors` array populated rather than as tool-level
errors, distinguishing "the tool worked, the SQL is invalid" from
infrastructure failures like missing parameters.

The `parse_sql` handler moves from `server.go` to `tools/parse.go` and
switches from its custom `parseSQLResult` struct to the envelope format
for consistency with the two new tools.

**Breaking change:** `parse_sql` response shape changed from
`{parser_version, statements}` to the envelope format
`{tier, parser_version, connection_status, data}`. Acceptable because
no stable clients depend on the previous shape.

Resolves: #10

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>