### PR TITLE
cmd: extract newEnvelope helper to reduce subcommand boilerplate

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -44,17 +44,10 @@ Then describe any table:
   crdb-sql describe users --schema schema.sql`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierSchemaFile,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			if len(schemaFiles) == 0 {
 				return r.RenderError(baseEnv,

--- a/cmd/envelope_test.go
+++ b/cmd/envelope_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func TestNewEnvelope(t *testing.T) {
+	t.Run("sets tier and connection status", func(t *testing.T) {
+		state := &rootState{outputFormat: output.FormatJSON}
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+
+		r, env, err := newEnvelope(state, output.TierZeroConfig, cmd)
+		require.NoError(t, err)
+		require.Equal(t, output.FormatJSON, r.Format)
+		require.Equal(t, output.TierZeroConfig, env.Tier)
+		require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+		require.NotEmpty(t, env.ParserVersion)
+	})
+
+	t.Run("TierUnset omits tier from JSON", func(t *testing.T) {
+		state := &rootState{outputFormat: output.FormatJSON}
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+
+		_, env, err := newEnvelope(state, output.TierUnset, cmd)
+		require.NoError(t, err)
+		require.Equal(t, output.TierUnset, env.Tier)
+
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"tier"`)
+	})
+}

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -37,17 +37,10 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 (inline SQL), a positional file argument, or stdin.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierZeroConfig,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
 			if err != nil {

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -40,17 +40,10 @@ statement tag (e.g. SELECT, ALTER TABLE), the original SQL text, and a
 normalized form with literal constants replaced by placeholders.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierZeroConfig,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
 			if err != nil {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -30,17 +30,10 @@ version. The connection string is read from the --dsn flag or the
 CRDB_DSN environment variable (flag takes precedence).`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierConnected,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			if state.dsn == "" {
 				return r.RenderError(baseEnv,

--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -38,17 +38,10 @@ WHERE clause, DROP TABLE, and SELECT *. Input is read from the -e flag
 includes a reason code, severity, human-readable message, and fix hint.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierZeroConfig,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,3 +115,30 @@ const (
 func Execute() error {
 	return newRootCmd().ExecuteContext(context.Background())
 }
+
+// newEnvelope builds the Renderer and base Envelope that each CLI
+// subcommand needs. On success the returned Envelope has its Tier,
+// ParserVersion, and ConnectionStatus populated; the caller owns Data
+// and may append to Errors via RenderError. On error ParserVersion
+// may be empty, but the Renderer and Envelope are still usable — the
+// caller should typically do:
+//
+//	r, env, err := newEnvelope(state, output.TierZeroConfig, cmd)
+//	if err != nil {
+//	    return r.RenderError(env, err)
+//	}
+func newEnvelope(
+	state *rootState, tier output.Tier, cmd *cobra.Command,
+) (output.Renderer, output.Envelope, error) {
+	r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
+	env := output.Envelope{
+		Tier:             tier,
+		ConnectionStatus: output.ConnectionDisconnected,
+	}
+	parserVer, err := parserVersion(Version)
+	if err != nil {
+		return r, env, err
+	}
+	env.ParserVersion = parserVer
+	return r, env, nil
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -41,17 +41,10 @@ position (line/column/byte offset). Input is read from the -e flag
 (inline SQL), a positional file argument, or stdin.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			baseEnv := output.Envelope{
-				Tier:             output.TierZeroConfig,
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-
-			parserVer, err := parserVersion(Version)
+			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
-			baseEnv.ParserVersion = parserVer
 
 			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -57,30 +57,19 @@ embedded Go build info, so it reflects whatever go.mod (including any
 replace directive) selected at build time.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			r := output.Renderer{Format: state.outputFormat, Out: cmd.OutOrStdout()}
-			// baseEnv is the partial context used on both the
-			// success path and the JSON-mode error path. The error
-			// path needs ConnectionStatus populated so agents see a
-			// well-formed envelope even when ParserVersion / Data
-			// resolution fails.
-			baseEnv := output.Envelope{
-				ConnectionStatus: output.ConnectionDisconnected,
-			}
-			parser, err := parserVersion(Version)
+			r, env, err := newEnvelope(state, output.TierUnset, cmd)
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return r.RenderError(env, err)
 			}
 			data, err := json.Marshal(struct {
 				BinaryVersion string `json:"binary_version"`
 			}{BinaryVersion: Version})
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return r.RenderError(env, err)
 			}
-			env := baseEnv
-			env.ParserVersion = parser
 			env.Data = data
 			return r.Render(env, func(w io.Writer) error {
-				_, werr := fmt.Fprintf(w, "crdb-sql: %s\ncockroachdb-parser: %s\n", Version, parser)
+				_, werr := fmt.Fprintf(w, "crdb-sql: %s\ncockroachdb-parser: %s\n", Version, env.ParserVersion)
 				return werr
 			})
 		},


### PR DESCRIPTION
Every CLI subcommand repeated ~10 lines of identical setup to create
an output.Renderer, initialize a base output.Envelope with tier and
connection status, resolve the parser version, and handle the
resolution error. The only value that varied was the Tier constant.

Extract a newEnvelope(state, tier, cmd) helper into root.go that
encapsulates this setup and returns a ready-to-use Renderer and
Envelope. Update all seven subcommands (format, parse, validate,
risk, ping, describe, version) to call the helper, shrinking each
RunE body by ~6 lines.

The version command is further simplified by eliminating its
baseEnv-to-env copy — the helper now sets ParserVersion before
returning, so the copy is no longer needed.

Resolves: #67