### PR TITLE
mcp: return structured errors from MCP tool handlers

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -27,15 +27,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
-	"github.com/spilchen/sql-ai-tools/internal/risk"
 )
 
-// Tool name constants for tools defined in this file. The three Tier 1
-// SQL tool names live in the tools subpackage.
-const (
-	PingToolName             = "ping"
-	DetectRiskyQueryToolName = "detect_risky_query"
-)
+// PingToolName is the registered MCP tool name for the health-check tool.
+// All other tool name constants live in the tools subpackage.
+const PingToolName = "ping"
 
 // NewServer constructs an MCP server for crdb-sql. binaryVersion is the
 // crdb-sql binary version string (typically cmd.Version), and
@@ -63,14 +59,7 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 	s.AddTool(tools.ParseSQLTool(), tools.ParseSQLHandler(parserVersion))
 	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion))
 	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion))
-	s.AddTool(
-		mcp.NewTool(
-			DetectRiskyQueryToolName,
-			mcp.WithDescription("Detect risky SQL patterns such as DELETE/UPDATE without WHERE, DROP TABLE, and SELECT *. Returns findings with reason codes, severity, and fix hints."),
-			mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
-		),
-		detectRiskyQueryHandler(parserVersion),
-	)
+	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion))
 	return s
 }
 
@@ -98,45 +87,4 @@ func pingHandler(parserVersion string) server.ToolHandlerFunc {
 type pingResult struct {
 	OK            bool   `json:"ok"`
 	ParserVersion string `json:"parser_version"`
-}
-
-// detectRiskyQueryHandler returns the handler for the
-// `detect_risky_query` tool. It delegates to risk.Analyze for the
-// actual analysis, so the MCP and CLI layers share one implementation.
-func detectRiskyQueryHandler(parserVersion string) server.ToolHandlerFunc {
-	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		raw, exists := req.GetArguments()["sql"]
-		if !exists {
-			return mcp.NewToolResultError("sql parameter is required"), nil
-		}
-		sql, ok := raw.(string)
-		if !ok {
-			return mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw)), nil
-		}
-		if sql == "" {
-			return mcp.NewToolResultError("sql parameter must not be empty"), nil
-		}
-
-		findings, err := risk.Analyze(sql)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("parse error: %v", err)), nil
-		}
-
-		result := detectRiskyQueryResult{
-			ParserVersion: parserVersion,
-			Findings:      findings,
-		}
-		body, err := json.Marshal(result)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
-		}
-		return mcp.NewToolResultText(string(body)), nil
-	}
-}
-
-// detectRiskyQueryResult is the JSON shape returned by the
-// `detect_risky_query` tool.
-type detectRiskyQueryResult struct {
-	ParserVersion string         `json:"parser_version"`
-	Findings      []risk.Finding `json:"findings"`
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
-	"github.com/spilchen/sql-ai-tools/internal/risk"
 )
 
 // TestPingHandler exercises the ping tool handler directly, bypassing
@@ -79,89 +78,11 @@ func TestNewServerRegistersTools(t *testing.T) {
 	require.NotNil(t, s)
 	registered := s.ListTools()
 
-	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, DetectRiskyQueryToolName} {
+	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, tools.DetectRiskyQueryToolName} {
 		require.Contains(t, registered, name)
 		require.NotNil(t, registered[name].Handler,
 			"%s must be registered with a non-nil handler", name)
 		require.NotEmpty(t, registered[name].Tool.Description,
 			"%s description is part of the user-facing contract", name)
-	}
-}
-
-// TestDetectRiskyQueryHandler exercises the detect_risky_query tool
-// handler directly, bypassing the MCP transport.
-func TestDetectRiskyQueryHandler(t *testing.T) {
-	tests := []struct {
-		name                 string
-		args                 map[string]any
-		expectedErr          bool
-		expectedFindingCount int
-		expectedReasonCode   string
-	}{
-		{
-			name:                 "risky DELETE",
-			args:                 map[string]any{"sql": "DELETE FROM users"},
-			expectedFindingCount: 1,
-			expectedReasonCode:   "DELETE_NO_WHERE",
-		},
-		{
-			name:                 "safe SELECT",
-			args:                 map[string]any{"sql": "SELECT id FROM t WHERE id = 1"},
-			expectedFindingCount: 0,
-		},
-		{
-			name:                 "multiple findings",
-			args:                 map[string]any{"sql": "DELETE FROM t; SELECT * FROM t"},
-			expectedFindingCount: 2,
-		},
-		{
-			name:        "parse error",
-			args:        map[string]any{"sql": "SELECTT 1"},
-			expectedErr: true,
-		},
-		{
-			name:        "empty sql",
-			args:        map[string]any{"sql": ""},
-			expectedErr: true,
-		},
-		{
-			name:        "missing sql param",
-			args:        map[string]any{},
-			expectedErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			handler := detectRiskyQueryHandler("v0.26.2")
-			req := mcpgo.CallToolRequest{}
-			req.Params.Arguments = tc.args
-
-			res, err := handler(context.Background(), req)
-			require.NoError(t, err)
-			require.NotNil(t, res)
-
-			if tc.expectedErr {
-				require.True(t, res.IsError, "expected tool-level error")
-				return
-			}
-
-			require.False(t, res.IsError)
-			require.Len(t, res.Content, 1)
-
-			text, ok := res.Content[0].(mcpgo.TextContent)
-			require.True(t, ok)
-
-			var result detectRiskyQueryResult
-			require.NoError(t, json.Unmarshal([]byte(text.Text), &result))
-			require.Equal(t, "v0.26.2", result.ParserVersion)
-			require.Len(t, result.Findings, tc.expectedFindingCount)
-
-			if tc.expectedReasonCode != "" {
-				require.Equal(t, tc.expectedReasonCode, result.Findings[0].ReasonCode)
-				require.Equal(t, risk.SeverityCritical, result.Findings[0].Severity)
-				require.NotEmpty(t, result.Findings[0].FixHint)
-			}
-		})
 	}
 }

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
 )
@@ -40,11 +41,7 @@ func FormatSQLHandler(parserVersion string) server.ToolHandlerFunc {
 
 		formatted, err := sqlformat.Format(sql)
 		if err != nil {
-			env.Errors = []output.Error{{
-				Code:     "internal_error",
-				Severity: output.SeverityError,
-				Message:  err.Error(),
-			}}
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 )
@@ -40,11 +41,7 @@ func ParseSQLHandler(parserVersion string) server.ToolHandlerFunc {
 
 		stmts, err := sqlparse.Classify(sql)
 		if err != nil {
-			env.Errors = []output.Error{{
-				Code:     "internal_error",
-				Severity: output.SeverityError,
-				Message:  err.Error(),
-			}}
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/risk.go
+++ b/internal/mcp/tools/risk.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+)
+
+// DetectRiskyQueryTool returns the MCP tool definition for detect_risky_query.
+func DetectRiskyQueryTool() mcp.Tool {
+	return mcp.NewTool(
+		DetectRiskyQueryToolName,
+		mcp.WithDescription("Detect risky SQL patterns such as DELETE/UPDATE without WHERE, DROP TABLE, and SELECT *. Returns findings with reason codes, severity, and fix hints."),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
+	)
+}
+
+// DetectRiskyQueryHandler returns the handler for the detect_risky_query
+// tool. It delegates to risk.Analyze and wraps the result in the standard
+// output.Envelope used by all tools in this package.
+func DetectRiskyQueryHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractSQL(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := baseEnvelope(parserVersion)
+
+		findings, err := risk.Analyze(sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(findings)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode findings: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -3,11 +3,11 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-// Package tools provides MCP tool handler constructors for the Tier 1
-// SQL tools (parse_sql, validate_sql, format_sql). Each handler returns
-// the same output.Envelope JSON shape that the CLI emits under
-// --output=json, so MCP clients get structured errors, parser version,
-// and tier metadata consistent with the CLI surface.
+// Package tools provides MCP tool handler constructors for the SQL
+// tools: parse_sql, validate_sql, format_sql, and detect_risky_query.
+// Each handler returns the same output.Envelope JSON shape that the CLI
+// emits under --output=json, so MCP clients get structured errors,
+// parser version, and tier metadata consistent with the CLI surface.
 //
 // Tool-level errors (mcp.NewToolResultError) are reserved for
 // infrastructure problems — missing or invalid parameters. SQL errors
@@ -26,11 +26,12 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
-// Registered MCP tool names for the Tier 1 SQL tools.
+// Registered MCP tool names.
 const (
-	ParseSQLToolName    = "parse_sql"
-	ValidateSQLToolName = "validate_sql"
-	FormatSQLToolName   = "format_sql"
+	ParseSQLToolName         = "parse_sql"
+	ValidateSQLToolName      = "validate_sql"
+	FormatSQLToolName        = "format_sql"
+	DetectRiskyQueryToolName = "detect_risky_query"
 )
 
 // extractSQL validates and returns the required "sql" string parameter

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 )
 
@@ -69,6 +70,7 @@ func TestParseSQLHandler(t *testing.T) {
 		args              map[string]any
 		expectedToolErr   bool
 		expectedEnvErrs   bool
+		expectedCode      string
 		expectedStmtCount int
 		expectedType      string
 		expectedTag       string
@@ -86,9 +88,10 @@ func TestParseSQLHandler(t *testing.T) {
 			expectedStmtCount: 2,
 		},
 		{
-			name:            "parse error returns envelope errors",
+			name:            "parse error returns structured SQLSTATE error",
 			args:            map[string]any{"sql": "SELECTT 1"},
 			expectedEnvErrs: true,
+			expectedCode:    "42601",
 		},
 		{
 			name:            "missing sql param",
@@ -125,6 +128,9 @@ func TestParseSQLHandler(t *testing.T) {
 			if tc.expectedEnvErrs {
 				require.NotEmpty(t, env.Errors)
 				require.Nil(t, env.Data)
+				if tc.expectedCode != "" {
+					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				}
 				return
 			}
 
@@ -237,6 +243,7 @@ func TestFormatSQLHandler(t *testing.T) {
 		args              map[string]any
 		expectedToolErr   bool
 		expectedEnvErrs   bool
+		expectedCode      string
 		expectedFormatted string
 	}{
 		{
@@ -250,9 +257,10 @@ func TestFormatSQLHandler(t *testing.T) {
 			expectedFormatted: "SELECT 1;\nSELECT 2",
 		},
 		{
-			name:            "parse error",
+			name:            "parse error returns structured SQLSTATE error",
 			args:            map[string]any{"sql": "SELECTT 1"},
 			expectedEnvErrs: true,
+			expectedCode:    "42601",
 		},
 		{
 			name:            "missing sql param",
@@ -289,6 +297,9 @@ func TestFormatSQLHandler(t *testing.T) {
 			if tc.expectedEnvErrs {
 				require.NotEmpty(t, env.Errors)
 				require.Nil(t, env.Data)
+				if tc.expectedCode != "" {
+					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				}
 				return
 			}
 
@@ -300,6 +311,95 @@ func TestFormatSQLHandler(t *testing.T) {
 			}
 			require.NoError(t, json.Unmarshal(env.Data, &data))
 			require.Equal(t, tc.expectedFormatted, data.FormattedSQL)
+		})
+	}
+}
+
+func TestDetectRiskyQueryHandler(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 map[string]any
+		expectedToolErr      bool
+		expectedEnvErrs      bool
+		expectedCode         string
+		expectedFindingCount int
+		expectedReasonCode   string
+	}{
+		{
+			name:                 "risky DELETE",
+			args:                 map[string]any{"sql": "DELETE FROM users"},
+			expectedFindingCount: 1,
+			expectedReasonCode:   "DELETE_NO_WHERE",
+		},
+		{
+			name:                 "safe SELECT",
+			args:                 map[string]any{"sql": "SELECT id FROM t WHERE id = 1"},
+			expectedFindingCount: 0,
+		},
+		{
+			name:                 "multiple findings",
+			args:                 map[string]any{"sql": "DELETE FROM t; SELECT * FROM t"},
+			expectedFindingCount: 2,
+		},
+		{
+			name:            "parse error returns structured SQLSTATE error",
+			args:            map[string]any{"sql": "SELECTT 1"},
+			expectedEnvErrs: true,
+			expectedCode:    "42601",
+		},
+		{
+			name:            "empty sql",
+			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+		{
+			name:            "missing sql param",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := DetectRiskyQueryHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				if tc.expectedCode != "" {
+					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				}
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			require.NotNil(t, env.Data)
+
+			var findings []risk.Finding
+			require.NoError(t, json.Unmarshal(env.Data, &findings))
+			require.Len(t, findings, tc.expectedFindingCount)
+
+			if tc.expectedReasonCode != "" {
+				require.Equal(t, tc.expectedReasonCode, findings[0].ReasonCode)
+				require.Equal(t, risk.SeverityCritical, findings[0].Severity)
+				require.NotEmpty(t, findings[0].FixHint)
+			}
 		})
 	}
 }


### PR DESCRIPTION
MCP tool handlers returned parse errors as generic flat strings or
`output.Error{Code: "internal_error", ...}` objects, discarding the
SQLSTATE code, severity, source position, and category that the `diag`
package extracts. An agent calling these tools via MCP got strictly
worse error information than the CLI surface.

Replace the generic error construction in `parse_sql` and `format_sql`
with `diag.FromParseError`, matching the pattern already used by
`validate_sql`. Move `detect_risky_query` from `server.go` into the
`tools` subpackage, adopting the same envelope pattern and structured
parse errors. This also eliminates duplicated parameter validation
logic.

All MCP tool handlers now return consistent structured error envelopes
with SQLSTATE codes (e.g. `42601`), severity, position, and category
on parse failures.

Resolves: #66

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>