### PR TITLE
describe: support --schema - to read DDL from stdin

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -18,6 +18,8 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
+const stdinSentinel = "-"
+
 // newDescribeCmd builds the `crdb-sql describe` subcommand. It loads
 // one or more schema files (--schema), parses them with the
 // CockroachDB parser, and describes the named table's columns, primary
@@ -41,7 +43,11 @@ obtain one from a running CockroachDB cluster with:
 
 Then describe any table:
 
-  crdb-sql describe users --schema schema.sql`,
+  crdb-sql describe users --schema schema.sql
+
+Use --schema - to read DDL from stdin, allowing direct piping:
+
+  cockroach sql -e 'SHOW CREATE ALL TABLES' | crdb-sql describe users --schema -`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
@@ -54,7 +60,12 @@ Then describe any table:
 					fmt.Errorf("at least one --schema file is required"))
 			}
 
-			cat, err := catalog.LoadFiles(schemaFiles)
+			sources, err := buildSchemaSources(schemaFiles, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			cat, err := catalog.Load(sources)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
@@ -93,9 +104,42 @@ Then describe any table:
 	}
 
 	cmd.Flags().StringArrayVar(&schemaFiles, "schema", nil,
-		"schema SQL file(s) to load (repeatable)")
+		`schema SQL file(s) to load (repeatable); use "-" for stdin`)
 
 	return cmd
+}
+
+// buildSchemaSources converts the raw --schema flag values into
+// catalog.SchemaSource entries. The sentinel "-" means "read from
+// stdin"; it may appear at most once.
+func buildSchemaSources(flags []string, stdin io.Reader) ([]catalog.SchemaSource, error) {
+	var sources []catalog.SchemaSource
+	stdinUsed := false
+
+	for _, f := range flags {
+		if f != stdinSentinel {
+			sources = append(sources, catalog.SchemaSource{Path: f})
+			continue
+		}
+		if stdinUsed {
+			return nil, fmt.Errorf("--schema - (stdin) can only be specified once")
+		}
+		stdinUsed = true
+
+		data, err := io.ReadAll(io.LimitReader(stdin, catalog.MaxSchemaFileSize+1))
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		if int64(len(data)) > catalog.MaxSchemaFileSize {
+			return nil, fmt.Errorf("stdin input is too large (%d bytes, max %d)",
+				len(data), catalog.MaxSchemaFileSize)
+		}
+		sources = append(sources, catalog.SchemaSource{
+			SQL:   string(data),
+			Label: "stdin",
+		})
+	}
+	return sources, nil
 }
 
 func renderTableText(w io.Writer, tbl catalog.Table) error {

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -261,6 +261,102 @@ func TestDescribeCmdWarningsInJSONOutput(t *testing.T) {
 	require.Contains(t, env.Errors[0].Message, "skipped 1 non-CREATE TABLE")
 }
 
+func TestDescribeCmdStdinBasic(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(bytes.NewBufferString(`CREATE TABLE t (id INT8 PRIMARY KEY, name TEXT)`))
+	root.SetArgs([]string{"describe", "t", "--schema", "-", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "t", tbl.Name)
+	require.Len(t, tbl.Columns, 2)
+	require.Equal(t, []string{"id"}, tbl.PrimaryKey)
+}
+
+func TestDescribeCmdStdinTextOutput(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(bytes.NewBufferString(`CREATE TABLE users (id INT8 PRIMARY KEY, email TEXT NOT NULL)`))
+	root.SetArgs([]string{"describe", "users", "--schema", "-"})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "Table: users")
+	require.Contains(t, got, "id")
+	require.Contains(t, got, "email")
+	require.Contains(t, got, "Primary Key: id")
+}
+
+func TestDescribeCmdStdinMixedWithFile(t *testing.T) {
+	schema := writeSchemaFile(t, `CREATE TABLE a (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(bytes.NewBufferString(`CREATE TABLE b (id INT8 PRIMARY KEY)`))
+	root.SetArgs([]string{"describe", "b", "--schema", schema, "--schema", "-", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "b", tbl.Name)
+}
+
+func TestDescribeCmdStdinDuplicateRejected(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(bytes.NewBufferString(`CREATE TABLE t (id INT8 PRIMARY KEY)`))
+	root.SetArgs([]string{"describe", "t", "--schema", "-", "--schema", "-", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "stdin")
+	require.Contains(t, env.Errors[0].Message, "once")
+}
+
+func TestDescribeCmdStdinEmpty(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(bytes.NewBufferString(""))
+	root.SetArgs([]string{"describe", "t", "--schema", "-", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 2)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	require.Contains(t, env.Errors[0].Message, "no SQL statements")
+	require.Contains(t, env.Errors[1].Message, "not found")
+}
+
 func TestDescribeCmdParseError(t *testing.T) {
 	schema := writeSchemaFile(t, `CREAT TABLE bad (id INT8)`)
 
@@ -276,5 +372,5 @@ func TestDescribeCmdParseError(t *testing.T) {
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.NotEmpty(t, env.Errors)
-	require.Contains(t, env.Errors[0].Message, "parse schema file")
+	require.Contains(t, env.Errors[0].Message, "parse schema")
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -4,10 +4,10 @@
 // included in the /LICENSE file.
 
 // Package catalog provides a lightweight in-memory representation of a
-// SQL schema loaded from CREATE TABLE DDL files. The primary entry
-// point is LoadFiles, which parses one or more .sql files using the
-// CockroachDB parser and builds a Catalog mapping table names to their
-// columns, primary key, and indexes.
+// SQL schema loaded from CREATE TABLE DDL. The primary entry point is
+// Load, which accepts a mix of file paths and raw SQL strings via
+// SchemaSource. LoadFiles is a convenience wrapper for file-only
+// callers.
 //
 // The catalog is the foundation for Tier 2 (schema-aware) analysis:
 // name resolution, column type lookup, and "did you mean?" suggestions

--- a/internal/catalog/loader.go
+++ b/internal/catalog/loader.go
@@ -14,37 +14,56 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
-// maxSchemaFileSize is the largest schema file LoadFiles will read.
-// Schema DDL files are typically small; a 100 MB limit prevents
-// accidental OOM from passing a full database dump.
-const maxSchemaFileSize = 100 << 20
+// MaxSchemaFileSize is the largest schema source Load will accept,
+// whether from a file or raw SQL. Schema DDL is typically small; a
+// 100 MB limit prevents accidental OOM from passing a full database
+// dump.
+const MaxSchemaFileSize = 100 << 20
 
-// LoadFiles parses the SQL content of each file and builds a Catalog
-// from the CREATE TABLE statements found. Non-CREATE TABLE statements
-// are skipped with a warning. If multiple files define the same table
-// name, the last definition wins and a warning is recorded.
-func LoadFiles(paths []string) (*Catalog, error) {
+// SchemaSource represents one source of schema DDL. Either Path or SQL
+// must be set (not both). Label is used in warnings and error messages;
+// when empty it defaults to Path (for file sources) or "<inline SQL>"
+// (for raw SQL sources).
+type SchemaSource struct {
+	Path  string // file to read
+	SQL   string // raw SQL content (used when Path is empty)
+	Label string // human-readable name for diagnostics
+}
+
+func (s SchemaSource) label() string {
+	if s.Label != "" {
+		return s.Label
+	}
+	if s.Path != "" {
+		return s.Path
+	}
+	return "<inline SQL>"
+}
+
+// Load parses schema SQL from the given sources and builds a Catalog
+// from the CREATE TABLE statements found. Sources may be file paths or
+// raw SQL strings. Non-CREATE TABLE statements are skipped with a
+// warning. If multiple sources define the same table name, the last
+// definition wins and a warning is recorded.
+func Load(sources []SchemaSource) (*Catalog, error) {
 	cat := &Catalog{byName: make(map[string]int)}
 
-	for _, path := range paths {
-		// Stat before ReadFile so we reject oversized files without
-		// allocating their contents into memory.
-		info, err := os.Stat(path)
+	for _, src := range sources {
+		label := src.label()
+
+		sql, err := readSource(src)
 		if err != nil {
-			return nil, fmt.Errorf("stat schema file %s: %w", path, err)
+			return nil, err
 		}
-		if info.Size() > maxSchemaFileSize {
-			return nil, fmt.Errorf("schema file %s is too large (%d bytes, max %d)",
-				path, info.Size(), maxSchemaFileSize)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("read schema file %s: %w", path, err)
+		if sql == "" {
+			cat.warnings = append(cat.warnings,
+				fmt.Sprintf("%s: source contained no SQL statements", label))
+			continue
 		}
 
-		stmts, err := parser.Parse(string(data))
+		stmts, err := parser.Parse(sql)
 		if err != nil {
-			return nil, fmt.Errorf("parse schema file %s: %w", path, err)
+			return nil, fmt.Errorf("parse schema %s: %w", label, err)
 		}
 
 		var skippedTags []string
@@ -57,14 +76,14 @@ func LoadFiles(paths []string) (*Catalog, error) {
 			tableName := ct.Table.Table()
 			if tableName == "" {
 				cat.warnings = append(cat.warnings,
-					fmt.Sprintf("%s: skipped CREATE TABLE with empty table name", path))
+					fmt.Sprintf("%s: skipped CREATE TABLE with empty table name", label))
 				continue
 			}
 			tbl := extractTable(ct)
 			key := strings.ToLower(tbl.Name)
 			if idx, exists := cat.byName[key]; exists {
 				cat.warnings = append(cat.warnings,
-					fmt.Sprintf("%s: table %q defined more than once; using last definition", path, tbl.Name))
+					fmt.Sprintf("%s: table %q defined more than once; using last definition", label, tbl.Name))
 				cat.tables[idx] = tbl
 			} else {
 				cat.byName[key] = len(cat.tables)
@@ -75,11 +94,50 @@ func LoadFiles(paths []string) (*Catalog, error) {
 		if len(skippedTags) > 0 {
 			cat.warnings = append(cat.warnings,
 				fmt.Sprintf("%s: skipped %d non-CREATE TABLE statement(s): %s",
-					path, len(skippedTags), strings.Join(skippedTags, ", ")))
+					label, len(skippedTags), strings.Join(skippedTags, ", ")))
 		}
 	}
 
 	return cat, nil
+}
+
+// LoadFiles parses the SQL content of each file and builds a Catalog.
+// It is a convenience wrapper around Load for callers that only have
+// file paths.
+func LoadFiles(paths []string) (*Catalog, error) {
+	sources := make([]SchemaSource, len(paths))
+	for i, p := range paths {
+		sources[i] = SchemaSource{Path: p}
+	}
+	return Load(sources)
+}
+
+// readSource returns the SQL content for a single SchemaSource. For
+// file-based sources it validates the file size before reading.
+func readSource(src SchemaSource) (string, error) {
+	if src.Path != "" && src.SQL != "" {
+		return "", fmt.Errorf("schema source %s has both Path and SQL set; only one is allowed",
+			src.label())
+	}
+	if src.Path == "" {
+		return src.SQL, nil
+	}
+
+	label := src.label()
+
+	info, err := os.Stat(src.Path)
+	if err != nil {
+		return "", fmt.Errorf("stat schema file %s: %w", label, err)
+	}
+	if info.Size() > MaxSchemaFileSize {
+		return "", fmt.Errorf("schema file %s is too large (%d bytes, max %d)",
+			label, info.Size(), MaxSchemaFileSize)
+	}
+	data, err := os.ReadFile(src.Path)
+	if err != nil {
+		return "", fmt.Errorf("read schema file %s: %w", label, err)
+	}
+	return string(data), nil
 }
 
 // extractTable converts a parsed CREATE TABLE AST into the catalog's

--- a/internal/catalog/loader_test.go
+++ b/internal/catalog/loader_test.go
@@ -243,7 +243,7 @@ func TestLoadFiles(t *testing.T) {
 		{
 			name:        "parse error",
 			sql:         "CREAT TABLE bad (id INT8);",
-			expectedErr: "parse schema file",
+			expectedErr: "parse schema",
 		},
 	}
 
@@ -352,11 +352,114 @@ func TestLoadFilesFileTooLarge(t *testing.T) {
 
 	f, err := os.Create(path)
 	require.NoError(t, err)
-	require.NoError(t, f.Truncate(maxSchemaFileSize+1))
+	require.NoError(t, f.Truncate(MaxSchemaFileSize+1))
 	require.NoError(t, f.Close())
 
 	_, err = LoadFiles([]string{path})
 	require.ErrorContains(t, err, "too large")
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name          string
+		sources       []SchemaSource
+		tableName     string
+		expectedTable Table
+		expectedErr   string
+	}{
+		{
+			name: "raw SQL source",
+			sources: []SchemaSource{
+				{SQL: `CREATE TABLE t (id INT8 PRIMARY KEY, name TEXT)`, Label: "test"},
+			},
+			tableName: "t",
+			expectedTable: Table{
+				Name: "t",
+				Columns: []Column{
+					{Name: "id", Type: "INT8", Nullable: false},
+					{Name: "name", Type: "STRING", Nullable: true},
+				},
+				PrimaryKey: []string{"id"},
+				Indexes:    []Index{},
+			},
+		},
+		{
+			name: "empty raw SQL",
+			sources: []SchemaSource{
+				{SQL: "", Label: "empty"},
+			},
+		},
+		{
+			name: "raw SQL parse error",
+			sources: []SchemaSource{
+				{SQL: "CREAT TABLE bad (id INT8)", Label: "inline"},
+			},
+			expectedErr: "parse schema inline",
+		},
+		{
+			name: "path and SQL mutually exclusive",
+			sources: []SchemaSource{
+				{Path: "/some/file.sql", SQL: "CREATE TABLE t (id INT8)", Label: "both"},
+			},
+			expectedErr: "both Path and SQL set",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cat, err := Load(tc.sources)
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.tableName == "" {
+				require.Empty(t, cat.TableNames())
+				return
+			}
+
+			tbl, ok := cat.Table(tc.tableName)
+			require.True(t, ok, "table %q not found in catalog", tc.tableName)
+			require.Equal(t, tc.expectedTable, tbl)
+		})
+	}
+}
+
+func TestLoadMixedSources(t *testing.T) {
+	filePath := writeSQL(t, `CREATE TABLE a (id INT8 PRIMARY KEY)`)
+
+	cat, err := Load([]SchemaSource{
+		{Path: filePath},
+		{SQL: `CREATE TABLE b (id INT8 PRIMARY KEY)`, Label: "stdin"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, cat.TableNames())
+
+	_, ok := cat.Table("a")
+	require.True(t, ok)
+	_, ok = cat.Table("b")
+	require.True(t, ok)
+}
+
+func TestLoadLabelInWarnings(t *testing.T) {
+	cat, err := Load([]SchemaSource{
+		{SQL: "SELECT 1; CREATE TABLE t (id INT8 PRIMARY KEY)", Label: "stdin"},
+	})
+	require.NoError(t, err)
+	require.Len(t, cat.Warnings(), 1)
+	require.Contains(t, cat.Warnings()[0], "stdin")
+	require.Contains(t, cat.Warnings()[0], "skipped 1 non-CREATE TABLE")
+}
+
+func TestLoadDefaultLabelForUnlabeledSQL(t *testing.T) {
+	cat, err := Load([]SchemaSource{
+		{SQL: ""},
+	})
+	require.NoError(t, err)
+	require.Len(t, cat.Warnings(), 1)
+	require.Contains(t, cat.Warnings()[0], "<inline SQL>")
 }
 
 func strPtr(s string) *string {


### PR DESCRIPTION
describe: support --schema - to read DDL from stdin

Allow users to pipe schema DDL directly into `crdb-sql describe`
without saving to an intermediate file, e.g.:

    cockroach sql -e 'SHOW CREATE ALL TABLES' | crdb-sql describe users --schema -

Introduce `catalog.SchemaSource` to abstract over file paths and raw
SQL strings, and refactor `LoadFiles` as a thin wrapper around the new
`Load` function. The `-` sentinel is handled in `buildSchemaSources`,
which reads stdin once and rejects duplicate `-` flags.

Stdin input is bounded by the same 100 MB limit as file-based sources
via `io.LimitReader`. Empty sources produce a warning rather than being
silently skipped.

Resolves: #57