### PR TITLE
cmd: add list-tables subcommand

### DIFF
--- a/cmd/list_tables.go
+++ b/cmd/list_tables.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// listTablesResult is the JSON-serializable payload for the list-tables
+// command. It wraps the table names in a struct rather than marshalling
+// a bare slice so the shape can be extended (e.g. with column counts)
+// without breaking consumers.
+type listTablesResult struct {
+	Tables []string `json:"tables"`
+}
+
+// newListTablesCmd builds the `crdb-sql list-tables` subcommand. It
+// loads one or more schema files (--schema), parses them with the
+// CockroachDB parser, and lists all table names found.
+//
+// This is a Tier 2 (schema-file) command: it works offline but
+// requires at least one --schema file.
+func newListTablesCmd(state *rootState) *cobra.Command {
+	var schemaFiles []string
+
+	cmd := &cobra.Command{
+		Use:   "list-tables",
+		Short: "List tables from schema files",
+		Long: `Load CREATE TABLE definitions from one or more --schema files and
+print the names of all tables found.
+
+Schema files are plain SQL containing CREATE TABLE statements. You can
+obtain one from a running CockroachDB cluster with:
+
+  cockroach sql -e 'SHOW CREATE ALL TABLES' > schema.sql
+
+Then list the tables:
+
+  crdb-sql list-tables --schema schema.sql`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			if len(schemaFiles) == 0 {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("at least one --schema file is required"))
+			}
+
+			cat, err := catalog.LoadFiles(schemaFiles)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			for _, w := range cat.Warnings() {
+				baseEnv.Errors = append(baseEnv.Errors, output.Error{
+					Code:     "schema_warning",
+					Severity: output.SeverityWarning,
+					Message:  w,
+				})
+			}
+
+			tables := cat.TableNames()
+			if tables == nil {
+				tables = []string{}
+			}
+
+			data, err := json.Marshal(listTablesResult{Tables: tables})
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				for _, name := range tables {
+					if _, err := fmt.Fprintln(w, name); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&schemaFiles, "schema", nil,
+		"schema SQL file(s) to load (repeatable)")
+
+	return cmd
+}

--- a/cmd/list_tables_test.go
+++ b/cmd/list_tables_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func TestListTablesCmdTextOutput(t *testing.T) {
+	schema := writeSchemaFile(t, `
+		CREATE TABLE users (id INT8 PRIMARY KEY);
+		CREATE TABLE orders (id INT8 PRIMARY KEY);
+	`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--schema", schema})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Equal(t, "users\norders\n", got)
+}
+
+func TestListTablesCmdJSONOutput(t *testing.T) {
+	schema := writeSchemaFile(t, `
+		CREATE TABLE users (id INT8 PRIMARY KEY);
+		CREATE TABLE orders (id INT8 PRIMARY KEY);
+	`)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"list-tables", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"users", "orders"}, result.Tables)
+}
+
+func TestListTablesCmdMissingSchemaFlag(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "--schema")
+}
+
+func TestListTablesCmdEmptySchema(t *testing.T) {
+	schema := writeSchemaFile(t, `SELECT 1;`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Empty(t, result.Tables)
+
+	require.NotEmpty(t, env.Errors)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+}
+
+func TestListTablesCmdMultipleSchemaFiles(t *testing.T) {
+	schema1 := writeSchemaFile(t, `CREATE TABLE a (id INT8 PRIMARY KEY)`)
+	schema2 := writeSchemaFile(t, `CREATE TABLE b (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--schema", schema1, "--schema", schema2, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"a", "b"}, result.Tables)
+}
+
+func TestListTablesCmdWarningsPropagated(t *testing.T) {
+	schema := writeSchemaFile(t, `
+		SELECT 1;
+		CREATE TABLE t (id INT8 PRIMARY KEY);
+	`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--schema", schema, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotNil(t, env.Data)
+
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	require.Contains(t, env.Errors[0].Message, "skipped 1 non-CREATE TABLE")
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"t"}, result.Tables)
+}
+
+func TestListTablesCmdParseError(t *testing.T) {
+	schema := writeSchemaFile(t, `CREAT TABLE bad (id INT8)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"list-tables", "--schema", schema, "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "parse schema")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newFormatCmd(state))
 	root.AddCommand(newValidateCmd(state))
 	root.AddCommand(newDescribeCmd(state))
+	root.AddCommand(newListTablesCmd(state))
 	root.AddCommand(newRiskCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root


### PR DESCRIPTION
## Summary

Add a Tier 2 (schema-file) `list-tables` subcommand that loads CREATE TABLE
definitions from `--schema` files and lists all table names found. The JSON
payload uses a wrapper struct (`{"tables": [...]}`) rather than a bare slice
so the shape can be extended by downstream consumers (#17, #22) without
breaking compatibility.

- New file `cmd/list_tables.go` with `newListTablesCmd`
- New file `cmd/list_tables_test.go` with 7 tests (text, JSON, missing flag, empty schema, multiple files, warnings, parse error)
- Registration in `cmd/root.go`

Resolves #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>