### PR TITLE
explain: add crdb-sql explain and explain_sql MCP tool

### DIFF
--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newExplainCmd builds the `crdb-sql explain` subcommand. It runs
+// `EXPLAIN <stmt>` against the cluster identified by --dsn (or the
+// CRDB_DSN env var) and renders the resulting plan tree.
+//
+// Input modes mirror format/parse/validate: -e for inline SQL, a
+// positional file argument, or stdin. Output modes mirror ping: text
+// (the raw EXPLAIN tabular rows) and json (structured envelope with
+// header, plan tree, and raw rows).
+//
+// This is a Tier 3 (connected) command. Read-only safety enforcement
+// (statement allowlist, transaction wrapping) is deferred to issue #21.
+func newExplainCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "explain [file]",
+		Short: "Run EXPLAIN against the cluster and return the plan as structured JSON",
+		Long: `Connect to a CockroachDB cluster and run EXPLAIN against the supplied
+DML statement. The wrapped statement is not executed. Input is read from
+the -e flag (inline SQL), a positional file argument, or stdin. The
+connection string is read from --dsn or CRDB_DSN (flag wins).`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			sql = strings.TrimSpace(sql)
+
+			if state.dsn == "" {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
+			}
+
+			mgr := conn.NewManager(state.dsn)
+			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
+
+			result, err := mgr.Explain(cmd.Context(), sql)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			baseEnv.ConnectionStatus = output.ConnectionConnected
+
+			data, err := json.Marshal(result)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				for _, row := range result.RawRows {
+					if _, werr := fmt.Fprintln(w, row); werr != nil {
+						return werr
+					}
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to explain")
+
+	return cmd
+}

--- a/cmd/explain_test.go
+++ b/cmd/explain_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// runExplain executes `crdb-sql explain` with the supplied args and
+// stdin, returning the captured stdout buffer and the Execute error.
+// Tests use this to keep setup boilerplate out of the table.
+func runExplain(t *testing.T, stdin string, args ...string) (*bytes.Buffer, error) {
+	t.Helper()
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(append([]string{"explain"}, args...))
+	return &stdout, root.Execute()
+}
+
+// TestExplainCmdNoDSN verifies that explain without a DSN fails
+// before any cluster contact, returning a structured error that names
+// both the flag and the env var.
+func TestExplainCmdNoDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	_, err := runExplain(t, "", "-e", "SELECT 1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no connection string")
+}
+
+// TestExplainCmdNoDSNJSON verifies the JSON envelope shape when no DSN
+// is configured: tier=connected, status=disconnected, an error entry
+// pointing the user at --dsn / CRDB_DSN, and no Data payload.
+func TestExplainCmdNoDSNJSON(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplain(t, "", "--output", "json", "-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "--dsn")
+	require.Contains(t, env.Errors[0].Message, "CRDB_DSN")
+	require.Empty(t, env.Data)
+}
+
+// TestExplainCmdNoInput verifies that an invocation with no -e, no
+// file, and no piped stdin reports an empty-input error rather than
+// attempting an EXPLAIN of the empty string.
+func TestExplainCmdNoInput(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runExplain(t, "", "--output", "json")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	// The exact message comes from sqlinput.ReadSQL; assert the salient
+	// substring rather than the full string to avoid coupling to its
+	// wording.
+	require.Contains(t, env.Errors[0].Message, "no SQL input")
+}
+
+// TestExplainCmdReachesConnectAttempt verifies that with a SQL input
+// and an unreachable DSN, explain gets past input parsing and DSN
+// validation and fails at the connect step. The exact error mirrors
+// ping's "connect to CockroachDB" wording so this also locks in that
+// the same conn.Manager path is used.
+func TestExplainCmdReachesConnectAttempt(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplain(t, "", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1",
+		"-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.NotContains(t, env.Errors[0].Message, "no connection string")
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+}
+
+// TestExplainCmdReadsFromFileArg verifies that a positional file
+// argument is plumbed through sqlinput.ReadSQL and reaches the connect
+// step (rather than failing at input resolution). Asserting the same
+// "connect to CockroachDB" error that the -e path produces locks in
+// that file input takes the same code path.
+func TestExplainCmdReadsFromFileArg(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "q.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("SELECT 1"), 0644))
+
+	stdout, err := runExplain(t, "", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1",
+		sqlFile)
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+		"file arg must reach the connect step, not fail at input parsing")
+}
+
+// TestExplainCmdReadsFromStdin verifies that piped SQL on stdin reaches
+// the connect step. Same shape as TestExplainCmdReadsFromFileArg but
+// covers the third documented input mode.
+func TestExplainCmdReadsFromStdin(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplain(t, "SELECT 1\n", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+		"stdin input must reach the connect step, not fail at input parsing")
+}
+
+// TestExplainCmdRejectsExtraArgs verifies that more than one positional
+// argument is rejected (the optional positional is the SQL file).
+func TestExplainCmdRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"explain", "file1.sql", "file2.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newDescribeCmd(state))
 	root.AddCommand(newListTablesCmd(state))
 	root.AddCommand(newRiskCmd(state))
+	root.AddCommand(newExplainCmd(state))
 	root.AddCommand(newMCPCmd())
 	return root
 }

--- a/internal/conn/explain_parse.go
+++ b/internal/conn/explain_parse.go
@@ -1,0 +1,216 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PlanNode is one operator in a CockroachDB EXPLAIN tree. Op is the
+// operator name with the leading bullet stripped (e.g. "scan", "filter",
+// "render"). Attrs holds the per-operator key/value attributes the
+// planner emits underneath the operator (e.g. "table": "t@primary",
+// "spans": "FULL SCAN"). Children are the direct child operators in
+// execution order, following EXPLAIN's tree-drawing glyphs.
+//
+// Both Attrs and Children use omitempty so leaf nodes and attribute-free
+// operators serialize to a compact JSON shape.
+type PlanNode struct {
+	Op       string            `json:"op"`
+	Attrs    map[string]string `json:"attrs,omitempty"`
+	Children []PlanNode        `json:"children,omitempty"`
+}
+
+// parseExplainTree converts the tabular `info` column rows of a CRDB
+// EXPLAIN result into structured form.
+//
+// Inputs:
+//   - rows: the contents of EXPLAIN's single `info` column, one slice
+//     entry per result row, in the order the cluster returned them.
+//
+// Outputs:
+//   - header: the leading `key: value` lines (typically `distribution`
+//     and `vectorized`) that precede the operator tree. Nil when the
+//     plan has no header.
+//   - plan: the operator forest. Most plans have one root, but defensive
+//     [] avoids assuming uniqueness.
+//   - err: non-nil only when a row's structure cannot be classified.
+//     Unrecognized rows fail loudly rather than getting silently
+//     dropped, so a CRDB upgrade that adds new EXPLAIN syntax surfaces
+//     here instead of producing a quietly-incomplete tree.
+//
+// Format reference: CRDB EXPLAIN emits a tree using the glyphs `•`
+// (operator marker), `│` (vertical continuation), `└──`/`├──` (last and
+// non-last child connectors). Header rows appear first, optionally
+// terminated by a `·` separator, then the operator tree. An operator at
+// rune-column D has its attribute lines indented two columns further
+// (D+2) and its child operators four columns further (D+4). Attribute
+// owners are resolved by column rather than by recency so that
+// continuation pipes from ancestors (e.g. `│     table: t1`, where the
+// pipe belongs to a still-open join above) do not steal attributes from
+// the most recently opened operator.
+func parseExplainTree(rows []string) (map[string]string, []PlanNode, error) {
+	if len(rows) == 0 {
+		return nil, nil, nil
+	}
+
+	var (
+		header   map[string]string
+		roots    []PlanNode
+		stack    []*stackEntry
+		inHeader = true
+	)
+
+	for i, raw := range rows {
+		line := strings.TrimRight(raw, " \t")
+		if line == "" || strings.TrimSpace(line) == "·" {
+			// Blank lines and the `·` separator end the header phase
+			// and otherwise act as visual separators inside the tree.
+			inHeader = false
+			continue
+		}
+
+		if opCol, op, ok := parseOperatorLine(line); ok {
+			inHeader = false
+			if op == "" {
+				return nil, nil, fmt.Errorf("explain row %d: bullet without operator name: %q", i, raw)
+			}
+			node := PlanNode{Op: op}
+			// Pop entries at or deeper than this column; the new
+			// operator either replaces a sibling at the same column
+			// or starts a deeper subtree.
+			for len(stack) > 0 && stack[len(stack)-1].col >= opCol {
+				stack = stack[:len(stack)-1]
+			}
+			if len(stack) == 0 {
+				roots = append(roots, node)
+				stack = append(stack, &stackEntry{col: opCol, node: &roots[len(roots)-1]})
+			} else {
+				parent := stack[len(stack)-1].node
+				parent.Children = append(parent.Children, node)
+				stack = append(stack, &stackEntry{
+					col:  opCol,
+					node: &parent.Children[len(parent.Children)-1],
+				})
+			}
+			continue
+		}
+
+		contentCol, content := findContent(line)
+		if content == "" {
+			// Pure prefix (e.g. a `│` continuation row); skip.
+			continue
+		}
+
+		if inHeader {
+			k, v, ok := splitKV(content)
+			if !ok {
+				return nil, nil, fmt.Errorf("explain row %d: header line is not key: value: %q", i, raw)
+			}
+			if header == nil {
+				header = make(map[string]string)
+			}
+			header[k] = v
+			continue
+		}
+
+		owner := ownerByColumn(stack, contentCol-2)
+		if owner == nil {
+			return nil, nil, fmt.Errorf(
+				"explain row %d: attribute at column %d has no open operator at column %d (raw: %q)",
+				i, contentCol, contentCol-2, raw,
+			)
+		}
+		k, v, ok := splitKV(content)
+		if !ok {
+			return nil, nil, fmt.Errorf("explain row %d: attribute is not key: value: %q", i, raw)
+		}
+		if owner.Attrs == nil {
+			owner.Attrs = make(map[string]string)
+		}
+		owner.Attrs[k] = v
+	}
+
+	return header, roots, nil
+}
+
+// stackEntry records one open operator on the depth stack. col is the
+// rune column at which its `•` glyph appears; node is a pointer into the
+// growing tree so further attributes and children can be attached.
+type stackEntry struct {
+	col  int
+	node *PlanNode
+}
+
+// isTreeGlyph reports whether r is one of the rune-wide glyphs CRDB uses
+// to draw the operator tree. Treating spaces as glyphs lets the parser
+// walk a mixed prefix like `│     table:` or `└── • scan` without caring
+// about the order of its components.
+func isTreeGlyph(r rune) bool {
+	switch r {
+	case ' ', '\t', '│', '└', '├', '─':
+		return true
+	}
+	return false
+}
+
+// parseOperatorLine returns (col, op, true) if line is a `<prefix>• <op>`
+// operator row, where col is the rune column of the `•` glyph. It
+// returns ("", false) if any non-glyph rune precedes the bullet, or if
+// no bullet is present at all — those are attribute or header rows that
+// the caller handles separately.
+func parseOperatorLine(line string) (int, string, bool) {
+	for i, r := range []rune(line) {
+		if r == '•' {
+			return i, strings.TrimSpace(string([]rune(line)[i+1:])), true
+		}
+		if !isTreeGlyph(r) {
+			return 0, "", false
+		}
+	}
+	return 0, "", false
+}
+
+// findContent walks past leading tree glyphs and whitespace and returns
+// the rune column of the first content rune together with the trimmed
+// content. When the entire line is glyphs/whitespace the column is -1
+// and the content is empty (a continuation-only row that the parser
+// skips).
+func findContent(line string) (int, string) {
+	runes := []rune(line)
+	for i, r := range runes {
+		if isTreeGlyph(r) {
+			continue
+		}
+		return i, strings.TrimSpace(string(runes[i:]))
+	}
+	return -1, ""
+}
+
+// ownerByColumn returns the open operator whose `•` is at the requested
+// column, or nil if none is open at that column. Search is from the top
+// of the stack so the most deeply nested matching operator wins (matters
+// only if a future change ever pushes duplicates at the same column).
+func ownerByColumn(stack []*stackEntry, col int) *PlanNode {
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i].col == col {
+			return stack[i].node
+		}
+	}
+	return nil
+}
+
+// splitKV splits "key: value" on the first colon, trimming whitespace
+// around both halves. Returns false when no colon is present so the
+// caller can decide whether to treat that as an error or skip.
+func splitKV(s string) (string, string, bool) {
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:]), true
+}

--- a/internal/conn/explain_parse_test.go
+++ b/internal/conn/explain_parse_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseExplainTree exercises the EXPLAIN tree parser against
+// representative shapes produced by CockroachDB's default EXPLAIN: the
+// degenerate empty result, header-only output, single-operator plans,
+// nested operators connected via `└──`, and multi-child join shapes
+// connected via `├──`/`└──`.
+func TestParseExplainTree(t *testing.T) {
+	tests := []struct {
+		name           string
+		rows           []string
+		expectedHeader map[string]string
+		expectedPlan   []PlanNode
+	}{
+		{
+			name:           "empty rows",
+			rows:           nil,
+			expectedHeader: nil,
+			expectedPlan:   nil,
+		},
+		{
+			name: "header only",
+			rows: []string{
+				"distribution: local",
+				"vectorized: true",
+			},
+			expectedHeader: map[string]string{
+				"distribution": "local",
+				"vectorized":   "true",
+			},
+			expectedPlan: nil,
+		},
+		{
+			name: "single operator no attrs",
+			rows: []string{
+				"distribution: local",
+				"vectorized: true",
+				"·",
+				"• values",
+			},
+			expectedHeader: map[string]string{"distribution": "local", "vectorized": "true"},
+			expectedPlan:   []PlanNode{{Op: "values"}},
+		},
+		{
+			name: "single operator with pipe-aligned attrs",
+			rows: []string{
+				"• scan",
+				"│ table: t@primary",
+				"│ spans: FULL SCAN",
+			},
+			expectedPlan: []PlanNode{
+				{
+					Op: "scan",
+					Attrs: map[string]string{
+						"table": "t@primary",
+						"spans": "FULL SCAN",
+					},
+				},
+			},
+		},
+		{
+			name: "two-level nest with last-child connector",
+			rows: []string{
+				"• render",
+				"│ estimated row count: 7",
+				"│",
+				"└── • scan",
+				"      table: t@primary",
+				"      spans: FULL SCAN",
+			},
+			expectedPlan: []PlanNode{
+				{
+					Op:    "render",
+					Attrs: map[string]string{"estimated row count": "7"},
+					Children: []PlanNode{
+						{
+							Op: "scan",
+							Attrs: map[string]string{
+								"table": "t@primary",
+								"spans": "FULL SCAN",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter wrapping scan",
+			rows: []string{
+				"distribution: local",
+				"vectorized: true",
+				"·",
+				"• filter",
+				"│ filter: a > 5",
+				"│",
+				"└── • scan",
+				"      table: t@primary",
+				"      spans: FULL SCAN",
+			},
+			expectedHeader: map[string]string{"distribution": "local", "vectorized": "true"},
+			expectedPlan: []PlanNode{
+				{
+					Op:    "filter",
+					Attrs: map[string]string{"filter": "a > 5"},
+					Children: []PlanNode{
+						{
+							Op: "scan",
+							Attrs: map[string]string{
+								"table": "t@primary",
+								"spans": "FULL SCAN",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two siblings under join",
+			rows: []string{
+				"• hash join",
+				"│ equality: (a) = (b)",
+				"│",
+				"├── • scan",
+				"│     table: t1@primary",
+				"│",
+				"└── • scan",
+				"      table: t2@primary",
+			},
+			expectedPlan: []PlanNode{
+				{
+					Op:    "hash join",
+					Attrs: map[string]string{"equality": "(a) = (b)"},
+					Children: []PlanNode{
+						{Op: "scan", Attrs: map[string]string{"table": "t1@primary"}},
+						{Op: "scan", Attrs: map[string]string{"table": "t2@primary"}},
+					},
+				},
+			},
+		},
+		{
+			// Locks in the column-based ownership rule: the `│` glyphs
+			// at column 0 of the t1 child's attribute rows belong to
+			// the still-open join above, not to the t1 scan. A naïve
+			// "owner is the most recently opened operator" rule would
+			// pass the simpler one-attr-per-child shape but mis-route
+			// here.
+			name: "non-last child with multiple attributes preserves owner-by-column",
+			rows: []string{
+				"• hash join",
+				"│ equality: (a) = (b)",
+				"│",
+				"├── • scan",
+				"│     table: t1@primary",
+				"│     spans: FULL SCAN",
+				"│     estimated row count: 1000",
+				"│",
+				"└── • scan",
+				"      table: t2@primary",
+				"      spans: FULL SCAN",
+			},
+			expectedPlan: []PlanNode{
+				{
+					Op:    "hash join",
+					Attrs: map[string]string{"equality": "(a) = (b)"},
+					Children: []PlanNode{
+						{
+							Op: "scan",
+							Attrs: map[string]string{
+								"table":               "t1@primary",
+								"spans":               "FULL SCAN",
+								"estimated row count": "1000",
+							},
+						},
+						{
+							Op: "scan",
+							Attrs: map[string]string{
+								"table": "t2@primary",
+								"spans": "FULL SCAN",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "attribute value containing colon",
+			rows: []string{
+				"• scan",
+				"│ spans: /1/foo:bar",
+			},
+			expectedPlan: []PlanNode{
+				{Op: "scan", Attrs: map[string]string{"spans": "/1/foo:bar"}},
+			},
+		},
+		{
+			name: "three-level nest",
+			rows: []string{
+				"• limit",
+				"│ count: 10",
+				"│",
+				"└── • sort",
+				"    │ order: +a",
+				"    │",
+				"    └── • scan",
+				"          table: t@primary",
+			},
+			expectedPlan: []PlanNode{
+				{
+					Op:    "limit",
+					Attrs: map[string]string{"count": "10"},
+					Children: []PlanNode{
+						{
+							Op:    "sort",
+							Attrs: map[string]string{"order": "+a"},
+							Children: []PlanNode{
+								{Op: "scan", Attrs: map[string]string{"table": "t@primary"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header, plan, err := parseExplainTree(tc.rows)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedHeader, header)
+			require.Equal(t, tc.expectedPlan, plan)
+		})
+	}
+}
+
+// TestParseExplainTreeErrors covers the loud-failure contract: rows
+// that don't fit the operator/attribute/separator shape return an error
+// rather than being silently dropped.
+func TestParseExplainTreeErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		rows        []string
+		expectedErr string
+	}{
+		{
+			name:        "bullet without operator name",
+			rows:        []string{"•   "},
+			expectedErr: "bullet without operator name",
+		},
+		{
+			name:        "header line missing colon",
+			rows:        []string{"not a header"},
+			expectedErr: "header line is not key: value",
+		},
+		{
+			name: "orphan attribute after separator",
+			rows: []string{
+				"·",
+				"  table: t@primary",
+			},
+			expectedErr: "has no open operator at column 0",
+		},
+		{
+			name: "attribute over-indented relative to last operator",
+			rows: []string{
+				"• scan",
+				"      │ table: t@primary",
+			},
+			expectedErr: "has no open operator at column 6",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseExplainTree(tc.rows)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -38,6 +38,21 @@ type ClusterInfo struct {
 	Version   string `json:"version"`
 }
 
+// ExplainResult is the structured form of a default `EXPLAIN <stmt>`.
+//
+// Header captures the leading `key: value` rows that appear before the
+// operator tree (typically distribution and vectorized). Plan is the
+// parsed operator forest. RawRows is the original tabular output the
+// cluster returned, retained so the CLI text mode can render the plan
+// exactly as `cockroach sql` would and so agents can re-parse if they
+// need to. ExplainResult is only constructed on the success path; any
+// failure (query, scan, parse) returns the zero value plus an error.
+type ExplainResult struct {
+	Header  map[string]string `json:"header,omitempty"`
+	Plan    []PlanNode        `json:"plan"`
+	RawRows []string          `json:"raw_rows"`
+}
+
 // Manager manages a lazy pgwire connection to a CockroachDB cluster.
 // It stores a DSN at construction time and defers the actual TCP
 // handshake until the first method that needs a live connection.
@@ -81,6 +96,64 @@ func (m *Manager) Ping(ctx context.Context) (ClusterInfo, error) {
 		return ClusterInfo{}, fmt.Errorf("query cluster info: %w", err)
 	}
 	return info, nil
+}
+
+// Explain runs `EXPLAIN <sql>` against the cluster and returns the
+// parsed plan tree alongside the raw tabular output.
+//
+// EXPLAIN (without ANALYZE) does not execute the wrapped statement, so
+// no read-only safety wrapper is applied here; the dedicated allowlist
+// (issue #21) layers on top. Cluster errors (syntax in the wrapped
+// statement, perm denied, etc.) are returned wrapped; callers surface
+// them as generic envelope errors today. SQLSTATE-aware enrichment for
+// pgwire errors is a future enhancement, not a current contract.
+//
+// On any query/scan/parse failure after a successful connect, the
+// underlying connection is closed and the Manager reverts to its
+// pre-connect state, mirroring Ping's recovery contract.
+func (m *Manager) Explain(ctx context.Context, sql string) (ExplainResult, error) {
+	if err := m.connect(ctx); err != nil {
+		return ExplainResult{}, err
+	}
+
+	result, err := m.runExplain(ctx, sql)
+	if err != nil {
+		m.conn.Close(ctx) //nolint:errcheck // best-effort cleanup
+		m.conn = nil
+		return ExplainResult{}, err
+	}
+	return result, nil
+}
+
+// runExplain is the inner half of Explain that owns the query/scan/parse
+// pipeline. Splitting it out lets Explain centralize the connection
+// recovery: any error returned here triggers the same close-and-nil
+// sequence in the caller, so the three failure modes (Query, Scan,
+// rows.Err, parse) cannot drift apart.
+func (m *Manager) runExplain(ctx context.Context, sql string) (ExplainResult, error) {
+	rows, err := m.conn.Query(ctx, "EXPLAIN "+sql)
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("run EXPLAIN: %w", err)
+	}
+	defer rows.Close()
+
+	var raw []string
+	for rows.Next() {
+		var info string
+		if err := rows.Scan(&info); err != nil {
+			return ExplainResult{}, fmt.Errorf("scan EXPLAIN row: %w", err)
+		}
+		raw = append(raw, info)
+	}
+	if err := rows.Err(); err != nil {
+		return ExplainResult{}, fmt.Errorf("read EXPLAIN rows: %w", err)
+	}
+
+	header, plan, err := parseExplainTree(raw)
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("parse EXPLAIN output: %w", err)
+	}
+	return ExplainResult{Header: header, Plan: plan, RawRows: raw}, nil
 }
 
 // Close closes the underlying connection if one was established.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,12 +5,13 @@
 
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
-// The server registers a health-check tool (ping), three Tier 1 SQL
-// tools (parse_sql, validate_sql, format_sql) via the tools subpackage,
-// and a risk-detection tool (detect_risky_query). Keeping construction
-// pure (no transport, no I/O) lets the cmd layer pick a transport —
-// currently just stdio — and lets tests exercise individual tool
-// handlers directly.
+// The server registers a health-check tool (ping), four Tier 1 SQL
+// tools (parse_sql, validate_sql, format_sql, detect_risky_query) via
+// the tools subpackage, and the Tier 3 explain_sql tool that runs
+// EXPLAIN against a live cluster. Keeping construction pure (no
+// transport, no I/O) lets the cmd layer pick a transport — currently
+// just stdio — and lets tests exercise individual tool handlers
+// directly.
 //
 // Versions are passed in by the caller rather than read from
 // debug.ReadBuildInfo here, so this package stays free of
@@ -60,6 +61,7 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion))
 	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion))
 	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion))
+	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion))
 	return s
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -78,7 +78,7 @@ func TestNewServerRegistersTools(t *testing.T) {
 	require.NotNil(t, s)
 	registered := s.ListTools()
 
-	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, tools.DetectRiskyQueryToolName} {
+	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, tools.DetectRiskyQueryToolName, tools.ExplainSQLToolName} {
 		require.Contains(t, registered, name)
 		require.NotNil(t, registered[name].Handler,
 			"%s must be registered with a non-nil handler", name)

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// ExplainSQLTool returns the MCP tool definition for explain_sql. The
+// `dsn` parameter is required because MCP sessions are stateless: the
+// server has no per-client connection to reuse, so each call carries
+// the connection string. Credentials are never logged or echoed back.
+func ExplainSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		ExplainSQLToolName,
+		mcp.WithDescription(`Run EXPLAIN against a CockroachDB cluster and return the plan as structured JSON. The wrapped statement is not executed (this is plain EXPLAIN, not EXPLAIN ANALYZE). Returns the operator tree, header (distribution/vectorized), and the raw tabular rows.`),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL DML statement to explain")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+	)
+}
+
+// ExplainSQLHandler returns the handler for the explain_sql tool. The
+// envelope's ConnectionStatus starts disconnected and flips to connected
+// only after a successful EXPLAIN, so partial-failure envelopes report
+// the actual reached state. Cluster-side errors (timeouts, syntax in the
+// wrapped statement, perm denied) populate env.Errors; tool-level errors
+// (missing parameters) are returned as mcp.NewToolResultError per the
+// discipline documented in tools.go.
+func ExplainSQLHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractRequiredString(req, "sql")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		dsn, toolErr := extractRequiredString(req, "dsn")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := connectedEnvelope(parserVersion)
+
+		mgr := conn.NewManager(dsn)
+		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
+
+		result, err := mgr.Explain(ctx, sql)
+		if err != nil {
+			env.Errors = []output.Error{{
+				Code:     "internal_error",
+				Severity: output.SeverityError,
+				Message:  err.Error(),
+			}}
+			return envelopeResult(env)
+		}
+
+		env.ConnectionStatus = output.ConnectionConnected
+		data, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -4,7 +4,11 @@
 // included in the /LICENSE file.
 
 // Package tools provides MCP tool handler constructors for the SQL
-// tools: parse_sql, validate_sql, format_sql, and detect_risky_query.
+// tools. The Tier 1 (zero-config) tools are parse_sql, validate_sql,
+// format_sql, and detect_risky_query; explain_sql is the only Tier 3
+// (connected) tool, requiring a per-call DSN since the MCP server holds
+// no per-session connection state.
+//
 // Each handler returns the same output.Envelope JSON shape that the CLI
 // emits under --output=json, so MCP clients get structured errors,
 // parser version, and tier metadata consistent with the CLI surface.
@@ -32,27 +36,36 @@ const (
 	ValidateSQLToolName      = "validate_sql"
 	FormatSQLToolName        = "format_sql"
 	DetectRiskyQueryToolName = "detect_risky_query"
+	ExplainSQLToolName       = "explain_sql"
 )
 
-// extractSQL validates and returns the required "sql" string parameter
-// from an MCP tool request. Leading and trailing whitespace is trimmed
-// so all handlers behave consistently. On success, the returned
-// *mcp.CallToolResult is nil. On failure (missing, wrong type, empty),
-// it is a pre-built tool error that the caller should return immediately.
-func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
-	raw, exists := req.GetArguments()["sql"]
+// extractRequiredString validates and returns a required string
+// parameter from an MCP tool request. Leading and trailing whitespace
+// is trimmed so all handlers behave consistently. On success, the
+// returned *mcp.CallToolResult is nil. On failure (missing, wrong type,
+// empty after trimming), it is a pre-built tool error that the caller
+// should return immediately.
+func extractRequiredString(req mcp.CallToolRequest, name string) (string, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[name]
 	if !exists {
-		return "", mcp.NewToolResultError("sql parameter is required")
+		return "", mcp.NewToolResultError(fmt.Sprintf("%s parameter is required", name))
 	}
-	sql, ok := raw.(string)
+	s, ok := raw.(string)
 	if !ok {
-		return "", mcp.NewToolResultError(fmt.Sprintf("sql parameter must be a string, got %T", raw))
+		return "", mcp.NewToolResultError(fmt.Sprintf("%s parameter must be a string, got %T", name, raw))
 	}
-	sql = strings.TrimSpace(sql)
-	if sql == "" {
-		return "", mcp.NewToolResultError("sql parameter must not be empty")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", mcp.NewToolResultError(fmt.Sprintf("%s parameter must not be empty", name))
 	}
-	return sql, nil
+	return s, nil
+}
+
+// extractSQL is a thin convenience wrapper around extractRequiredString
+// for the common "sql" parameter, kept so the four SQL-only handlers
+// (parse, validate, format, risk) stay terse.
+func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
+	return extractRequiredString(req, "sql")
 }
 
 // baseEnvelope returns a pre-populated Envelope for Tier 1 (zero-config,
@@ -60,6 +73,18 @@ func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
 func baseEnvelope(parserVersion string) output.Envelope {
 	return output.Envelope{
 		Tier:             output.TierZeroConfig,
+		ParserVersion:    parserVersion,
+		ConnectionStatus: output.ConnectionDisconnected,
+	}
+}
+
+// connectedEnvelope returns a pre-populated Envelope for Tier 3
+// (connected) tools. ConnectionStatus starts disconnected and is flipped
+// to connected by the handler after a successful round-trip to the
+// cluster, so a partial failure surfaces with the correct state.
+func connectedEnvelope(parserVersion string) output.Envelope {
+	return output.Envelope{
+		Tier:             output.TierConnected,
 		ParserVersion:    parserVersion,
 		ConnectionStatus: output.ConnectionDisconnected,
 	}

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -34,6 +34,62 @@ func requireEnvelope(t *testing.T, res *mcpgo.CallToolResult) output.Envelope {
 	return env
 }
 
+// TestExplainSQLHandlerParameterValidation covers the tool-level error
+// path for explain_sql. Cluster round-trips are not exercised here
+// because the handler does not gain new logic beyond parameter
+// validation and conn.Manager wiring; an end-to-end smoke is documented
+// in the issue verification plan.
+func TestExplainSQLHandlerParameterValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing both params", args: map[string]any{}},
+		{name: "missing dsn", args: map[string]any{"sql": "SELECT 1"}},
+		{name: "missing sql", args: map[string]any{"dsn": "postgres://h:26257/db"}},
+		{name: "empty sql", args: map[string]any{"sql": "", "dsn": "postgres://h:26257/db"}},
+		{name: "empty dsn", args: map[string]any{"sql": "SELECT 1", "dsn": ""}},
+		{name: "wrong type sql", args: map[string]any{"sql": 1, "dsn": "postgres://h:26257/db"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExplainSQLHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.True(t, res.IsError, "expected tool-level error")
+		})
+	}
+}
+
+// TestExplainSQLHandlerConnectionFailureSurfacesEnvelopeError verifies
+// that when the cluster is unreachable, the handler returns a successful
+// MCP tool result whose envelope carries the error — not a tool-level
+// error. This is the discipline documented in tools.go: SQL/cluster
+// problems live in the envelope so agents can read them uniformly.
+func TestExplainSQLHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql": "SELECT 1",
+		// Unreachable host — connection will fail before any query.
+		"dsn": "postgres://nope:1/db?connect_timeout=1",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+		"failed connect must leave status disconnected")
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+}
+
 func TestExtractSQL(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Run EXPLAIN against a CockroachDB cluster and return the plan as
structured JSON. Adds a Tier 3 (connected) capability paired across
the CLI and MCP surfaces so agents have a uniform path from validate
to explain to (eventually) execute.

Three pieces land together:

- **internal/conn**: a pure tree parser converts EXPLAIN's tabular
  `info` rows into a nested `{op, attrs, children}` forest. Operator
  ownership of attribute lines is resolved by rune column rather
  than recency so continuation pipes from still-open ancestors
  (e.g. `│     table: t1` under a join) do not steal attributes
  from the most recently opened operator. `Manager.Explain` wraps
  the round-trip; any query/scan/parse failure routes through one
  cleanup site that closes and nils the connection (mirroring
  `Ping`'s recovery contract). EXPLAIN (without ANALYZE) does not
  execute the wrapped statement, so no read-only safety wrapper is
  layered here; that is the dedicated job of #21.

- **internal/mcp/tools**: a new `explain_sql` tool mirrors the CLI's
  output shape inside the standard envelope. `extractSQL` is
  generalized to `extractRequiredString` so the new `dsn` parameter
  reuses the same validation, and `connectedEnvelope` joins
  `baseEnvelope` as the Tier 3 counterpart.

- **cmd**: a new `explain` subcommand wires `conn.Manager.Explain`
  into the standard `-e | file | stdin` input triad and the existing
  DSN/conn lifecycle, mirroring `ping` for the connected path and
  `format` for the input path. Text mode prints the raw EXPLAIN
  rows verbatim; JSON mode emits the full envelope with header,
  plan tree, and raw rows.

Resolves: #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)