### PR TITLE
validate: add table name resolution against --schema catalog

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -67,16 +67,10 @@ Use --schema - to read DDL from stdin, allowing direct piping:
 
 			cat, err := catalog.Load(sources)
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return renderSchemaLoadError(r, baseEnv, err)
 			}
 
-			for _, w := range cat.Warnings() {
-				baseEnv.Errors = append(baseEnv.Errors, output.Error{
-					Code:     "schema_warning",
-					Severity: output.SeverityWarning,
-					Message:  w,
-				})
-			}
+			appendSchemaWarnings(&baseEnv, cat)
 
 			tableName := args[0]
 			tbl, ok := cat.Table(tableName)

--- a/cmd/list_tables.go
+++ b/cmd/list_tables.go
@@ -61,16 +61,10 @@ Then list the tables:
 
 			cat, err := catalog.LoadFiles(schemaFiles)
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return renderSchemaLoadError(r, baseEnv, err)
 			}
 
-			for _, w := range cat.Warnings() {
-				baseEnv.Errors = append(baseEnv.Errors, output.Error{
-					Code:     "schema_warning",
-					Severity: output.SeverityWarning,
-					Message:  w,
-				})
-			}
+			appendSchemaWarnings(&baseEnv, cat)
 
 			tables := cat.TableNames()
 			if tables == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,10 +14,14 @@ package cmd
 
 import (
 	"context"
+	"io"
 	"os"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
 	"github.com/spf13/cobra"
 
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
@@ -143,4 +147,54 @@ func newEnvelope(
 	}
 	env.ParserVersion = parserVer
 	return r, env, nil
+}
+
+// appendSchemaWarnings copies any non-fatal issues recorded by the
+// catalog loader (skipped statements, duplicate definitions) into env
+// as warning-severity envelope entries. Subcommands that consume a
+// catalog call this once after Load/LoadFiles so agents see the
+// loader's diagnostics in the same Errors stream as everything else.
+func appendSchemaWarnings(env *output.Envelope, cat *catalog.Catalog) {
+	for _, w := range cat.Warnings() {
+		env.Errors = append(env.Errors, output.Error{
+			Code:     "schema_warning",
+			Severity: output.SeverityWarning,
+			Message:  w,
+		})
+	}
+}
+
+// renderSchemaLoadError surfaces a catalog.Load/LoadFiles failure as
+// a structured envelope error rather than a generic "internal_error".
+// When the underlying cause carries a SQLSTATE (typically a 42601
+// parse error from a malformed schema file), that code is propagated
+// so agents can branch on it; otherwise the error is tagged
+// "schema_load_error" for I/O and validation failures.
+//
+// Returns output.ErrRendered so the caller signals failure to main.go
+// the same way renderDiagErrors does.
+func renderSchemaLoadError(r output.Renderer, env output.Envelope, err error) error {
+	// pgerror.GetPGCode returns "XXUUU" (Uncategorized) when the
+	// error chain has no SQLSTATE attached — typical for I/O errors
+	// from os.Stat / os.ReadFile. Treat that as "no real code" so we
+	// fall through to the dedicated schema_load_error tag.
+	code := pgerror.GetPGCode(err).String()
+	if code == "" || code == "XXUUU" {
+		code = "schema_load_error"
+	}
+	category := diag.CategoryForCode(code)
+	env.Errors = append(env.Errors, output.Error{
+		Code:     code,
+		Severity: output.SeverityError,
+		Message:  err.Error(),
+		Category: category,
+	})
+	env.Data = nil
+	if rerr := r.Render(env, func(w io.Writer) error {
+		_, werr := io.WriteString(w, err.Error()+"\n")
+		return werr
+	}); rerr != nil {
+		return rerr
+	}
+	return output.ErrRendered
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -14,10 +14,49 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/semcheck"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// validateChecks records which validation phases ran on the success
+// path. Each field is "ok" (ran and passed) or "skipped" (prerequisite
+// missing). A failing phase aborts the command via an envelope error,
+// so "fail" never appears here.
+type validateChecks struct {
+	Syntax         string `json:"syntax"`
+	TypeCheck      string `json:"type_check"`
+	NameResolution string `json:"name_resolution"`
+}
+
+// validateResult is the JSON payload emitted by `crdb-sql validate` on
+// the success path. The expanded shape (vs. a bare {valid: true})
+// exposes which phases ran, so agents can tell whether name resolution
+// was skipped due to a missing --schema. Adding a phase means adding a
+// field here and updating the rendering code to set it.
+type validateResult struct {
+	Valid  bool           `json:"valid"`
+	Checks validateChecks `json:"checks"`
+}
+
+const (
+	checkOK      = "ok"
+	checkSkipped = "skipped"
+
+	// capabilityRequiredCode is the envelope error code emitted when a
+	// validation phase is skipped because its prerequisite (e.g.
+	// --schema) is not satisfied. The matching category is the same
+	// string so agents can branch on either field.
+	capabilityRequiredCode     = "capability_required"
+	capabilityRequiredCategory = "capability_required"
+
+	// capabilityNameResolution is the canonical identifier for the
+	// table-name-resolution phase. It is shared between the phase's
+	// skipped-warning Context and any human-readable message text so
+	// the two cannot drift.
+	capabilityNameResolution = "name_resolution"
 )
 
 // newValidateCmd builds the `crdb-sql validate` subcommand. It reads
@@ -27,21 +66,39 @@ import (
 // structured envelope entry with SQLSTATE code, severity, message,
 // and source position.
 //
-// This is a Tier 1 (zero-config) command: it works offline with no
-// schema files or cluster connection.
+// When one or more --schema files are supplied the command additionally
+// resolves table references against the loaded catalog and reports
+// unknown tables (Tier 2). Without --schema, name resolution is skipped
+// and the envelope carries a `capability_required` warning entry so
+// agents can detect the missing capability rather than silently trust
+// a partial result.
 func newValidateCmd(state *rootState) *cobra.Command {
-	var expr string
+	var (
+		expr        string
+		schemaFiles []string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "validate [file]",
-		Short: "Check SQL for syntax errors",
+		Short: "Check SQL for syntax, type, and (with --schema) name errors",
 		Long: `Parse SQL and report whether it is syntactically valid. On failure,
 the error includes the SQLSTATE code, severity, message, and source
 position (line/column/byte offset). Input is read from the -e flag
-(inline SQL), a positional file argument, or stdin.`,
+(inline SQL), a positional file argument, or stdin.
+
+When --schema FILE is supplied (repeatable), table references in
+SELECT/INSERT/UPDATE/DELETE statements are checked against the loaded
+catalog and unknown tables are reported as 42P01 errors with an
+"available_tables" context list. Without --schema, name resolution is
+skipped and a capability_required warning is added to the envelope so
+agents can tell that the check did not run.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
+			tier := output.TierZeroConfig
+			if len(schemaFiles) > 0 {
+				tier = output.TierSchemaFile
+			}
+			r, baseEnv, err := newEnvelope(state, tier, cmd)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
@@ -64,24 +121,74 @@ position (line/column/byte offset). Input is read from the -e flag
 				return renderDiagErrors(r, baseEnv, typeErrs)
 			}
 
-			data, err := json.Marshal(struct {
-				Valid bool `json:"valid"`
-			}{Valid: true})
+			checks := validateChecks{
+				Syntax:    checkOK,
+				TypeCheck: checkOK,
+			}
+
+			if len(schemaFiles) == 0 {
+				checks.NameResolution = checkSkipped
+				baseEnv.Errors = append(baseEnv.Errors, capabilityRequiredError(
+					capabilityNameResolution,
+					"name resolution skipped: --schema not provided",
+					"pass --schema FILE to enable table name resolution",
+				))
+			} else {
+				cat, err := catalog.LoadFiles(schemaFiles)
+				if err != nil {
+					return renderSchemaLoadError(r, baseEnv, err)
+				}
+				appendSchemaWarnings(&baseEnv, cat)
+				if nameErrs := semcheck.CheckTableNames(stmts, sql, cat); len(nameErrs) > 0 {
+					return renderDiagErrors(r, baseEnv, nameErrs)
+				}
+				checks.NameResolution = checkOK
+			}
+
+			data, err := json.Marshal(validateResult{Valid: true, Checks: checks})
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
 			baseEnv.Data = data
 
 			return r.Render(baseEnv, func(w io.Writer) error {
-				_, werr := fmt.Fprintln(w, "Valid.")
-				return werr
+				if _, werr := fmt.Fprintln(w, "Valid."); werr != nil {
+					return werr
+				}
+				if checks.NameResolution == checkSkipped {
+					_, werr := fmt.Fprintln(w, "note: name resolution skipped (pass --schema to enable)")
+					return werr
+				}
+				return nil
 			})
 		},
 	}
 
 	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to validate")
+	cmd.Flags().StringArrayVar(&schemaFiles, "schema", nil,
+		"schema SQL file(s) to enable table name resolution (repeatable)")
 
 	return cmd
+}
+
+// capabilityRequiredError builds the warning entry that signals a
+// validation phase was skipped because its prerequisite is missing.
+// capability is the short identifier of the skipped phase (e.g.
+// "name_resolution"); message is the user-facing summary; hint tells
+// the user how to enable the phase. The result is appended to the
+// envelope's Errors list rather than aborting the command — exit code
+// stays 0 because the phases that did run all passed.
+func capabilityRequiredError(capability, message, hint string) output.Error {
+	return output.Error{
+		Code:     capabilityRequiredCode,
+		Severity: output.SeverityWarning,
+		Message:  message,
+		Category: capabilityRequiredCategory,
+		Context: map[string]any{
+			"capability": capability,
+			"hint":       hint,
+		},
+	}
 }
 
 // renderParseError enriches a parser error with SQLSTATE code and
@@ -92,10 +199,12 @@ func renderParseError(r output.Renderer, env output.Envelope, parseErr error, sq
 	return renderDiagErrors(r, env, []output.Error{diag.FromParseError(parseErr, sql)})
 }
 
-// renderDiagErrors renders one or more diagnostic errors (parse or
-// type-check) through the standard envelope path.
+// renderDiagErrors renders one or more diagnostic errors (parse, type-
+// check, or name resolution) through the standard envelope path. Any
+// errors already attached to env (e.g. schema-load warnings) are
+// preserved; the new errors are appended.
 func renderDiagErrors(r output.Renderer, env output.Envelope, errs []output.Error) error {
-	env.Errors = errs
+	env.Errors = append(env.Errors, errs...)
 	env.Data = nil
 
 	if err := r.Render(env, func(w io.Writer) error {

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -18,8 +18,26 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
+// validTextNoSchema is the text-mode stdout produced by a successful
+// validate run when --schema is not supplied: the success line plus the
+// capability_required note. Centralised so behavior changes only need
+// to update one place.
+const validTextNoSchema = "Valid.\nnote: name resolution skipped (pass --schema to enable)\n"
+
+// writeUsersSchema writes a minimal "users" schema to a temp file and
+// returns its path. Used by tests that exercise the --schema code path.
+func writeUsersSchema(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "schema.sql")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("CREATE TABLE users (id INT PRIMARY KEY);"), 0644))
+	return path
+}
+
 // TestValidateCmdTextSuccess verifies that valid SQL in text mode
-// prints "Valid." to stdout.
+// prints "Valid." plus the capability_required note (because no
+// --schema was provided).
 func TestValidateCmdTextSuccess(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
@@ -29,11 +47,13 @@ func TestValidateCmdTextSuccess(t *testing.T) {
 	root.SetArgs([]string{"validate"})
 
 	require.NoError(t, root.Execute())
-	require.Equal(t, "Valid.\n", stdout.String())
+	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
-// TestValidateCmdJSONSuccess verifies that valid SQL in JSON mode
-// produces an envelope with {"valid": true} data and no errors.
+// TestValidateCmdJSONSuccess verifies the JSON envelope shape on the
+// no-schema success path: tier=zero_config, a single capability_required
+// warning entry, and a checks block recording that name resolution was
+// skipped.
 func TestValidateCmdJSONSuccess(t *testing.T) {
 	root := newRootCmd()
 	var stdout, stderr bytes.Buffer
@@ -50,13 +70,26 @@ func TestValidateCmdJSONSuccess(t *testing.T) {
 	require.Equal(t, output.TierZeroConfig, env.Tier)
 	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
 	require.NotEmpty(t, env.ParserVersion)
-	require.Empty(t, env.Errors)
+
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "capability_required", env.Errors[0].Code)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	require.Equal(t, "capability_required", env.Errors[0].Category)
+	require.Equal(t, "name_resolution", env.Errors[0].Context["capability"])
 
 	var payload struct {
-		Valid bool `json:"valid"`
+		Valid  bool `json:"valid"`
+		Checks struct {
+			Syntax         string `json:"syntax"`
+			TypeCheck      string `json:"type_check"`
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
 	}
 	require.NoError(t, json.Unmarshal(env.Data, &payload))
 	require.True(t, payload.Valid)
+	require.Equal(t, "ok", payload.Checks.Syntax)
+	require.Equal(t, "ok", payload.Checks.TypeCheck)
+	require.Equal(t, "skipped", payload.Checks.NameResolution)
 }
 
 // TestValidateCmdTextError verifies that invalid SQL in text mode
@@ -116,7 +149,7 @@ func TestValidateCmdExprFlag(t *testing.T) {
 	root.SetArgs([]string{"validate", "-e", "SELECT 1"})
 
 	require.NoError(t, root.Execute())
-	require.Equal(t, "Valid.\n", stdout.String())
+	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
 // TestValidateCmdFileArg verifies reading SQL from a file argument.
@@ -132,7 +165,7 @@ func TestValidateCmdFileArg(t *testing.T) {
 	root.SetArgs([]string{"validate", sqlFile})
 
 	require.NoError(t, root.Execute())
-	require.Equal(t, "Valid.\n", stdout.String())
+	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
 // TestValidateCmdEmptyInput verifies that empty stdin produces an error.
@@ -170,7 +203,7 @@ func TestValidateCmdMultiStatementSuccess(t *testing.T) {
 	root.SetArgs([]string{"validate"})
 
 	require.NoError(t, root.Execute())
-	require.Equal(t, "Valid.\n", stdout.String())
+	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
 // TestValidateCmdTypeErrorText verifies that a type mismatch in text
@@ -225,7 +258,7 @@ func TestValidateCmdColumnRefNoTypeError(t *testing.T) {
 	root.SetArgs([]string{"validate"})
 
 	require.NoError(t, root.Execute())
-	require.Equal(t, "Valid.\n", stdout.String())
+	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
 // TestValidateCmdMultiStatementError verifies that an error in a later
@@ -250,4 +283,146 @@ func TestValidateCmdMultiStatementError(t *testing.T) {
 	require.Equal(t, 2, pos.Line)
 	require.Equal(t, 12, pos.Column)
 	require.Equal(t, 21, pos.ByteOffset)
+}
+
+// TestValidateCmdSchemaUnknownTable verifies that --schema enables name
+// resolution and that an unknown table produces a 42P01 envelope error
+// with the catalog's tables in available_tables.
+func TestValidateCmdSchemaUnknownTable(t *testing.T) {
+	schema := writeUsersSchema(t)
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json",
+		"--schema", schema, "-e", "SELECT * FROM usrs"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Len(t, env.Errors, 1)
+	require.Nil(t, env.Data)
+
+	diagErr := env.Errors[0]
+	require.Equal(t, "42P01", diagErr.Code)
+	require.Equal(t, "unknown_table", diagErr.Category)
+	require.Contains(t, diagErr.Message, "usrs")
+	avail, ok := diagErr.Context["available_tables"].([]any)
+	require.True(t, ok, "available_tables must be a JSON array")
+	require.Equal(t, []any{"users"}, avail)
+}
+
+// TestValidateCmdSchemaKnownTable verifies the success path with
+// --schema: tier=schema_file, no errors, name_resolution=ok.
+func TestValidateCmdSchemaKnownTable(t *testing.T) {
+	schema := writeUsersSchema(t)
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json",
+		"--schema", schema, "-e", "SELECT * FROM users"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Empty(t, env.Errors)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.True(t, payload.Valid)
+	require.Equal(t, "ok", payload.Checks.NameResolution)
+}
+
+// TestValidateCmdSchemaUnknownTableText verifies that unknown-table
+// errors render in text mode with line/column and the SQLSTATE code.
+func TestValidateCmdSchemaUnknownTableText(t *testing.T) {
+	schema := writeUsersSchema(t)
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate",
+		"--schema", schema, "-e", "SELECT * FROM usrs"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, "1:15:")
+	require.Contains(t, got, `"usrs"`)
+	require.Contains(t, got, "42P01")
+}
+
+// TestValidateCmdSchemaParseError verifies that a malformed schema
+// file surfaces the parser's SQLSTATE (42601) rather than the generic
+// internal_error code.
+func TestValidateCmdSchemaParseError(t *testing.T) {
+	dir := t.TempDir()
+	schema := filepath.Join(dir, "bad.sql")
+	require.NoError(t, os.WriteFile(schema,
+		[]byte("CREATE TABLE FROM"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json",
+		"--schema", schema, "-e", "SELECT 1"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "42601", env.Errors[0].Code)
+	require.Equal(t, "syntax_error", env.Errors[0].Category)
+	require.Contains(t, env.Errors[0].Message, "bad.sql")
+}
+
+// TestValidateCmdSchemaMissingFile verifies that an unreadable schema
+// path is reported with the dedicated schema_load_error code rather
+// than the generic internal_error code.
+func TestValidateCmdSchemaMissingFile(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json",
+		"--schema", "/nonexistent/schema.sql", "-e", "SELECT 1"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "schema_load_error", env.Errors[0].Code)
+	require.Contains(t, env.Errors[0].Message, "/nonexistent/schema.sql")
+}
+
+// TestValidateCmdSchemaTextSuccess verifies that text mode with
+// --schema and a known table prints "Valid." with no skipped-note.
+func TestValidateCmdSchemaTextSuccess(t *testing.T) {
+	schema := writeUsersSchema(t)
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate",
+		"--schema", schema, "-e", "SELECT * FROM users"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String())
 }

--- a/internal/semcheck/names.go
+++ b/internal/semcheck/names.go
@@ -1,0 +1,265 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// unknownTableCode is the SQLSTATE for "undefined_table". CockroachDB
+// itself emits this code for missing-table errors, so agents can branch
+// on it without parsing the message.
+const unknownTableCode = "42P01"
+
+// CheckTableNames walks every statement in stmts and reports table
+// references that do not resolve in cat. CTE names from WITH clauses
+// and table aliases are added to a per-statement scope so they are not
+// flagged.
+//
+// Errors are deduplicated by name across the whole input — a single
+// missing table referenced from two statements produces one error, not
+// two. The first reference's source position is reported.
+//
+// fullSQL is the original SQL text used to compute 1-based line/column
+// positions. cat must be non-nil; the caller decides whether to call
+// this based on whether a catalog is available.
+func CheckTableNames(stmts statements.Statements, fullSQL string, cat *catalog.Catalog) []output.Error {
+	if cat == nil || len(stmts) == 0 {
+		return nil
+	}
+
+	var errs []output.Error
+	seen := make(map[string]struct{})
+	availableTables := sync.OnceValue(cat.TableNames)
+
+	// stmtStart advances through fullSQL so each statement's
+	// position lookups search only within its own slice. Without
+	// this, "SELECT * FROM users u; SELECT * FROM u" would resolve
+	// "u" to the substring inside "users".
+	stmtStart := 0
+	for i := range stmts {
+		stmt := stmts[i].AST
+		if stmt == nil {
+			continue
+		}
+		stmtSQL := stmts[i].SQL
+		stmtEnd := stmtStart + len(stmtSQL)
+		if rel := strings.Index(fullSQL[stmtStart:], stmtSQL); rel >= 0 {
+			stmtStart += rel
+			stmtEnd = stmtStart + len(stmtSQL)
+		}
+
+		v := &tableNameVisitor{
+			cat:             cat,
+			fullSQL:         fullSQL,
+			stmtStart:       stmtStart,
+			stmtEnd:         stmtEnd,
+			availableTables: availableTables,
+			scope:           newScope(),
+			seen:            seen,
+			errs:            &errs,
+		}
+		tree.WalkStmt(v, stmt)
+
+		stmtStart = stmtEnd
+	}
+	return errs
+}
+
+// tableNameVisitor walks one top-level statement collecting unresolved
+// table references.
+//
+// Lifecycle: one visitor per statement; created by CheckTableNames and
+// discarded once WalkStmt returns. seen is shared across statements so
+// the same missing name only produces one error per input. scope is
+// per-statement so CTE names from one statement do not leak into the
+// next. stmtStart/stmtEnd bound the byte range searched by positionFor.
+//
+// The visitor implements tree.ExtendedVisitor — required because a plain
+// tree.Visitor skips TableExpr subtrees during WalkStmt.
+type tableNameVisitor struct {
+	cat             *catalog.Catalog
+	fullSQL         string
+	stmtStart       int
+	stmtEnd         int
+	availableTables func() []string
+	scope           *nameScope
+	seen            map[string]struct{}
+	errs            *[]output.Error
+}
+
+var _ tree.ExtendedVisitor = (*tableNameVisitor)(nil)
+
+func (v *tableNameVisitor) VisitPre(expr tree.Expr) (bool, tree.Expr)          { return true, expr }
+func (v *tableNameVisitor) VisitPost(expr tree.Expr) tree.Expr                 { return expr }
+func (v *tableNameVisitor) VisitTablePost(e tree.TableExpr) tree.TableExpr     { return e }
+func (v *tableNameVisitor) VisitStatementPost(s tree.Statement) tree.Statement { return s }
+
+func (v *tableNameVisitor) VisitTablePre(expr tree.TableExpr) (bool, tree.TableExpr) {
+	switch t := expr.(type) {
+	case *tree.AliasedTableExpr:
+		// Bind the alias before returning so it is in scope when
+		// walkTableExpr recurses into expr.Expr (e.g. a subquery
+		// in FROM that references the alias via a lateral join).
+		if t.As.Alias != "" {
+			v.scope.add(string(t.As.Alias))
+		}
+		return true, expr
+	case *tree.TableName:
+		v.checkTable(t)
+		return false, expr
+	case *tree.TableRef:
+		// Numeric "[123 AS t]" form; no name to resolve.
+		return false, expr
+	}
+	return true, expr
+}
+
+func (v *tableNameVisitor) VisitStatementPre(stmt tree.Statement) (bool, tree.Statement) {
+	// Bind CTE names before visiting the body so references to them
+	// are not flagged. A flat scope (rather than nested frames) is
+	// sufficient because CTE/alias names within a statement are
+	// visible everywhere downstream of their declaration.
+	if w := withClause(stmt); w != nil {
+		for _, cte := range w.CTEList {
+			if cte == nil {
+				continue
+			}
+			if name := string(cte.Name.Alias); name != "" {
+				v.scope.add(name)
+			}
+		}
+	}
+	return true, stmt
+}
+
+// checkTable reports tn as unknown when it is neither in the
+// per-statement scope nor in the catalog. Schema/database qualifiers
+// on tn are ignored — the catalog is single-level and tn.Table()
+// returns the bare object name.
+func (v *tableNameVisitor) checkTable(tn *tree.TableName) {
+	name := tn.Table()
+	if name == "" || v.scope.has(name) {
+		return
+	}
+	if _, ok := v.cat.Table(name); ok {
+		return
+	}
+
+	key := strings.ToLower(name)
+	if _, dup := v.seen[key]; dup {
+		return
+	}
+	v.seen[key] = struct{}{}
+
+	*v.errs = append(*v.errs, output.Error{
+		Code:     unknownTableCode,
+		Severity: output.SeverityError,
+		Message:  fmt.Sprintf("relation %q does not exist", name),
+		Position: v.positionFor(name),
+		Category: diag.CategoryUnknownTable,
+		Context: map[string]any{
+			"available_tables": v.availableTables(),
+		},
+	})
+}
+
+// positionFor locates name within the current statement's byte range
+// and returns its 1-based position. Identifier word boundaries are
+// enforced so a search for "u" does not match the "u" inside "users".
+// Returns nil when the name cannot be found within the statement's
+// range — typically because the parser rendered a delimited or
+// case-folded identifier that does not appear verbatim in the source.
+func (v *tableNameVisitor) positionFor(name string) *output.Position {
+	if name == "" {
+		return nil
+	}
+	stmtText := v.fullSQL[v.stmtStart:v.stmtEnd]
+	for off := 0; off < len(stmtText); {
+		rel := indexFold(stmtText[off:], name)
+		if rel < 0 {
+			return nil
+		}
+		abs := v.stmtStart + off + rel
+		if isWordBoundary(v.fullSQL, abs, abs+len(name)) {
+			return diag.PositionFromByteOffset(v.fullSQL, abs)
+		}
+		off += rel + 1
+	}
+	return nil
+}
+
+// indexFold is strings.Index with ASCII case folding. Catalog lookups
+// are case-insensitive, so position lookups must be too.
+func indexFold(haystack, needle string) int {
+	return strings.Index(strings.ToLower(haystack), strings.ToLower(needle))
+}
+
+// isWordBoundary reports whether [start, end) in s is bordered by
+// non-identifier bytes (or string boundaries). An identifier byte is
+// ASCII letter/digit/underscore — sufficient for SQL identifiers in
+// the unquoted contexts the substring search applies to.
+func isWordBoundary(s string, start, end int) bool {
+	return !isIdentByte(byteAt(s, start-1)) && !isIdentByte(byteAt(s, end))
+}
+
+func byteAt(s string, i int) byte {
+	if i < 0 || i >= len(s) {
+		return 0
+	}
+	return s[i]
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// nameScope is a case-insensitive set of identifiers that should not
+// be reported as unknown tables (CTE names and table aliases). The
+// wrapper enforces case-folding at the API boundary so callers cannot
+// accidentally bypass it.
+type nameScope struct {
+	names map[string]struct{}
+}
+
+func newScope() *nameScope {
+	return &nameScope{names: make(map[string]struct{})}
+}
+
+func (s *nameScope) add(name string) {
+	s.names[strings.ToLower(name)] = struct{}{}
+}
+
+func (s *nameScope) has(name string) bool {
+	_, ok := s.names[strings.ToLower(name)]
+	return ok
+}
+
+func withClause(stmt tree.Statement) *tree.With {
+	switch s := stmt.(type) {
+	case *tree.Select:
+		return s.With
+	case *tree.Insert:
+		return s.With
+	case *tree.Update:
+		return s.With
+	case *tree.Delete:
+		return s.With
+	}
+	return nil
+}

--- a/internal/semcheck/names_test.go
+++ b/internal/semcheck/names_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+)
+
+// usersOnlyCatalog returns a catalog containing a single "users" table.
+// It is the default fixture for cases that only need to distinguish
+// "known" from "unknown" tables.
+func usersOnlyCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	cat, err := catalog.Load([]catalog.SchemaSource{{
+		SQL:   "CREATE TABLE users (id INT PRIMARY KEY)",
+		Label: "test",
+	}})
+	require.NoError(t, err)
+	return cat
+}
+
+func TestCheckTableNames(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		expectedCount    int
+		expectedMissing  string // first missing-table name (when expectedCount > 0)
+		expectedAvail    []string
+		expectedCategory string
+	}{
+		{
+			name:          "known table",
+			sql:           "SELECT * FROM users",
+			expectedCount: 0,
+		},
+		{
+			name:             "unknown table in SELECT",
+			sql:              "SELECT * FROM usrs",
+			expectedCount:    1,
+			expectedMissing:  "usrs",
+			expectedAvail:    []string{"users"},
+			expectedCategory: diag.CategoryUnknownTable,
+		},
+		{
+			name:            "unknown table in INSERT",
+			sql:             "INSERT INTO usrs (id) VALUES (1)",
+			expectedCount:   1,
+			expectedMissing: "usrs",
+		},
+		{
+			name:            "unknown table in UPDATE",
+			sql:             "UPDATE usrs SET id = 2 WHERE id = 1",
+			expectedCount:   1,
+			expectedMissing: "usrs",
+		},
+		{
+			name:            "unknown table in DELETE",
+			sql:             "DELETE FROM usrs WHERE id = 1",
+			expectedCount:   1,
+			expectedMissing: "usrs",
+		},
+		{
+			name:          "join known and unknown reports only unknown",
+			sql:           "SELECT * FROM users u JOIN orders o ON u.id = o.user_id",
+			expectedCount: 1,
+		},
+		{
+			name:          "CTE shadows missing table",
+			sql:           "WITH t AS (SELECT 1) SELECT * FROM t",
+			expectedCount: 0,
+		},
+		{
+			name:          "subquery in FROM flags inner unknown",
+			sql:           "SELECT * FROM (SELECT * FROM usrs) x",
+			expectedCount: 1,
+		},
+		{
+			name:          "numeric TableRef skipped",
+			sql:           "SELECT * FROM [1 AS t]",
+			expectedCount: 0,
+		},
+		{
+			name:          "no table references",
+			sql:           "SELECT 1",
+			expectedCount: 0,
+		},
+		{
+			name:          "qualified name resolves on bare object",
+			sql:           "SELECT * FROM public.users",
+			expectedCount: 0,
+		},
+		{
+			name:          "case-insensitive lookup",
+			sql:           "SELECT * FROM USERS",
+			expectedCount: 0,
+		},
+		{
+			name:          "duplicate references collapse",
+			sql:           "SELECT * FROM usrs WHERE EXISTS (SELECT 1 FROM usrs)",
+			expectedCount: 1,
+		},
+		{
+			name:            "join with both sides unknown",
+			sql:             "SELECT * FROM unk1 u JOIN unk2 v ON u.id = v.id",
+			expectedCount:   2,
+			expectedMissing: "unk1",
+		},
+		{
+			name:          "two distinct unknowns in one statement",
+			sql:           "SELECT * FROM missingA, missingB",
+			expectedCount: 2,
+		},
+		{
+			name:          "UNION flags both sides",
+			sql:           "SELECT * FROM unk1 UNION SELECT * FROM unk2",
+			expectedCount: 2,
+		},
+		{
+			name:          "CTE body still flags inner unknown",
+			sql:           "WITH x AS (SELECT * FROM usrs) SELECT * FROM x",
+			expectedCount: 1,
+		},
+		{
+			name:          "DELETE USING flags unknown",
+			sql:           "DELETE FROM users USING unk WHERE users.id = unk.id",
+			expectedCount: 1,
+		},
+		{
+			name:          "INSERT ON CONFLICT does not double-flag target",
+			sql:           "INSERT INTO users (id) VALUES (1) ON CONFLICT (id) DO NOTHING",
+			expectedCount: 0,
+		},
+	}
+
+	cat := usersOnlyCatalog(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err, "parse must succeed")
+
+			errs := CheckTableNames(stmts, tc.sql, cat)
+			require.Len(t, errs, tc.expectedCount)
+
+			if tc.expectedCount == 0 {
+				return
+			}
+			first := errs[0]
+			require.Equal(t, unknownTableCode, first.Code)
+			if tc.expectedMissing != "" {
+				require.Contains(t, first.Message, tc.expectedMissing)
+			}
+			if tc.expectedCategory != "" {
+				require.Equal(t, tc.expectedCategory, first.Category)
+			}
+			if tc.expectedAvail != nil {
+				avail, ok := first.Context["available_tables"].([]string)
+				require.True(t, ok, "available_tables must be []string")
+				require.Equal(t, tc.expectedAvail, avail)
+			}
+		})
+	}
+}
+
+// TestCheckTableNamesPosition verifies that the reported position
+// points at the first occurrence of the missing table name in the SQL.
+func TestCheckTableNamesPosition(t *testing.T) {
+	cat := usersOnlyCatalog(t)
+	sql := "SELECT * FROM usrs"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckTableNames(stmts, sql, cat)
+	require.Len(t, errs, 1)
+	require.NotNil(t, errs[0].Position)
+	require.Equal(t, 1, errs[0].Position.Line)
+	require.Equal(t, 15, errs[0].Position.Column)
+	require.Equal(t, 14, errs[0].Position.ByteOffset)
+}
+
+// TestCheckTableNamesAliasScopePerStatement verifies that an alias
+// introduced in one statement does not leak into the next, and that
+// the reported position points at the second statement's "u" rather
+// than the substring inside "users" in the first.
+func TestCheckTableNamesAliasScopePerStatement(t *testing.T) {
+	cat := usersOnlyCatalog(t)
+	sql := "SELECT * FROM users u; SELECT * FROM u"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckTableNames(stmts, sql, cat)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message, `"u"`)
+	require.NotNil(t, errs[0].Position)
+	// The standalone "u" sits at byte 37 in the input, not byte 14
+	// (which would be the "u" inside "users" in the first statement).
+	require.Equal(t, 37, errs[0].Position.ByteOffset)
+}
+
+// TestCheckTableNamesNilCatalog verifies that a nil catalog is treated
+// as a no-op rather than panicking. CheckTableNames is meant to be
+// guarded by the caller; this is defense in depth.
+func TestCheckTableNamesNilCatalog(t *testing.T) {
+	stmts, err := parser.Parse("SELECT * FROM usrs")
+	require.NoError(t, err)
+	require.Empty(t, CheckTableNames(stmts, "SELECT * FROM usrs", nil))
+}
+
+// TestCheckTableNamesEmptyStatements verifies the no-statements path.
+func TestCheckTableNamesEmptyStatements(t *testing.T) {
+	cat := usersOnlyCatalog(t)
+	require.Empty(t, CheckTableNames(nil, "", cat))
+}


### PR DESCRIPTION
When `--schema FILE` is supplied (repeatable), `crdb-sql validate` now walks SELECT/INSERT/UPDATE/DELETE statements for table references and reports unknown tables as `42P01` envelope errors with category `unknown_table` and an `available_tables` context list. The walker honours CTE names from WITH clauses and table aliases, recurses into joins, FROM-clause subqueries, and UNION/INTERSECT branches via `tree.ExtendedVisitor`, and deduplicates repeated references to the same name across the whole input.

Without `--schema`, name resolution is skipped and the envelope carries a `capability_required` warning entry plus a `{valid, checks}` partial result so agents can detect that the phase did not run, per the design doc's Visibility principle. Exit code stays 0 in that case because the phases that did run all passed.

Schema-load failures now surface the underlying SQLSTATE (e.g. `42601` for a malformed CREATE TABLE) via a new `renderSchemaLoadError` helper, falling back to a dedicated `schema_load_error` code for I/O failures rather than the generic `internal_error` tag.

Resolves: #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)