### PR TITLE
cmd: add --target-version flag and plumb through MCP and envelope

### DIFF
--- a/cmd/envelope_test.go
+++ b/cmd/envelope_test.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -43,4 +44,82 @@ func TestNewEnvelope(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, string(data), `"tier"`)
 	})
+
+	t.Run("no target version omits field and emits no warning", func(t *testing.T) {
+		state := &rootState{outputFormat: output.FormatJSON}
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+
+		_, env, err := newEnvelope(state, output.TierZeroConfig, cmd)
+		require.NoError(t, err)
+		require.Empty(t, env.TargetVersion)
+		require.Empty(t, env.Errors)
+
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+		require.NotContains(t, string(data), `"target_version"`)
+	})
+
+	t.Run("target version stamps field on envelope", func(t *testing.T) {
+		// VersionMismatchWarning's logic is exercised end-to-end in
+		// internal/output/version_test.go. Asserting warning emission
+		// here would require stubbing the parser version: under
+		// `go test` parserVersion(Version) returns "unknown" because
+		// the test binary's debug.ReadBuildInfo does not list the
+		// cockroachdb-parser dep the same way the production binary
+		// does. So this case verifies only the field-stamping wiring;
+		// the warning predicate is covered as a unit test.
+		state := &rootState{
+			outputFormat:  output.FormatJSON,
+			targetVersion: "25.4.0",
+		}
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+
+		_, env, err := newEnvelope(state, output.TierZeroConfig, cmd)
+		require.NoError(t, err)
+		require.Equal(t, "25.4.0", env.TargetVersion)
+	})
+}
+
+// TestRootRejectsMalformedTargetVersion confirms PersistentPreRunE
+// surfaces the validation error before any subcommand RunE runs, so
+// the user sees a clear message instead of a partially-constructed
+// envelope. The error is also wrapped with the flag name so users
+// know which flag failed when several are passed.
+func TestRootRejectsMalformedTargetVersion(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"parse", "--target-version", "not-a-version"})
+
+	err := root.Execute()
+	require.ErrorContains(t, err, "--target-version")
+	require.ErrorContains(t, err, "target version")
+	require.ErrorContains(t, err, "not-a-version",
+		"the offending value must appear in the message so the user can spot the typo")
+}
+
+// TestRootCanonicalizesTargetVersion is the positive counterpart to
+// TestRootRejectsMalformedTargetVersion. It runs `parse` end-to-end
+// with --target-version v25.4.0 and asserts the envelope reports
+// the canonical (no-"v") form. A future regression that drops the
+// canonicalization assignment in PersistentPreRunE would surface as
+// "v25.4.0" in the JSON output.
+func TestRootCanonicalizesTargetVersion(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"parse", "--target-version", "v25.4.0", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "25.4.0", env.TargetVersion,
+		"PersistentPreRunE must store the canonical (no-'v') form")
 }

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -20,7 +20,11 @@ import (
 // blocks until the client disconnects (stdin closes); a clean
 // disconnect returns nil, anything else surfaces as the cobra error.
 // The registered tools are defined in internal/mcp.NewServer.
-func newMCPCmd() *cobra.Command {
+//
+// state.targetVersion (if set via --target-version) is forwarded to
+// the server as a default applied to every tool call; per-call
+// target_version arguments override it.
+func newMCPCmd(state *rootState) *cobra.Command {
 	return &cobra.Command{
 		Use:   "mcp",
 		Short: "Run the crdb-sql MCP server on stdio",
@@ -37,7 +41,7 @@ via "claude mcp add"); the process exits when the client closes stdin.`,
 			if err != nil {
 				return err
 			}
-			s := internalmcp.NewServer(Version, parserVer)
+			s := internalmcp.NewServer(Version, parserVer, state.targetVersion)
 			// Wrap the transport error so a failure in the stdio loop
 			// surfaces through cobra's "Error:" line as obviously
 			// transport-layer rather than as an opaque message from

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,17 @@ type rootState struct {
 	// as "no project config; use flags" — config consumption is
 	// opt-in per subcommand. Populated by PersistentPreRunE.
 	cfg *config.File
+
+	// targetVersion is the canonical CockroachDB version the user
+	// declared via --target-version. The empty string is the
+	// sentinel for "flag not supplied"; newEnvelope (and the MCP
+	// server, which forwards it as the per-call default) reads this
+	// to decide whether to stamp the field and emit a mismatch
+	// warning. "Canonical" means the leading "v" (if any) has been
+	// stripped and components have been validated as unsigned
+	// integers; ValidateTargetVersion is the sole producer.
+	// Populated by PersistentPreRunE after format validation.
+	targetVersion string
 }
 
 // newRootCmd builds a fresh root command with all subcommands attached.
@@ -104,6 +115,18 @@ round-tripping through a live cluster.`,
 				return err
 			}
 			state.cfg = cfg
+
+			rawTarget, err := cmd.Flags().GetString(targetVersionFlag)
+			if err != nil {
+				return err
+			}
+			if rawTarget != "" {
+				canonical, err := output.ValidateTargetVersion(rawTarget)
+				if err != nil {
+					return fmt.Errorf("--%s: %w", targetVersionFlag, err)
+				}
+				state.targetVersion = canonical
+			}
 			return nil
 		},
 	}
@@ -113,6 +136,8 @@ round-tripping through a live cluster.`,
 		"CockroachDB connection string (overrides CRDB_DSN env var)")
 	root.PersistentFlags().String(configFlag, "",
 		"path to crdb-sql.yaml (default: auto-discover in CWD)")
+	root.PersistentFlags().String(targetVersionFlag, "",
+		"Target CockroachDB version (e.g. 25.4.0); reported in the response envelope")
 	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newPingCmd(state))
 	root.AddCommand(newParseCmd(state))
@@ -122,7 +147,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newListTablesCmd(state))
 	root.AddCommand(newRiskCmd(state))
 	root.AddCommand(newExplainCmd(state))
-	root.AddCommand(newMCPCmd())
+	root.AddCommand(newMCPCmd(state))
 	return root
 }
 
@@ -130,9 +155,10 @@ round-tripping through a live cluster.`,
 // between the root command's flag registration and PersistentPreRunE
 // lookup so the two stay in sync.
 const (
-	outputFlag = "output"
-	dsnFlag    = "dsn"
-	configFlag = "config"
+	outputFlag        = "output"
+	dsnFlag           = "dsn"
+	configFlag        = "config"
+	targetVersionFlag = "target-version"
 )
 
 // loadConfig resolves the project YAML config. When path is non-empty,
@@ -183,6 +209,12 @@ func newEnvelope(
 		return r, env, err
 	}
 	env.ParserVersion = parserVer
+	if state.targetVersion != "" {
+		env.TargetVersion = state.targetVersion
+		if warning, ok := output.VersionMismatchWarning(parserVer, state.targetVersion); ok {
+			env.Errors = append(env.Errors, warning)
+		}
+	}
 	return r, env, nil
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -34,20 +34,29 @@ import (
 // All other tool name constants live in the tools subpackage.
 const PingToolName = "ping"
 
-// NewServer constructs an MCP server for crdb-sql. binaryVersion is the
-// crdb-sql binary version string (typically cmd.Version), and
-// parserVersion is the resolved cockroachdb-parser module version
-// (typically the result of cmd.parserVersion). Both are reported
-// verbatim — binaryVersion in the server handshake, and parserVersion
-// in every tool response — so callers should resolve them before
-// invoking NewServer.
+// NewServer constructs an MCP server for crdb-sql. The three string
+// arguments name distinct concepts that flow through every tool
+// response, and callers must resolve them before invoking NewServer:
+//
+//   - crdbSQLVersion is the crdb-sql binary version (typically
+//     cmd.Version). Reported in the MCP server handshake so clients
+//     can identify which build they are talking to.
+//   - parserVersion is the resolved cockroachdb-parser module version
+//     (typically the result of cmd.parserVersion). Stamped into every
+//     tool's envelope so clients always know which SQL dialect this
+//     binary actually understands.
+//   - defaultTargetVersion is the user-declared CockroachDB target
+//     version (typically state.targetVersion from the --target-version
+//     flag), or "" when the user did not supply one. Used as a default
+//     for every tool call; per-call target_version arguments override
+//     it.
 //
 // The returned server has no transport bound; callers wire it to stdio
 // (or, in the future, sse/http) themselves.
-func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
+func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *server.MCPServer {
 	s := server.NewMCPServer(
 		"crdb-sql",
-		binaryVersion,
+		crdbSQLVersion,
 		server.WithToolCapabilities(false /* listChanged */),
 	)
 	s.AddTool(
@@ -57,11 +66,11 @@ func NewServer(binaryVersion, parserVersion string) *server.MCPServer {
 		),
 		pingHandler(parserVersion),
 	)
-	s.AddTool(tools.ParseSQLTool(), tools.ParseSQLHandler(parserVersion))
-	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion))
-	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion))
-	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion))
-	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion))
+	s.AddTool(tools.ParseSQLTool(), tools.ParseSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
 	return s
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -74,7 +74,7 @@ func TestPingHandler(t *testing.T) {
 // AddTool — or renames a tool — would silently break MCP clients; this
 // test surfaces it without speaking the protocol.
 func TestNewServerRegistersTools(t *testing.T) {
-	s := NewServer("v1.2.3", "v0.26.2")
+	s := NewServer("v1.2.3", "v0.26.2", "" /* defaultTargetVersion */)
 	require.NotNil(t, s)
 	registered := s.ListTools()
 

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -27,6 +27,7 @@ func ExplainSQLTool() mcp.Tool {
 		mcp.WithDescription(`Run EXPLAIN against a CockroachDB cluster and return the plan as structured JSON. The wrapped statement is not executed (this is plain EXPLAIN, not EXPLAIN ANALYZE). Returns the operator tree, header (distribution/vectorized), and the raw tabular rows.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL DML statement to explain")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
 }
 
@@ -37,7 +38,12 @@ func ExplainSQLTool() mcp.Tool {
 // wrapped statement, perm denied) populate env.Errors; tool-level errors
 // (missing parameters) are returned as mcp.NewToolResultError per the
 // discipline documented in tools.go.
-func ExplainSQLHandler(parserVersion string) server.ToolHandlerFunc {
+//
+// defaultTargetVersion is the server-level default; per-call
+// target_version arguments override it. The resolved value is
+// stamped onto the envelope (and may add a mismatch warning) per
+// the contract documented on connectedEnvelope.
+func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractRequiredString(req, "sql")
 		if toolErr != nil {
@@ -47,8 +53,12 @@ func ExplainSQLHandler(parserVersion string) server.ToolHandlerFunc {
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := connectedEnvelope(parserVersion)
+		env := connectedEnvelope(parserVersion, target)
 
 		mgr := conn.NewManager(dsn)
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -24,20 +24,27 @@ func FormatSQLTool() mcp.Tool {
 		FormatSQLToolName,
 		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format. Returns an envelope with the formatted SQL string."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to format (may contain multiple semicolon-separated statements)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
 }
 
 // FormatSQLHandler returns the handler for the format_sql tool. It
 // delegates to sqlformat.Format and wraps the result in the standard
-// output.Envelope used by all Tier 1 tools.
-func FormatSQLHandler(parserVersion string) server.ToolHandlerFunc {
+// output.Envelope used by all Tier 1 tools. defaultTargetVersion is
+// the server-level default; per-call target_version arguments override
+// it.
+func FormatSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractSQL(req)
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := baseEnvelope(parserVersion)
+		env := baseEnvelope(parserVersion, target)
 
 		formatted, err := sqlformat.Format(sql)
 		if err != nil {

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -24,20 +24,28 @@ func ParseSQLTool() mcp.Tool {
 		ParseSQLToolName,
 		mcp.WithDescription("Parse and classify SQL statements. Returns an envelope with statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
 }
 
 // ParseSQLHandler returns the handler for the parse_sql tool. It
 // delegates to sqlparse.Classify and wraps the result in the standard
-// output.Envelope used by all Tier 1 tools.
-func ParseSQLHandler(parserVersion string) server.ToolHandlerFunc {
+// output.Envelope used by all Tier 1 tools. defaultTargetVersion is
+// the server-level default (typically the value of --target-version on
+// the `crdb-sql mcp` invocation); per-call target_version arguments
+// override it.
+func ParseSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractSQL(req)
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := baseEnvelope(parserVersion)
+		env := baseEnvelope(parserVersion, target)
 
 		stmts, err := sqlparse.Classify(sql)
 		if err != nil {

--- a/internal/mcp/tools/risk.go
+++ b/internal/mcp/tools/risk.go
@@ -24,20 +24,27 @@ func DetectRiskyQueryTool() mcp.Tool {
 		DetectRiskyQueryToolName,
 		mcp.WithDescription("Detect risky SQL patterns such as DELETE/UPDATE without WHERE, DROP TABLE, and SELECT *. Returns findings with reason codes, severity, and fix hints."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
 }
 
 // DetectRiskyQueryHandler returns the handler for the detect_risky_query
 // tool. It delegates to risk.Analyze and wraps the result in the standard
-// output.Envelope used by all tools in this package.
-func DetectRiskyQueryHandler(parserVersion string) server.ToolHandlerFunc {
+// output.Envelope used by all tools in this package. defaultTargetVersion
+// is the server-level default; per-call target_version arguments
+// override it.
+func DetectRiskyQueryHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractSQL(req)
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := baseEnvelope(parserVersion)
+		env := baseEnvelope(parserVersion, target)
 
 		findings, err := risk.Analyze(sql)
 		if err != nil {

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -39,6 +39,18 @@ const (
 	ExplainSQLToolName       = "explain_sql"
 )
 
+// TargetVersionParamName is the optional MCP tool parameter name that
+// lets a client override the server's default target CockroachDB
+// version on a per-call basis. Tools that accept it follow the same
+// validation rules as the CLI's --target-version flag (see
+// output.ValidateTargetVersion).
+const TargetVersionParamName = "target_version"
+
+// TargetVersionParamDescription is the shared MCP-schema description
+// for the target_version parameter so every tool documents the
+// argument identically.
+const TargetVersionParamDescription = "Optional target CockroachDB version (MAJOR.MINOR or MAJOR.MINOR.PATCH, with optional leading 'v'). Overrides the server-level default for this call."
+
 // extractRequiredString validates and returns a required string
 // parameter from an MCP tool request. Leading and trailing whitespace
 // is trimmed so all handlers behave consistently. On success, the
@@ -69,25 +81,95 @@ func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
 }
 
 // baseEnvelope returns a pre-populated Envelope for Tier 1 (zero-config,
-// disconnected) tools.
-func baseEnvelope(parserVersion string) output.Envelope {
-	return output.Envelope{
+// disconnected) tools. When targetVersion is non-empty it is stamped
+// onto the envelope and, if it differs from parserVersion at the
+// MAJOR.MINOR level, an output.CodeTargetVersionMismatch warning is
+// appended to Errors. Pass "" for targetVersion when the caller wants
+// no target-version stamping (matches the CLI behaviour when
+// --target-version is omitted).
+//
+// The append site here mirrors the CLI append site in
+// cmd/newEnvelope; both must use output.VersionMismatchWarning so the
+// two surfaces stay in sync.
+func baseEnvelope(parserVersion, targetVersion string) output.Envelope {
+	env := output.Envelope{
 		Tier:             output.TierZeroConfig,
 		ParserVersion:    parserVersion,
 		ConnectionStatus: output.ConnectionDisconnected,
 	}
+	stampTargetVersion(&env, parserVersion, targetVersion)
+	return env
 }
 
 // connectedEnvelope returns a pre-populated Envelope for Tier 3
 // (connected) tools. ConnectionStatus starts disconnected and is flipped
 // to connected by the handler after a successful round-trip to the
 // cluster, so a partial failure surfaces with the correct state.
-func connectedEnvelope(parserVersion string) output.Envelope {
-	return output.Envelope{
+//
+// targetVersion follows the same contract as baseEnvelope: empty
+// means "no target-version stamping," non-empty stamps the field and
+// (when MAJOR.MINOR diverges from parserVersion) appends a mismatch
+// warning. This keeps Tier 3 tools consistent with the CLI and Tier 1
+// surfaces.
+func connectedEnvelope(parserVersion, targetVersion string) output.Envelope {
+	env := output.Envelope{
 		Tier:             output.TierConnected,
 		ParserVersion:    parserVersion,
 		ConnectionStatus: output.ConnectionDisconnected,
 	}
+	stampTargetVersion(&env, parserVersion, targetVersion)
+	return env
+}
+
+// stampTargetVersion is the shared post-construction step for
+// baseEnvelope and connectedEnvelope. Centralising it ensures the
+// two surfaces never drift on whether the warning is appended or
+// what code it carries.
+func stampTargetVersion(env *output.Envelope, parserVersion, targetVersion string) {
+	if targetVersion == "" {
+		return
+	}
+	env.TargetVersion = targetVersion
+	if warning, ok := output.VersionMismatchWarning(parserVersion, targetVersion); ok {
+		env.Errors = append(env.Errors, warning)
+	}
+}
+
+// resolveTargetVersion picks the target version to stamp onto the
+// envelope for a single tool call. The per-call target_version
+// argument wins over defaultTargetVersion when it is present, a
+// string, and non-empty after trimming. A non-string value is a
+// hard error (returned as a tool error) because there is no
+// reasonable interpretation; an empty string is treated as "use the
+// default" so clients can send the field unconditionally without
+// disabling the server-level default.
+//
+// On success the returned *mcp.CallToolResult is nil. On a malformed
+// per-call argument it is a pre-built tool error so the caller can
+// return immediately rather than producing a misleading envelope.
+func resolveTargetVersion(req mcp.CallToolRequest, defaultTargetVersion string) (string, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[TargetVersionParamName]
+	if !exists {
+		return defaultTargetVersion, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter must be a string, got %T", TargetVersionParamName, raw))
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		// Treat an empty per-call value as "use the default" rather
+		// than as a validation error; clients that send {"target_version": ""}
+		// likely mean "no override".
+		return defaultTargetVersion, nil
+	}
+	canonical, err := output.ValidateTargetVersion(s)
+	if err != nil {
+		return "", mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter: %v", TargetVersionParamName, err))
+	}
+	return canonical, nil
 }
 
 // envelopeResult marshals env as JSON and wraps it in a successful MCP

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -54,7 +54,7 @@ func TestExplainSQLHandlerParameterValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := ExplainSQLHandler(testParserVersion)
+			handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
 			req := mcpgo.CallToolRequest{}
 			req.Params.Arguments = tc.args
 
@@ -66,13 +66,44 @@ func TestExplainSQLHandlerParameterValidation(t *testing.T) {
 	}
 }
 
+// TestExplainSQLHandlerRejectsMalformedTargetVersion confirms a
+// per-call target_version that fails validation is rejected as a
+// tool error before any cluster dial is attempted. The Tier 3 path
+// shares resolveTargetVersion with the Tier 1 handlers, but explain
+// has the additional cost of a network attempt — so this case
+// specifically pins that validation runs first.
+func TestExplainSQLHandlerRejectsMalformedTargetVersion(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECT 1",
+		"dsn":            "postgres://nope:1/db?connect_timeout=1",
+		"target_version": "garbage",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "malformed target_version must surface as a tool error")
+}
+
+// TestExplainSQLToolAdvertisesTargetVersionParam pins that the MCP
+// schema for explain_sql lists target_version among its parameters,
+// so clients can discover the override surface from tool metadata
+// without reading the source.
+func TestExplainSQLToolAdvertisesTargetVersionParam(t *testing.T) {
+	tool := ExplainSQLTool()
+	props := tool.InputSchema.Properties
+	require.Contains(t, props, TargetVersionParamName,
+		"explain_sql schema must advertise the target_version property")
+}
+
 // TestExplainSQLHandlerConnectionFailureSurfacesEnvelopeError verifies
 // that when the cluster is unreachable, the handler returns a successful
 // MCP tool result whose envelope carries the error — not a tool-level
 // error. This is the discipline documented in tools.go: SQL/cluster
 // problems live in the envelope so agents can read them uniformly.
 func TestExplainSQLHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
-	handler := ExplainSQLHandler(testParserVersion)
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"sql": "SELECT 1",
@@ -163,7 +194,7 @@ func TestParseSQLHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := ParseSQLHandler(testParserVersion)
+			handler := ParseSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
 			req := mcpgo.CallToolRequest{}
 			req.Params.Arguments = tc.args
 
@@ -252,7 +283,7 @@ func TestValidateSQLHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := ValidateSQLHandler(testParserVersion)
+			handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
 			req := mcpgo.CallToolRequest{}
 			req.Params.Arguments = tc.args
 
@@ -332,7 +363,7 @@ func TestFormatSQLHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := FormatSQLHandler(testParserVersion)
+			handler := FormatSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
 			req := mcpgo.CallToolRequest{}
 			req.Params.Arguments = tc.args
 
@@ -417,7 +448,7 @@ func TestDetectRiskyQueryHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			handler := DetectRiskyQueryHandler(testParserVersion)
+			handler := DetectRiskyQueryHandler(testParserVersion, "" /* defaultTargetVersion */)
 			req := mcpgo.CallToolRequest{}
 			req.Params.Arguments = tc.args
 
@@ -456,6 +487,220 @@ func TestDetectRiskyQueryHandler(t *testing.T) {
 				require.Equal(t, risk.SeverityCritical, findings[0].Severity)
 				require.NotEmpty(t, findings[0].FixHint)
 			}
+		})
+	}
+}
+
+// TestResolveTargetVersion locks the precedence rule (per-call argument
+// beats server default), the empty-string-means-default convention, and
+// the input-validation contract. The wire-level effect of the chosen
+// value (envelope stamping + warning) is covered separately in
+// TestBaseEnvelope and the per-tool integration cases below.
+func TestResolveTargetVersion(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  map[string]any
+		defaultTargetVersion  string
+		expectedTargetVersion string
+		expectedToolErr       bool
+	}{
+		{
+			name:                  "no arg uses default",
+			args:                  map[string]any{},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "25.4.0",
+		},
+		{
+			name:                  "no arg and no default yields empty",
+			args:                  map[string]any{},
+			defaultTargetVersion:  "",
+			expectedTargetVersion: "",
+		},
+		{
+			name:                  "per-call arg overrides default",
+			args:                  map[string]any{"target_version": "26.1.0"},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "26.1.0",
+		},
+		{
+			name:                  "per-call arg canonicalizes leading v",
+			args:                  map[string]any{"target_version": "v26.1.0"},
+			defaultTargetVersion:  "",
+			expectedTargetVersion: "26.1.0",
+		},
+		{
+			// Pins that override and canonicalization compose; a
+			// future short-circuit that returns the per-call arg
+			// raw when a default is also set would slip past
+			// either case in isolation.
+			name:                  "per-call arg with leading v beats default and canonicalizes",
+			args:                  map[string]any{"target_version": "v26.1.0"},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "26.1.0",
+		},
+		{
+			name:                  "empty per-call arg falls through to default",
+			args:                  map[string]any{"target_version": ""},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "25.4.0",
+		},
+		{
+			name:                 "non-string per-call arg returns tool error",
+			args:                 map[string]any{"target_version": 25},
+			defaultTargetVersion: "",
+			expectedToolErr:      true,
+		},
+		{
+			name:                 "malformed per-call arg returns tool error",
+			args:                 map[string]any{"target_version": "garbage"},
+			defaultTargetVersion: "",
+			expectedToolErr:      true,
+		},
+		{
+			name:                 "leading whitespace on per-call arg is tolerated",
+			args:                 map[string]any{"target_version": "  25.4.0  "},
+			defaultTargetVersion: "",
+			// resolveTargetVersion both trims itself and forwards
+			// to ValidateTargetVersion (which also trims), so this
+			// pins that whitespace handling matches the CLI.
+			expectedTargetVersion: "25.4.0",
+		},
+		{
+			// Pins that "v" alone is rejected as malformed rather
+			// than canonicalized to "" and silently falling
+			// through to the default.
+			name:                 "v-only per-call arg returns tool error",
+			args:                 map[string]any{"target_version": "v"},
+			defaultTargetVersion: "25.4.0",
+			expectedToolErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			got, toolErr := resolveTargetVersion(req, tc.defaultTargetVersion)
+			if tc.expectedToolErr {
+				require.NotNil(t, toolErr)
+				return
+			}
+			require.Nil(t, toolErr)
+			require.Equal(t, tc.expectedTargetVersion, got)
+		})
+	}
+}
+
+// TestResolveTargetVersionErrorMentionsParam pins that tool errors
+// returned for a malformed target_version argument include the
+// parameter name. Clients invoking a tool with several validated
+// arguments need to know *which* one was rejected.
+func TestResolveTargetVersionErrorMentionsParam(t *testing.T) {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"target_version": "garbage"}
+
+	_, toolErr := resolveTargetVersion(req, "")
+	require.NotNil(t, toolErr)
+	require.True(t, toolErr.IsError)
+	require.Len(t, toolErr.Content, 1)
+	text, ok := toolErr.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	require.Contains(t, text.Text, TargetVersionParamName)
+}
+
+// TestBaseEnvelope pins the wire-level effect of targetVersion: empty
+// → no field, no warning; non-empty matching parser → field stamped,
+// no warning; non-empty mismatching parser → field stamped + warning
+// appended. Each tool handler delegates to this helper, so covering it
+// once spares per-tool duplication.
+func TestBaseEnvelope(t *testing.T) {
+	t.Run("empty target version omits field and emits no warning", func(t *testing.T) {
+		env := baseEnvelope("v0.26.2", "")
+		require.Equal(t, output.TierZeroConfig, env.Tier)
+		require.Equal(t, "v0.26.2", env.ParserVersion)
+		require.Empty(t, env.TargetVersion)
+		require.Empty(t, env.Errors)
+	})
+
+	t.Run("matching target version stamps field with no warning", func(t *testing.T) {
+		env := baseEnvelope("v0.26.2", "0.26.5")
+		require.Equal(t, "0.26.5", env.TargetVersion)
+		require.Empty(t, env.Errors,
+			"matching MAJOR.MINOR must not produce a warning")
+	})
+
+	t.Run("mismatched target version stamps field and appends warning", func(t *testing.T) {
+		env := baseEnvelope("v0.26.2", "1.0.0")
+		require.Equal(t, "1.0.0", env.TargetVersion)
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, "target_version_mismatch", env.Errors[0].Code)
+		require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	})
+}
+
+// TestParseSQLHandlerTargetVersion confirms that the per-call
+// target_version argument lands on the envelope returned by an actual
+// tool handler. The other three Tier 1 handlers go through the same
+// resolve+stamp helpers, so this single end-to-end check protects the
+// whole MCP wiring without quadrupling the table sizes above.
+func TestParseSQLHandlerTargetVersion(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  map[string]any
+		defaultTargetVersion  string
+		expectedTargetVersion string
+		expectedToolErr       bool
+	}{
+		{
+			name:                  "default applies when no per-call arg",
+			args:                  map[string]any{"sql": "SELECT 1"},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "25.4.0",
+		},
+		{
+			name: "per-call arg overrides default",
+			args: map[string]any{
+				"sql":            "SELECT 1",
+				"target_version": "26.1.0",
+			},
+			defaultTargetVersion:  "25.4.0",
+			expectedTargetVersion: "26.1.0",
+		},
+		{
+			name:                  "no arg and no default omits field",
+			args:                  map[string]any{"sql": "SELECT 1"},
+			defaultTargetVersion:  "",
+			expectedTargetVersion: "",
+		},
+		{
+			name: "malformed per-call arg returns tool error",
+			args: map[string]any{
+				"sql":            "SELECT 1",
+				"target_version": "garbage",
+			},
+			defaultTargetVersion: "",
+			expectedToolErr:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ParseSQLHandler(testParserVersion, tc.defaultTargetVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError)
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, tc.expectedTargetVersion, env.TargetVersion)
 		})
 	}
 }

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -25,20 +25,27 @@ func ValidateSQLTool() mcp.Tool {
 		ValidateSQLToolName,
 		mcp.WithDescription("Validate SQL for syntax and type errors. Returns an envelope with {\"valid\": true} on success, or structured errors with SQLSTATE codes, severity, message, and source position on failure."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to validate")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
 }
 
 // ValidateSQLHandler returns the handler for the validate_sql tool. It
 // parses the SQL, runs expression type checking, and returns the
 // standard output.Envelope used by all Tier 1 tools.
-func ValidateSQLHandler(parserVersion string) server.ToolHandlerFunc {
+// defaultTargetVersion is the server-level default; per-call
+// target_version arguments override it.
+func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractSQL(req)
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := baseEnvelope(parserVersion)
+		env := baseEnvelope(parserVersion, target)
 
 		stmts, parseErr := parser.Parse(sql)
 		if parseErr != nil {

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -74,6 +74,10 @@ const (
 //     value.
 //   - ParserVersion and ConnectionStatus are always emitted so agents
 //     can rely on their presence.
+//   - TargetVersion uses omitempty so the field is absent when the
+//     user did not pass --target-version (or the equivalent MCP
+//     parameter). This preserves byte-identical output for the
+//     unflagged path.
 //   - Errors uses omitempty so a clean run produces no errors key
 //     rather than a noisy "errors": null.
 //   - Data is json.RawMessage so each subcommand controls its own
@@ -82,10 +86,23 @@ const (
 type Envelope struct {
 	Tier             Tier             `json:"tier,omitempty"`
 	ParserVersion    string           `json:"parser_version"`
+	TargetVersion    string           `json:"target_version,omitempty"`
 	ConnectionStatus ConnectionStatus `json:"connection_status"`
 	Errors           []Error          `json:"errors,omitempty"`
 	Data             json.RawMessage  `json:"data,omitempty"`
 }
+
+// Stable Error.Code values. Agents key off these strings, so renames
+// are breaking changes; new codes are added by appending here. Codes
+// are namespaced by the producing concept (e.g. "target_version_*"
+// for envelope-level version-handling diagnostics).
+const (
+	// CodeTargetVersionMismatch is emitted by
+	// output.VersionMismatchWarning when the user-declared target
+	// version differs from the bundled parser version at the
+	// MAJOR.MINOR level.
+	CodeTargetVersionMismatch = "target_version_mismatch"
+)
 
 // Severity is the severity level of a structured Error. Values use the
 // PostgreSQL frontend/backend protocol severity strings (uppercase) so

--- a/internal/output/envelope_test.go
+++ b/internal/output/envelope_test.go
@@ -56,6 +56,21 @@ func TestEnvelopeMarshal(t *testing.T) {
 }`,
 		},
 		{
+			name: "target_version emitted when set",
+			envelope: Envelope{
+				Tier:             TierZeroConfig,
+				ParserVersion:    "v0.26.2",
+				TargetVersion:    "25.4.0",
+				ConnectionStatus: ConnectionDisconnected,
+			},
+			expectedJSON: `{
+  "tier": "zero_config",
+  "parser_version": "v0.26.2",
+  "target_version": "25.4.0",
+  "connection_status": "disconnected"
+}`,
+		},
+		{
 			name: "errors-only envelope",
 			envelope: Envelope{
 				ParserVersion:    "v0.26.2",

--- a/internal/output/version.go
+++ b/internal/output/version.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package output
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ValidateTargetVersion parses a user-supplied CockroachDB target
+// version string and returns its canonical form. The accepted shapes
+// are MAJOR.MINOR and MAJOR.MINOR.PATCH, optionally prefixed with a
+// single "v" (so "v25.4.0" and "25.4.0" are both accepted). The
+// canonical form differs from the input in exactly one way: a leading
+// "v" is stripped. Patch presence/absence and exact digits are
+// preserved verbatim, so "25.4" and "25.4.0" remain distinct strings
+// even though they represent the same minor release.
+//
+// Surrounding whitespace is trimmed before validation so the CLI and
+// MCP entry points behave the same when callers paste a value.
+//
+// An empty input (after trimming) returns an error; callers that
+// treat empty as "no target version supplied" should check for the
+// empty string before invoking this helper.
+func ValidateTargetVersion(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("target version must not be empty")
+	}
+	canonical := strings.TrimPrefix(s, "v")
+	parts := strings.Split(canonical, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return "", fmt.Errorf("target version %q is not MAJOR.MINOR or MAJOR.MINOR.PATCH", s)
+	}
+	for _, p := range parts {
+		if p == "" {
+			return "", fmt.Errorf("target version %q has an empty component", s)
+		}
+		// ParseUint rejects signs and non-numeric input in one step,
+		// so "-1.4.0", "+1.4.0", and "25.x.0" all fail here. Atoi
+		// would accept the signed forms, which is not the contract
+		// we advertise.
+		if _, err := strconv.ParseUint(p, 10, 32); err != nil {
+			return "", fmt.Errorf("target version %q has non-numeric component %q", s, p)
+		}
+	}
+	return canonical, nil
+}
+
+// VersionMismatchWarning compares the parser version compiled into the
+// binary against the user-supplied target version and, when the major
+// or minor components differ, returns a warning Error suitable for
+// appending to Envelope.Errors. The bool return indicates whether a
+// warning was produced; callers should append only when it is true.
+//
+// targetVersion is expected to already be in canonical form
+// (post-ValidateTargetVersion). The silent-skip path is meant to
+// tolerate an unresolvable parserVersion; a parse failure on
+// targetVersion would indicate a caller contract violation but is
+// also tolerated rather than panicked on, since it never makes sense
+// to fail a SQL operation just because the version-mismatch check
+// could not run.
+//
+// Comparison is on MAJOR.MINOR only — patch-level differences are
+// noise for users who care about feature compatibility, not bug-fix
+// releases. If either input cannot be parsed (e.g. parserVersion
+// resolved to "unknown" in a development build), no warning is
+// produced; callers should not punish users for an unresolvable
+// bundled version.
+//
+// Known limitation (tracked separately): parserVersion today is the
+// cockroachdb-parser Go-module version (e.g. "v0.26.2"), not the
+// CockroachDB release version it implements. Until the parser ships
+// a CRDB-version mapping, a user supplying --target-version 25.4.0
+// will see "parser is v0.26 but target is v25.4" — technically
+// correct under the implemented contract, but semantically a false
+// positive. Stage 2/3 (#83/#85) will revisit how versions compare.
+func VersionMismatchWarning(parserVersion, targetVersion string) (Error, bool) {
+	parserMajorMinor, ok := majorMinor(parserVersion)
+	if !ok {
+		return Error{}, false
+	}
+	targetMajorMinor, ok := majorMinor(targetVersion)
+	if !ok {
+		return Error{}, false
+	}
+	if parserMajorMinor == targetMajorMinor {
+		return Error{}, false
+	}
+	return Error{
+		Code:     CodeTargetVersionMismatch,
+		Severity: SeverityWarning,
+		Message: fmt.Sprintf(
+			"parser is v%s but target is v%s — results may differ",
+			parserMajorMinor, targetMajorMinor,
+		),
+	}, true
+}
+
+// majorMinor extracts the MAJOR.MINOR prefix from a version string,
+// tolerating a leading "v" and any number of additional dot-separated
+// suffix components (e.g. patch, build metadata, pre-release tags).
+// Returns ("", false) when the string does not start with two
+// dot-separated unsigned-numeric components. Sign-prefixed parts like
+// "-1" are rejected to match ValidateTargetVersion's contract.
+func majorMinor(v string) (string, bool) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return "", false
+	}
+	if _, err := strconv.ParseUint(parts[0], 10, 32); err != nil {
+		return "", false
+	}
+	if _, err := strconv.ParseUint(parts[1], 10, 32); err != nil {
+		return "", false
+	}
+	return parts[0] + "." + parts[1], true
+}

--- a/internal/output/version_test.go
+++ b/internal/output/version_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTargetVersion(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expectedCanonical string
+		expectedErr       string
+	}{
+		{name: "major.minor.patch", input: "25.4.0", expectedCanonical: "25.4.0"},
+		{name: "major.minor", input: "25.4", expectedCanonical: "25.4"},
+		{name: "leading v stripped", input: "v25.4.0", expectedCanonical: "25.4.0"},
+		{name: "leading v with major.minor", input: "v25.4", expectedCanonical: "25.4"},
+		{name: "multi-digit components", input: "v123.456.789", expectedCanonical: "123.456.789"},
+		{name: "empty rejected", input: "", expectedErr: "must not be empty"},
+		{name: "single component rejected", input: "25", expectedErr: "MAJOR.MINOR"},
+		{name: "four components rejected", input: "25.4.0.1", expectedErr: "MAJOR.MINOR"},
+		{name: "non-numeric rejected", input: "25.x.0", expectedErr: "non-numeric"},
+		{name: "trailing dot rejected", input: "25.4.", expectedErr: "empty component"},
+		{name: "leading dot rejected", input: ".25.4", expectedErr: "empty component"},
+		{name: "negative component rejected", input: "-1.4.0", expectedErr: "non-numeric"},
+		{name: "signed component rejected", input: "25.+4.0", expectedErr: "non-numeric"},
+		{name: "leading whitespace trimmed", input: "  25.4.0", expectedCanonical: "25.4.0"},
+		{name: "trailing whitespace trimmed", input: "25.4.0\n", expectedCanonical: "25.4.0"},
+		{name: "whitespace-only rejected", input: "   ", expectedErr: "must not be empty"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ValidateTargetVersion(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCanonical, got)
+		})
+	}
+}
+
+func TestVersionMismatchWarning(t *testing.T) {
+	tests := []struct {
+		name            string
+		parser          string
+		target          string
+		expectWarning   bool
+		expectedMessage string
+	}{
+		{
+			name:            "different major.minor produces warning",
+			parser:          "v26.2.0",
+			target:          "25.4.0",
+			expectWarning:   true,
+			expectedMessage: "parser is v26.2 but target is v25.4 — results may differ",
+		},
+		{
+			name:          "matching major.minor produces no warning",
+			parser:        "v25.4.0",
+			target:        "25.4.1",
+			expectWarning: false,
+		},
+		{
+			name:          "matching major.minor without patch",
+			parser:        "v25.4.0",
+			target:        "25.4",
+			expectWarning: false,
+		},
+		{
+			name:          "different major produces warning",
+			parser:        "v26.0.0",
+			target:        "25.0.0",
+			expectWarning: true,
+		},
+		{
+			name:          "different minor produces warning",
+			parser:        "v25.3.0",
+			target:        "25.4.0",
+			expectWarning: true,
+		},
+		{
+			name:          "unknown parser version skips warning",
+			parser:        "unknown",
+			target:        "25.4.0",
+			expectWarning: false,
+		},
+		{
+			name:          "unparseable target skips warning",
+			parser:        "v25.4.0",
+			target:        "garbage",
+			expectWarning: false,
+		},
+		{
+			// Pins that majorMinor uses ParseUint, not Atoi. A
+			// regression that swapped back to Atoi would silently
+			// start emitting warnings against signed parser
+			// versions in dev builds.
+			name:          "signed parser component skips warning",
+			parser:        "-1.4.0",
+			target:        "25.4.0",
+			expectWarning: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			warning, ok := VersionMismatchWarning(tc.parser, tc.target)
+			require.Equal(t, tc.expectWarning, ok)
+			if !tc.expectWarning {
+				return
+			}
+			require.Equal(t, "target_version_mismatch", warning.Code)
+			require.Equal(t, SeverityWarning, warning.Severity)
+			if tc.expectedMessage != "" {
+				require.Equal(t, tc.expectedMessage, warning.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a --target-version persistent flag so users can declare the
CockroachDB version they target. The value is canonicalized
(MAJOR.MINOR or MAJOR.MINOR.PATCH, with optional leading "v") and
stamped onto the response envelope as `target_version`. When the
target diverges from the bundled cockroachdb-parser at the
MAJOR.MINOR level, a `target_version_mismatch` warning is appended
to envelope.errors so agents can spot the mismatch without parsing
human-readable text.

The MCP surface gets equivalent reach. `crdb-sql mcp` accepts the
same flag as a server-level default, and every Tier 1 tool (parse,
validate, format, detect_risky_query) now accepts an optional
per-call `target_version` argument that overrides the default.

Behaviour change: none yet. This is stage 1 of #81 -- wiring only.
Stages 2 and 3 (#83, #85) will act on the value to gate parser and
validation behaviour.

Notes for reviewers:
- The warning reuses the existing output.Error+SeverityWarning
  pattern (see cmd/describe.go) rather than introducing a separate
  Warnings field on the envelope.
- The new envelope field uses `omitempty` so the unflagged path
  produces byte-identical JSON to today.
- internal/mcp.NewServer renamed binaryVersion -> crdbSQLVersion
  to disambiguate from parserVersion and the new
  defaultTargetVersion.
- Known limitation documented in VersionMismatchWarning godoc:
  parserVersion today is the cockroachdb-parser Go-module version
  (v0.26.2), not the CRDB release version. Until a parser-to-CRDB
  mapping exists, mismatch warnings against legitimate targets are
  semantic false positives. Stage 2/3 will revisit.

Resolves: #82
Informs: #81