### PR TITLE
config: add crdb-sql.yaml for schema/query globs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/config"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
@@ -45,6 +47,12 @@ type rootState struct {
 	// a connection check for empty and return a structured error.
 	// Populated by PersistentPreRunE.
 	dsn string
+
+	// cfg is the parsed crdb-sql.yaml, or nil when no config file was
+	// found in CWD (or pointed at by --config). Subcommands treat nil
+	// as "no project config; use flags" — config consumption is
+	// opt-in per subcommand. Populated by PersistentPreRunE.
+	cfg *config.File
 }
 
 // newRootCmd builds a fresh root command with all subcommands attached.
@@ -86,6 +94,16 @@ round-tripping through a live cluster.`,
 			} else {
 				state.dsn = os.Getenv("CRDB_DSN")
 			}
+
+			cfgPath, err := cmd.Flags().GetString(configFlag)
+			if err != nil {
+				return err
+			}
+			cfg, err := loadConfig(cfgPath)
+			if err != nil {
+				return err
+			}
+			state.cfg = cfg
 			return nil
 		},
 	}
@@ -93,6 +111,8 @@ round-tripping through a live cluster.`,
 		`output format: "text" or "json"`)
 	root.PersistentFlags().String(dsnFlag, "",
 		"CockroachDB connection string (overrides CRDB_DSN env var)")
+	root.PersistentFlags().String(configFlag, "",
+		"path to crdb-sql.yaml (default: auto-discover in CWD)")
 	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newPingCmd(state))
 	root.AddCommand(newParseCmd(state))
@@ -112,7 +132,24 @@ round-tripping through a live cluster.`,
 const (
 	outputFlag = "output"
 	dsnFlag    = "dsn"
+	configFlag = "config"
 )
+
+// loadConfig resolves the project YAML config. When path is non-empty,
+// the file at that path must exist and parse cleanly (explicit user
+// intent — fail loudly). When path is empty, Discover looks in CWD;
+// absence is silently tolerated so commands work outside configured
+// projects.
+func loadConfig(path string) (*config.File, error) {
+	if path != "" {
+		return config.Load(path)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	return config.Discover(cwd)
+}
 
 // Execute runs the root command against process arguments and returns
 // whatever cobra surfaces. It does not print the error or call

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
@@ -72,6 +73,12 @@ const (
 // and the envelope carries a `capability_required` warning entry so
 // agents can detect the missing capability rather than silently trust
 // a partial result.
+//
+// When neither -e nor a file argument is given AND a crdb-sql.yaml
+// config has been auto-discovered (or pointed at by --config), validate
+// falls back to the project-wide path: every query file matched by the
+// config is parsed, type-checked, and (per pair) name-resolved against
+// the pair's schema globs, all reported in one envelope.
 func newValidateCmd(state *rootState) *cobra.Command {
 	var (
 		expr        string
@@ -91,9 +98,17 @@ SELECT/INSERT/UPDATE/DELETE statements are checked against the loaded
 catalog and unknown tables are reported as 42P01 errors with an
 "available_tables" context list. Without --schema, name resolution is
 skipped and a capability_required warning is added to the envelope so
-agents can tell that the check did not run.`,
+agents can tell that the check did not run.
+
+If no -e and no file argument are given and a crdb-sql.yaml config is
+present in the working directory, validate iterates every query file
+matched by the config and reports per-file results in one envelope.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if expr == "" && len(args) == 0 && len(schemaFiles) == 0 && state.cfg != nil {
+				return runValidateConfig(state, cmd)
+			}
+
 			tier := output.TierZeroConfig
 			if len(schemaFiles) > 0 {
 				tier = output.TierSchemaFile
@@ -169,6 +184,214 @@ agents can tell that the check did not run.`,
 		"schema SQL file(s) to enable table name resolution (repeatable)")
 
 	return cmd
+}
+
+// fileResult is one entry in the JSON payload for the config-driven
+// validate path. Each query file gets exactly one entry; ErrorCount
+// is the number of structured Errors attributable to that file.
+type fileResult struct {
+	File       string `json:"file"`
+	Valid      bool   `json:"valid"`
+	ErrorCount int    `json:"error_count"`
+}
+
+// runValidateConfig executes the YAML-config fallback path of
+// validate. It expands every SQLPair's globs, loads the schema set
+// into a catalog (DDL parse failures abort the run), then parses and
+// name-resolves each query file individually against that catalog.
+// Per-file diagnostics accumulate into one envelope with a JSON
+// payload describing each file's pass/fail status.
+//
+// Each SQLPair gets its own catalog so projects can keep production
+// and test schemas separate. A pair with no schema globs runs syntax
+// and type checks only — its query files are still validated, just
+// without name resolution.
+func runValidateConfig(state *rootState, cmd *cobra.Command) error {
+	r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
+	if err != nil {
+		return r.RenderError(baseEnv, err)
+	}
+
+	cfg := state.cfg
+	var (
+		results       []fileResult
+		queryAnyError bool
+	)
+
+	for _, pair := range cfg.SQL {
+		schemaPaths, err := pair.ExpandSchema(cfg.BaseDir)
+		if err != nil {
+			return r.RenderError(baseEnv, err)
+		}
+		queryPaths, err := pair.ExpandQueries(cfg.BaseDir)
+		if err != nil {
+			return r.RenderError(baseEnv, err)
+		}
+
+		// Load the pair's schema set into a catalog. A DDL parse
+		// failure is a config-level error: the project's source-of-
+		// truth schema is broken, and no per-query result would be
+		// trustworthy.
+		var cat *catalog.Catalog
+		if len(schemaPaths) > 0 {
+			cat, err = catalog.LoadFiles(schemaPaths)
+			if err != nil {
+				return renderSchemaLoadError(r, baseEnv, err)
+			}
+			appendSchemaWarnings(&baseEnv, cat)
+		}
+
+		for _, qp := range queryPaths {
+			fileErrs, ok := validateQueryFile(qp, cat)
+			results = append(results, fileResult{
+				File:       qp,
+				Valid:      ok,
+				ErrorCount: len(fileErrs),
+			})
+			baseEnv.Errors = append(baseEnv.Errors, fileErrs...)
+			if !ok {
+				queryAnyError = true
+			}
+		}
+	}
+
+	data, err := json.Marshal(struct {
+		Files []fileResult `json:"files"`
+	}{Files: results})
+	if err != nil {
+		return r.RenderError(baseEnv, err)
+	}
+	baseEnv.Data = data
+
+	renderErr := r.Render(baseEnv, func(w io.Writer) error {
+		return renderConfigText(w, results, baseEnv.Errors)
+	})
+	if renderErr != nil {
+		return renderErr
+	}
+	// Mirror the single-input path: a failed validation exits
+	// non-zero via ErrRendered so CI pipelines (and the shell)
+	// notice. queryAnyError covers per-file query problems; schema
+	// warnings alone are not failures.
+	if queryAnyError {
+		return output.ErrRendered
+	}
+	return nil
+}
+
+// validateQueryFile reads one query file and runs the same parse +
+// type-check pipeline used in the single-input path. When cat is
+// non-nil, table-name resolution also runs against it. Each returned
+// output.Error is tagged with the file path in Context["file"] so
+// agents can attribute diagnostics across many files in one envelope.
+// Returns ok=true when no errors were found.
+func validateQueryFile(path string, cat *catalog.Catalog) (errs []output.Error, ok bool) {
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		return []output.Error{{
+			Code:     "io_error",
+			Severity: output.SeverityError,
+			Message:  fmt.Sprintf("read query file: %v", readErr),
+			Context:  map[string]any{"file": path},
+		}}, false
+	}
+	sql := strings.TrimSpace(string(data))
+	if sql == "" {
+		// An empty query file is not an error: glob matches can pick
+		// up partial files in development. Reporting "file is empty"
+		// would be noise for the common case of `git checkout` mid-
+		// edit.
+		return nil, true
+	}
+
+	stmts, parseErr := parser.Parse(sql)
+	if parseErr != nil {
+		e := diag.FromParseError(parseErr, sql)
+		return []output.Error{tagFile(e, path)}, false
+	}
+
+	var fileErrs []output.Error
+	for _, e := range semcheck.CheckExprTypes(stmts, sql) {
+		fileErrs = append(fileErrs, tagFile(e, path))
+	}
+	if cat != nil {
+		for _, e := range semcheck.CheckTableNames(stmts, sql, cat) {
+			fileErrs = append(fileErrs, tagFile(e, path))
+		}
+	}
+	if len(fileErrs) == 0 {
+		return nil, true
+	}
+	return fileErrs, false
+}
+
+// tagFile attaches the source file path to an error's Context so
+// downstream consumers (agents, CI runners) can group diagnostics by
+// file. Existing Context entries are preserved.
+//
+// The returned Error always owns a fresh Context map: output.Error is
+// passed by value but its Context field is a map header, so without a
+// copy the caller's map would be mutated and the "file" tag could
+// bleed across files if upstream code reuses error templates.
+func tagFile(e output.Error, path string) output.Error {
+	if e.Context == nil {
+		e.Context = map[string]any{"file": path}
+		return e
+	}
+	ctx := make(map[string]any, len(e.Context)+1)
+	for k, v := range e.Context {
+		ctx[k] = v
+	}
+	ctx["file"] = path
+	e.Context = ctx
+	return e
+}
+
+// renderConfigText is the human-readable layout for the config-driven
+// validate path. One line per file: either "PATH: valid" or, for
+// failed files, the per-file diagnostics with line/column/code.
+// Schema-level warnings (no associated file) print first.
+func renderConfigText(w io.Writer, results []fileResult, errs []output.Error) error {
+	for _, e := range errs {
+		if _, hasFile := e.Context["file"]; hasFile {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "[%s] %s\n", e.Severity, e.Message); err != nil {
+			return err
+		}
+	}
+
+	errsByFile := make(map[string][]output.Error, len(results))
+	for _, e := range errs {
+		path, ok := e.Context["file"].(string)
+		if !ok {
+			continue
+		}
+		errsByFile[path] = append(errsByFile[path], e)
+	}
+
+	for _, fr := range results {
+		if fr.Valid {
+			if _, err := fmt.Fprintf(w, "%s: valid\n", fr.File); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, e := range errsByFile[fr.File] {
+			pos := e.Position
+			if pos != nil {
+				if _, err := fmt.Fprintf(w, "%s:%d:%d: %s [%s]\n",
+					fr.File, pos.Line, pos.Column, e.Message, e.Code); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "%s: %s [%s]\n", fr.File, e.Message, e.Code); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // capabilityRequiredError builds the warning entry that signals a

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -261,6 +261,339 @@ func TestValidateCmdColumnRefNoTypeError(t *testing.T) {
 	require.Equal(t, validTextNoSchema, stdout.String())
 }
 
+// writeFile is a small test helper that creates a file under dir
+// (creating parents as needed) and returns the full path.
+func writeFile(t *testing.T, dir, rel, contents string) string {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+	return full
+}
+
+// setupValidateConfigProject lays down a tiny project with one
+// schema, one valid query, one query that fails to parse, and a
+// crdb-sql.yaml that ties them together. Returns the directory and
+// the absolute paths of the two query files for assertion-side use.
+func setupValidateConfigProject(t *testing.T) (dir, goodQuery, badQuery string) {
+	t.Helper()
+	dir = t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY, name STRING);\n")
+	goodQuery = writeFile(t, dir, "queries/q1.sql", "SELECT * FROM users;\n")
+	badQuery = writeFile(t, dir, "queries/sub/q2_bad.sql", "SELECT FROM\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/**/*.sql"]
+`)
+	return dir, goodQuery, badQuery
+}
+
+// TestValidateCmdConfigJSON verifies the YAML-driven path: with a
+// config and no -e/file arg, validate iterates every matched query
+// file, attaches the file path to each error's Context, and exits
+// non-zero overall when any file is invalid.
+func TestValidateCmdConfigJSON(t *testing.T) {
+	dir, goodQuery, badQuery := setupValidateConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered, "any failed file must surface as ErrRendered")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Len(t, env.Errors, 1, "exactly the bad query should produce an error")
+
+	gotErr := env.Errors[0]
+	require.Equal(t, "42601", gotErr.Code)
+	require.Equal(t, badQuery, gotErr.Context["file"])
+
+	var payload struct {
+		Files []struct {
+			File       string `json:"file"`
+			Valid      bool   `json:"valid"`
+			ErrorCount int    `json:"error_count"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 2)
+
+	byFile := map[string]bool{}
+	for _, f := range payload.Files {
+		byFile[f.File] = f.Valid
+	}
+	require.True(t, byFile[goodQuery], "good query should be valid")
+	require.False(t, byFile[badQuery], "bad query should be invalid")
+}
+
+// TestValidateCmdConfigText verifies that text-mode output for the
+// config path lists each file with a status line.
+func TestValidateCmdConfigText(t *testing.T) {
+	dir, goodQuery, badQuery := setupValidateConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	got := stdout.String()
+	require.Contains(t, got, goodQuery+": valid")
+	require.Contains(t, got, badQuery+":")
+	require.Contains(t, got, "syntax error")
+	require.Contains(t, got, "42601")
+}
+
+// TestValidateCmdConfigAllValid verifies that a config whose query
+// files all parse cleanly exits zero (no ErrRendered) and reports no
+// errors.
+func TestValidateCmdConfigAllValid(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	good1 := writeFile(t, dir, "queries/q1.sql", "SELECT * FROM users;\n")
+	good2 := writeFile(t, dir, "queries/q2.sql", "SELECT 1;\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var payload struct {
+		Files []struct {
+			File  string `json:"file"`
+			Valid bool   `json:"valid"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 2)
+	for _, f := range payload.Files {
+		require.True(t, f.Valid, "file %s should be valid", f.File)
+	}
+	require.Contains(t, []string{payload.Files[0].File, payload.Files[1].File}, good1)
+	require.Contains(t, []string{payload.Files[0].File, payload.Files[1].File}, good2)
+}
+
+// TestValidateCmdCLIOverridesConfig verifies that an explicit -e
+// short-circuits the config path even when a config is loaded — the
+// per-user precedence rule.
+func TestValidateCmdCLIOverridesConfig(t *testing.T) {
+	dir, _, _ := setupValidateConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+		"-e", "SELECT 1",
+	})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, validTextNoSchema, stdout.String(),
+		"explicit -e must short-circuit the config path and run the no-schema text path")
+}
+
+// TestValidateCmdConfigCLISchemaWins verifies that an explicit --schema
+// also short-circuits the config path: the user is asking for a one-off
+// validation against a specific schema, not the project default.
+func TestValidateCmdConfigCLISchemaWins(t *testing.T) {
+	dir, _, _ := setupValidateConfigProject(t)
+	otherSchema := writeUsersSchema(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+		"--schema", otherSchema,
+		"-e", "SELECT * FROM users",
+	})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, "Valid.\n", stdout.String(),
+		"explicit --schema must use the single-input flow with name resolution")
+}
+
+// TestValidateCmdConfigUnknownTable verifies that the YAML config path
+// runs name resolution against the loaded schema and surfaces unknown-
+// table errors per file (proving the catalog is actually consulted, not
+// just loaded).
+func TestValidateCmdConfigUnknownTable(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	bad := writeFile(t, dir, "queries/q.sql", "SELECT * FROM nonexistent;\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "42P01", env.Errors[0].Code)
+	require.Equal(t, bad, env.Errors[0].Context["file"])
+}
+
+// TestValidateCmdConfigMissingFileFails verifies that pointing
+// --config at a non-existent path is a hard error rather than a
+// silent fall-through (Discover tolerates absence; explicit Load does
+// not).
+func TestValidateCmdConfigMissingFileFails(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--config", filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+}
+
+// TestValidateCmdConfigMultiPair verifies that two pairs each get their
+// own catalog: a query that references a table from one pair must not
+// resolve against the other pair's schema. This guards against a
+// regression where the catalog construction is hoisted out of the
+// per-pair loop.
+func TestValidateCmdConfigMultiPair(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "prod/schema.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	writeFile(t, dir, "test/schema.sql",
+		"CREATE TABLE fixtures (id INT PRIMARY KEY);\n")
+	prodGood := writeFile(t, dir, "prod/queries/q.sql", "SELECT * FROM users;\n")
+	testGood := writeFile(t, dir, "test/queries/q.sql", "SELECT * FROM fixtures;\n")
+	prodBad := writeFile(t, dir, "prod/queries/cross.sql", "SELECT * FROM fixtures;\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["prod/schema.sql"]
+    queries: ["prod/queries/*.sql"]
+  - schema: ["test/schema.sql"]
+    queries: ["test/queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered, "prod/cross.sql references the test pair's table; pair isolation must surface this")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "42P01", env.Errors[0].Code)
+	require.Equal(t, prodBad, env.Errors[0].Context["file"])
+
+	var payload struct {
+		Files []struct {
+			File  string `json:"file"`
+			Valid bool   `json:"valid"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 3)
+
+	byFile := map[string]bool{}
+	for _, f := range payload.Files {
+		byFile[f.File] = f.Valid
+	}
+	require.True(t, byFile[prodGood], "prod query against prod schema must resolve")
+	require.True(t, byFile[testGood], "test query against test schema must resolve")
+	require.False(t, byFile[prodBad], "prod query against test-only table must fail")
+}
+
+// TestValidateCmdConfigBadSchemaFails verifies that a DDL parse
+// failure in a config-listed schema file aborts validation entirely
+// (the catalog is a config-level prerequisite, not a per-file
+// concern).
+func TestValidateCmdConfigBadSchemaFails(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/broken.sql", "CREATE TABLE bad (")
+	writeFile(t, dir, "queries/q.sql", "SELECT 1;")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+}
+
 // TestValidateCmdMultiStatementError verifies that an error in a later
 // statement reports the correct position relative to the full input.
 func TestValidateCmdMultiStatementError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.2
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/cockroachdb/cockroachdb-parser v0.0.0-00010101000000-000000000000
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.10.6
@@ -12,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -76,7 +78,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/cockroachdb/cockroachdb-parser => github.com/spilchen/cockroachdb-parser v0.26.2

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/biogo/store v0.0.0-20201120204734-aad293a2328f/go.mod h1:z52shMwD6SGw
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/blevesearch/snowballstem v0.9.0 h1:lMQ189YspGP6sXvZQ4WZ+MLawfV8wOmPoD/iWeNXm8s=
 github.com/blevesearch/snowballstem v0.9.0/go.mod h1:PivSj3JMc8WuaFkTSRDW2SlrulNWPl4ABg1tC/hlgLs=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/broady/gogeohash v0.0.0-20120525094510-7b2c40d64042 h1:iEdmkrNMLXbM7ecffOAtZJQOQUTE4iMonxrb5opUgE4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,199 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package config loads the optional crdb-sql.yaml project file that
+// maps schema-file globs to query-file globs. When a config is present,
+// schema-aware subcommands (currently validate) can run with no flags
+// and operate over every matching query file in the project.
+//
+// The file lives at the project root and is auto-discovered from the
+// current working directory by the root command's PersistentPreRunE.
+// Absence of a config file is not an error — Discover returns
+// (nil, nil) and the subcommand falls back to its existing flag-driven
+// behavior.
+//
+// The schema is intentionally small (one version, repeating
+// schema/queries pairs); richer fields (per-pair name, default tier,
+// connection profile) can be added in future versions without breaking
+// readers that already understand version 1.
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"gopkg.in/yaml.v3"
+)
+
+// SupportedVersion is the only schema version this build understands.
+// Bumping it is a breaking change for older binaries; introduce a new
+// version only when a field's meaning changes incompatibly.
+const SupportedVersion = 1
+
+// DefaultFilenames are the names Discover looks for in the working
+// directory, in priority order. Both spellings are accepted because
+// .yaml and .yml are equally common in Go projects.
+var DefaultFilenames = []string{"crdb-sql.yaml", "crdb-sql.yml"}
+
+// MaxConfigFileSize caps the size of a config file Load will read.
+// Configs are tiny by nature; the limit exists only to prevent a
+// pathological 1GB YAML file from being slurped into memory.
+const MaxConfigFileSize = 1 << 20 // 1 MiB
+
+// File is the parsed crdb-sql.yaml. It is populated by Load (and
+// Discover) and then attached to the root command's per-invocation
+// state so subcommands can read it.
+//
+// BaseDir is set by the loader to the directory containing the YAML
+// file. Globs in SQL[*].Schema and SQL[*].Queries are resolved
+// relative to BaseDir, which makes configs portable across machines
+// (no absolute paths required) and makes tests easy to write
+// (point the loader at t.TempDir()).
+type File struct {
+	Version int       `yaml:"version"`
+	SQL     []SQLPair `yaml:"sql"`
+
+	// BaseDir is the directory the config file was loaded from. Not
+	// present in the YAML; populated by Load. Empty for File values
+	// constructed in tests without going through Load — those tests
+	// must use absolute glob patterns.
+	BaseDir string `yaml:"-"`
+}
+
+// SQLPair maps a set of CREATE TABLE schema files to the queries that
+// should be validated against that schema. Both sides are lists of
+// glob patterns (doublestar syntax: `**` matches any depth).
+//
+// Multiple pairs in one config let a project keep, e.g., production
+// schema with its queries separate from a test fixture schema with
+// its own queries.
+type SQLPair struct {
+	Schema  []string `yaml:"schema"`
+	Queries []string `yaml:"queries"`
+}
+
+// Load reads and parses the config file at path. The returned *File
+// has BaseDir set to filepath.Dir(path) so subsequent glob expansion
+// resolves patterns relative to the config's location.
+//
+// Load is strict: unknown YAML fields produce an error rather than
+// being silently dropped. This catches typos in the config (e.g.
+// `querys:` instead of `queries:`) at load time instead of producing
+// a confusing empty match later.
+func Load(path string) (*File, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat config file %s: %w", path, err)
+	}
+	if info.Size() > MaxConfigFileSize {
+		return nil, fmt.Errorf("config file %s is too large (%d bytes, max %d)",
+			path, info.Size(), MaxConfigFileSize)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %s: %w", path, err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var f File
+	if err := dec.Decode(&f); err != nil {
+		return nil, fmt.Errorf("parse config file %s: %w", path, err)
+	}
+
+	if f.Version != SupportedVersion {
+		return nil, fmt.Errorf(
+			"config file %s: unsupported version %d (this build supports version %d)",
+			path, f.Version, SupportedVersion)
+	}
+
+	f.BaseDir = filepath.Dir(path)
+	return &f, nil
+}
+
+// Discover looks for a config file in cwd. If none of DefaultFilenames
+// exists, it returns (nil, nil) — absence is not an error, callers
+// just fall through to their existing flag-driven behavior.
+//
+// Only cwd is checked; there is no walk-up to parent directories.
+// This matches the issue spec ("from CWD") and avoids surprises
+// where a config two levels up silently changes a command's behavior.
+func Discover(cwd string) (*File, error) {
+	for _, name := range DefaultFilenames {
+		path := filepath.Join(cwd, name)
+		_, err := os.Stat(path)
+		if err == nil {
+			return Load(path)
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("stat candidate config %s: %w", path, err)
+		}
+	}
+	return nil, nil
+}
+
+// ExpandSchema returns the concrete file paths matched by the pair's
+// Schema globs, resolved against baseDir. Patterns may use doublestar
+// syntax (`**` for recursive matches). Results are deduplicated and
+// sorted for stable downstream behavior.
+//
+// An empty pattern list returns an empty slice (no error). A pattern
+// that matches nothing also produces no error here — the caller
+// decides whether zero matches is meaningful (validate, for instance,
+// treats a pair with no query matches as a no-op rather than a
+// failure).
+func (p SQLPair) ExpandSchema(baseDir string) ([]string, error) {
+	return expandGlobs(baseDir, p.Schema)
+}
+
+// ExpandQueries is the queries-side counterpart to ExpandSchema; see
+// that method for the semantics of pattern matching, deduplication,
+// and zero matches.
+func (p SQLPair) ExpandQueries(baseDir string) ([]string, error) {
+	return expandGlobs(baseDir, p.Queries)
+}
+
+// expandGlobs resolves each pattern against baseDir using doublestar
+// (so `**` patterns work) and returns a sorted, deduplicated list of
+// matched paths. Absolute patterns are honored as-is; baseDir is only
+// joined for relative patterns.
+//
+// Why not filepath.Glob: stdlib Glob does not support `**`, which the
+// YAML schema explicitly relies on (`queries/**/*.sql`). Doublestar
+// is the de-facto Go library for shell-style recursive globs.
+func expandGlobs(baseDir string, patterns []string) ([]string, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var out []string
+	for _, pat := range patterns {
+		full := pat
+		if !filepath.IsAbs(pat) {
+			full = filepath.Join(baseDir, pat)
+		}
+		matches, err := doublestar.FilepathGlob(full)
+		if err != nil {
+			return nil, fmt.Errorf("expand glob %q: %w", pat, err)
+		}
+		for _, m := range matches {
+			if _, dup := seen[m]; dup {
+				continue
+			}
+			seen[m] = struct{}{}
+			out = append(out, m)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile creates a file with the given contents under dir, including
+// any parent directories. Test helper only.
+func writeFile(t *testing.T, dir, rel, contents string) string {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+	return full
+}
+
+// TestLoadValid covers the happy path: a well-formed config parses
+// into the expected structure with BaseDir populated.
+func TestLoadValid(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/**/*.sql"]
+  - schema: ["test/schema.sql"]
+    queries: ["test/**/*.sql"]
+`)
+
+	f, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, 1, f.Version)
+	require.Len(t, f.SQL, 2)
+	require.Equal(t, []string{"schema/*.sql"}, f.SQL[0].Schema)
+	require.Equal(t, []string{"queries/**/*.sql"}, f.SQL[0].Queries)
+	require.Equal(t, dir, f.BaseDir)
+}
+
+// TestLoadErrors exercises the rejection paths so that misconfigured
+// files fail loudly at load time rather than producing surprising
+// empty matches downstream.
+func TestLoadErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		contents    string
+		expectedErr string
+	}{
+		{
+			name: "unsupported version",
+			contents: `version: 99
+sql: []
+`,
+			expectedErr: "unsupported version 99",
+		},
+		{
+			name: "missing version defaults to zero and rejected",
+			contents: `sql:
+  - schema: ["a.sql"]
+    queries: ["q.sql"]
+`,
+			expectedErr: "unsupported version 0",
+		},
+		{
+			name: "unknown top-level field",
+			contents: `version: 1
+sql: []
+unexpected: true
+`,
+			expectedErr: "field unexpected not found",
+		},
+		{
+			name: "typo in nested field",
+			contents: `version: 1
+sql:
+  - schema: ["a.sql"]
+    querys: ["q.sql"]
+`,
+			expectedErr: "field querys not found",
+		},
+		{
+			name:        "malformed yaml",
+			contents:    "version: 1\nsql: [unterminated",
+			expectedErr: "parse config file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeFile(t, dir, "crdb-sql.yaml", tc.contents)
+			_, err := Load(path)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// TestLoadMissingFile verifies that Load (unlike Discover) treats a
+// missing file as an error — explicit paths must exist.
+func TestLoadMissingFile(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nope.yaml"))
+	require.Error(t, err)
+}
+
+// TestDiscoverMissing verifies that absence of any default-named
+// config returns (nil, nil). This is what lets every command tolerate
+// being run outside a configured project.
+func TestDiscoverMissing(t *testing.T) {
+	f, err := Discover(t.TempDir())
+	require.NoError(t, err)
+	require.Nil(t, f)
+}
+
+// TestDiscoverPicksFirstMatch verifies that crdb-sql.yaml takes
+// precedence over crdb-sql.yml when both are present.
+func TestDiscoverPicksFirstMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yaml", "version: 1\nsql: []\n")
+	writeFile(t, dir, "crdb-sql.yml", "version: 99\nsql: []\n")
+
+	f, err := Discover(dir)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	require.Equal(t, 1, f.Version, "should have loaded the .yaml file, not the .yml")
+}
+
+// TestDiscoverYmlSpelling verifies that the .yml fallback works when
+// only that spelling is present.
+func TestDiscoverYmlSpelling(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yml", "version: 1\nsql: []\n")
+
+	f, err := Discover(dir)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	require.Equal(t, dir, f.BaseDir)
+}
+
+// TestExpandGlobs covers schema/query glob resolution. The cases
+// exercise the dimensions that are easy to get wrong: deep recursion
+// via `**`, deduplication when patterns overlap, deterministic
+// ordering, and zero-match patterns.
+func TestExpandGlobs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql", "")
+	writeFile(t, dir, "schema/orders.sql", "")
+	writeFile(t, dir, "queries/q1.sql", "")
+	writeFile(t, dir, "queries/sub/q2.sql", "")
+	writeFile(t, dir, "queries/sub/deep/q3.sql", "")
+
+	tests := []struct {
+		name             string
+		patterns         []string
+		expectedSuffixes []string
+	}{
+		{
+			name:     "no patterns returns nil",
+			patterns: nil,
+		},
+		{
+			name:     "single shallow glob",
+			patterns: []string{"schema/*.sql"},
+			expectedSuffixes: []string{
+				"schema/orders.sql",
+				"schema/users.sql",
+			},
+		},
+		{
+			name:     "double-star recursive glob",
+			patterns: []string{"queries/**/*.sql"},
+			expectedSuffixes: []string{
+				"queries/q1.sql",
+				"queries/sub/deep/q3.sql",
+				"queries/sub/q2.sql",
+			},
+		},
+		{
+			name:     "overlapping patterns deduplicate",
+			patterns: []string{"queries/**/*.sql", "queries/sub/*.sql"},
+			expectedSuffixes: []string{
+				"queries/q1.sql",
+				"queries/sub/deep/q3.sql",
+				"queries/sub/q2.sql",
+			},
+		},
+		{
+			name:     "no matches returns empty without error",
+			patterns: []string{"missing/*.sql"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandGlobs(dir, tc.patterns)
+			require.NoError(t, err)
+			require.Len(t, got, len(tc.expectedSuffixes))
+			for i, suf := range tc.expectedSuffixes {
+				require.True(t, strings.HasSuffix(got[i], suf),
+					"result %d %q should end with %q", i, got[i], suf)
+			}
+		})
+	}
+}
+
+// TestExpandGlobsAbsolutePath verifies that an absolute pattern is
+// honored as-is and not re-rooted under baseDir.
+func TestExpandGlobsAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "abs.sql", "")
+	abs := filepath.Join(dir, "abs.sql")
+
+	got, err := expandGlobs("/some/other/place", []string{abs})
+	require.NoError(t, err)
+	require.Equal(t, []string{abs}, got)
+}
+
+// TestSQLPairExpand verifies the public ExpandSchema/ExpandQueries
+// methods route through the same machinery as expandGlobs.
+func TestSQLPairExpand(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "s.sql", "")
+	writeFile(t, dir, "q.sql", "")
+
+	p := SQLPair{
+		Schema:  []string{"s.sql"},
+		Queries: []string{"q.sql"},
+	}
+	schema, err := p.ExpandSchema(dir)
+	require.NoError(t, err)
+	require.Len(t, schema, 1)
+	require.True(t, strings.HasSuffix(schema[0], "s.sql"))
+
+	queries, err := p.ExpandQueries(dir)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.True(t, strings.HasSuffix(queries[0], "q.sql"))
+}


### PR DESCRIPTION
Introduce a project-level YAML config (`crdb-sql.yaml`) that maps schema-file globs to query-file globs and is auto-discovered from CWD by the root command's `PersistentPreRunE`. The new `internal/config` package handles strict YAML parsing (unknown fields rejected, version must be 1, 1 MiB cap), CWD-only discovery (`.yaml` then `.yml`), and `doublestar` glob expansion so that `**` patterns work as written in the design doc.

The `validate` command consumes the config: when no `-e`, no positional file argument, and no `--schema` flag are given and a config has been loaded, it iterates every `SQLPair`. For each pair, the schema globs are expanded into a catalog (DDL parse failures abort) and every matched query file is individually parsed, type-checked, and resolved against that pair's catalog. Per-file diagnostics accumulate into one envelope with `Context["file"]` tagging; the JSON payload exposes a `{files: [...]}` array; the command exits non-zero via `ErrRendered` if any query fails. Each pair gets its own catalog so production and test schemas stay isolated. Schema warnings surface as severity=`WARNING` entries but do not fail the run on their own. Tier is promoted to `schema_file` when the config path runs.

Explicit CLI input (`-e`, a file argument, or `--schema`) short-circuits the config path entirely, matching the standard "flags override config file" precedence. With no config present, `validate`'s existing flag-driven behavior is unchanged.

Auto-discovery in `describe` and `list-tables` is tracked separately as #91 and #92.

Resolves: #26