### PR TITLE
mcp: add list_tables, describe_table tools and schema-aware validate_sql

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/config"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
 )
 
 // rootState is the per-invocation container for cobra-resolved global
@@ -218,19 +219,10 @@ func newEnvelope(
 	return r, env, nil
 }
 
-// appendSchemaWarnings copies any non-fatal issues recorded by the
-// catalog loader (skipped statements, duplicate definitions) into env
-// as warning-severity envelope entries. Subcommands that consume a
-// catalog call this once after Load/LoadFiles so agents see the
-// loader's diagnostics in the same Errors stream as everything else.
+// appendSchemaWarnings is a thin alias for schemawarn.Append kept on
+// the cmd package so subcommand code stays terse.
 func appendSchemaWarnings(env *output.Envelope, cat *catalog.Catalog) {
-	for _, w := range cat.Warnings() {
-		env.Errors = append(env.Errors, output.Error{
-			Code:     "schema_warning",
-			Severity: output.SeverityWarning,
-			Message:  w,
-		})
-	}
+	schemawarn.Append(env, cat)
 }
 
 // renderSchemaLoadError surfaces a catalog.Load/LoadFiles failure as

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -20,44 +20,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/semcheck"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
-)
-
-// validateChecks records which validation phases ran on the success
-// path. Each field is "ok" (ran and passed) or "skipped" (prerequisite
-// missing). A failing phase aborts the command via an envelope error,
-// so "fail" never appears here.
-type validateChecks struct {
-	Syntax         string `json:"syntax"`
-	TypeCheck      string `json:"type_check"`
-	NameResolution string `json:"name_resolution"`
-}
-
-// validateResult is the JSON payload emitted by `crdb-sql validate` on
-// the success path. The expanded shape (vs. a bare {valid: true})
-// exposes which phases ran, so agents can tell whether name resolution
-// was skipped due to a missing --schema. Adding a phase means adding a
-// field here and updating the rendering code to set it.
-type validateResult struct {
-	Valid  bool           `json:"valid"`
-	Checks validateChecks `json:"checks"`
-}
-
-const (
-	checkOK      = "ok"
-	checkSkipped = "skipped"
-
-	// capabilityRequiredCode is the envelope error code emitted when a
-	// validation phase is skipped because its prerequisite (e.g.
-	// --schema) is not satisfied. The matching category is the same
-	// string so agents can branch on either field.
-	capabilityRequiredCode     = "capability_required"
-	capabilityRequiredCategory = "capability_required"
-
-	// capabilityNameResolution is the canonical identifier for the
-	// table-name-resolution phase. It is shared between the phase's
-	// skipped-warning Context and any human-readable message text so
-	// the two cannot drift.
-	capabilityNameResolution = "name_resolution"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
 )
 
 // newValidateCmd builds the `crdb-sql validate` subcommand. It reads
@@ -136,15 +99,15 @@ matched by the config and reports per-file results in one envelope.`,
 				return renderDiagErrors(r, baseEnv, typeErrs)
 			}
 
-			checks := validateChecks{
-				Syntax:    checkOK,
-				TypeCheck: checkOK,
+			checks := validateresult.Checks{
+				Syntax:    validateresult.CheckOK,
+				TypeCheck: validateresult.CheckOK,
 			}
 
 			if len(schemaFiles) == 0 {
-				checks.NameResolution = checkSkipped
-				baseEnv.Errors = append(baseEnv.Errors, capabilityRequiredError(
-					capabilityNameResolution,
+				checks.NameResolution = validateresult.CheckSkipped
+				baseEnv.Errors = append(baseEnv.Errors, validateresult.CapabilityRequiredError(
+					validateresult.CapabilityNameResolution,
 					"name resolution skipped: --schema not provided",
 					"pass --schema FILE to enable table name resolution",
 				))
@@ -157,10 +120,10 @@ matched by the config and reports per-file results in one envelope.`,
 				if nameErrs := semcheck.CheckTableNames(stmts, sql, cat); len(nameErrs) > 0 {
 					return renderDiagErrors(r, baseEnv, nameErrs)
 				}
-				checks.NameResolution = checkOK
+				checks.NameResolution = validateresult.CheckOK
 			}
 
-			data, err := json.Marshal(validateResult{Valid: true, Checks: checks})
+			data, err := json.Marshal(validateresult.Result{Valid: true, Checks: checks})
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
@@ -170,7 +133,7 @@ matched by the config and reports per-file results in one envelope.`,
 				if _, werr := fmt.Fprintln(w, "Valid."); werr != nil {
 					return werr
 				}
-				if checks.NameResolution == checkSkipped {
+				if checks.NameResolution == validateresult.CheckSkipped {
 					_, werr := fmt.Fprintln(w, "note: name resolution skipped (pass --schema to enable)")
 					return werr
 				}
@@ -392,26 +355,6 @@ func renderConfigText(w io.Writer, results []fileResult, errs []output.Error) er
 		}
 	}
 	return nil
-}
-
-// capabilityRequiredError builds the warning entry that signals a
-// validation phase was skipped because its prerequisite is missing.
-// capability is the short identifier of the skipped phase (e.g.
-// "name_resolution"); message is the user-facing summary; hint tells
-// the user how to enable the phase. The result is appended to the
-// envelope's Errors list rather than aborting the command — exit code
-// stays 0 because the phases that did run all passed.
-func capabilityRequiredError(capability, message, hint string) output.Error {
-	return output.Error{
-		Code:     capabilityRequiredCode,
-		Severity: output.SeverityWarning,
-		Message:  message,
-		Category: capabilityRequiredCategory,
-		Context: map[string]any{
-			"capability": capability,
-			"hint":       hint,
-		},
-	}
 }
 
 // renderParseError enriches a parser error with SQLSTATE code and

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,9 +6,12 @@
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
 // The server registers a health-check tool (ping), four Tier 1 SQL
-// tools (parse_sql, validate_sql, format_sql, detect_risky_query) via
-// the tools subpackage, and the Tier 3 explain_sql tool that runs
-// EXPLAIN against a live cluster. Keeping construction pure (no
+// tools (parse_sql, validate_sql, format_sql, detect_risky_query),
+// two Tier 2 catalog tools (list_tables, describe_table) that operate
+// on inline CREATE TABLE schemas, and the Tier 3 explain_sql tool that
+// runs EXPLAIN against a live cluster. validate_sql is dual-tier: it
+// runs Tier 1 by default and lifts to Tier 2 (name resolution) when
+// the caller supplies inline schemas. Keeping construction pure (no
 // transport, no I/O) lets the cmd layer pick a transport — currently
 // just stdio — and lets tests exercise individual tool handlers
 // directly.
@@ -71,6 +74,8 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))
+	s.AddTool(tools.DescribeTableTool(), tools.DescribeTableHandler(parserVersion))
 	return s
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -78,7 +78,16 @@ func TestNewServerRegistersTools(t *testing.T) {
 	require.NotNil(t, s)
 	registered := s.ListTools()
 
-	for _, name := range []string{PingToolName, tools.ParseSQLToolName, tools.ValidateSQLToolName, tools.FormatSQLToolName, tools.DetectRiskyQueryToolName, tools.ExplainSQLToolName} {
+	for _, name := range []string{
+		PingToolName,
+		tools.ParseSQLToolName,
+		tools.ValidateSQLToolName,
+		tools.FormatSQLToolName,
+		tools.DetectRiskyQueryToolName,
+		tools.ExplainSQLToolName,
+		tools.ListTablesToolName,
+		tools.DescribeTableToolName,
+	} {
 		require.Contains(t, registered, name)
 		require.NotNil(t, registered[name].Handler,
 			"%s must be registered with a non-nil handler", name)

--- a/internal/mcp/tools/catalog.go
+++ b/internal/mcp/tools/catalog.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
+)
+
+// schemasParam is the wire name of the inline-schemas argument shared by
+// list_tables, describe_table, and (optionally) validate_sql. Centralized
+// so all three handlers' tool definitions stay in lockstep.
+const schemasParam = "schemas"
+
+// schemasRequirement controls whether extractSchemas accepts an
+// absent/empty schemas argument. A typed alias for the requirement
+// keeps call sites self-documenting (extractSchemas(req, schemasRequired))
+// and prevents the boolean from being silently inverted by a future
+// refactor.
+type schemasRequirement bool
+
+const (
+	schemasOptional schemasRequirement = false
+	schemasRequired schemasRequirement = true
+)
+
+// undefinedTableCode is the SQLSTATE for a missing table reference.
+// describe_table returns this when the requested table is not present in
+// the loaded catalog so agents can branch on it the same way they would
+// on a real cluster's "relation does not exist" error.
+const undefinedTableCode = "42P01"
+
+// schemaLoadErrorCode is the fallback envelope code emitted when
+// catalog.Load returns an error that carries no SQLSTATE — typically an
+// I/O or validation failure rather than a parser error. Mirrors the
+// CLI's renderSchemaLoadError fallback so both surfaces tag I/O-level
+// schema failures identically.
+const schemaLoadErrorCode = "schema_load_error"
+
+// ListTablesTool returns the MCP tool definition for list_tables.
+func ListTablesTool() mcp.Tool {
+	return mcp.NewTool(
+		ListTablesToolName,
+		mcp.WithDescription(`List tables defined in one or more inline CREATE TABLE schemas. Returns an envelope whose data payload is {"tables": [...]} (always present, possibly empty). Loader warnings are surfaced as schema_warning entries in the envelope errors stream.`),
+		mcp.WithArray(schemasParam,
+			mcp.Required(),
+			mcp.MinItems(1),
+			mcp.Description("Inline schema sources; each {label, sql} maps to a catalog.SchemaSource. label is optional and only used in warnings/errors."),
+			mcp.Items(schemasItemSchema()),
+		),
+	)
+}
+
+// DescribeTableTool returns the MCP tool definition for describe_table.
+func DescribeTableTool() mcp.Tool {
+	return mcp.NewTool(
+		DescribeTableToolName,
+		mcp.WithDescription(`Describe a single table from one or more inline CREATE TABLE schemas. Returns an envelope whose data payload is the catalog.Table JSON (name, columns, primary key, indexes). When the table is missing the envelope carries a 42P01 error with an "available_tables" context list.`),
+		mcp.WithString("table",
+			mcp.Required(),
+			mcp.Description("Table name to describe (case-insensitive)."),
+		),
+		mcp.WithArray(schemasParam,
+			mcp.Required(),
+			mcp.MinItems(1),
+			mcp.Description("Inline schema sources; each {label, sql} maps to a catalog.SchemaSource. label is optional and only used in warnings/errors."),
+			mcp.Items(schemasItemSchema()),
+		),
+	)
+}
+
+// ListTablesHandler returns the handler for the list_tables tool. It
+// builds an in-memory catalog from the inline schemas argument and
+// emits the same {"tables": [...]} payload as the CLI list-tables
+// command (including the nil-to-empty normalization so the slice
+// always marshals as `[]`, never `null`).
+func ListTablesHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sources, toolErr := extractSchemas(req, schemasRequired)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := schemaFileEnvelope(parserVersion, "" /* targetVersion */)
+
+		cat, err := catalog.Load(sources)
+		if err != nil {
+			env.Errors = []output.Error{schemaLoadEnvelopeError(err)}
+			return envelopeResult(env)
+		}
+		schemawarn.Append(&env, cat)
+
+		tables := cat.TableNames()
+		if tables == nil {
+			tables = []string{}
+		}
+
+		data, err := json.Marshal(struct {
+			Tables []string `json:"tables"`
+		}{Tables: tables})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}
+
+// DescribeTableHandler returns the handler for the describe_table tool.
+// Unlike the CLI's `describe`, a missing table is surfaced as a
+// structured 42P01 envelope error (with an "available_tables" context
+// list) rather than a generic internal_error — the MCP envelope is
+// designed for programmatic consumption and benefits from the real
+// SQLSTATE.
+func DescribeTableHandler(parserVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		tableName, toolErr := extractRequiredString(req, "table")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		sources, toolErr := extractSchemas(req, schemasRequired)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := schemaFileEnvelope(parserVersion, "" /* targetVersion */)
+
+		cat, err := catalog.Load(sources)
+		if err != nil {
+			env.Errors = []output.Error{schemaLoadEnvelopeError(err)}
+			return envelopeResult(env)
+		}
+		schemawarn.Append(&env, cat)
+
+		tbl, ok := cat.Table(tableName)
+		if !ok {
+			env.Errors = append(env.Errors, tableNotFoundError(tableName, cat.TableNames()))
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(tbl)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}
+
+// extractSchemas pulls the schemas argument from req and converts each
+// entry into a catalog.SchemaSource. mode=schemasRequired rejects a
+// missing or empty argument with a tool-level error (used by
+// list_tables and describe_table); mode=schemasOptional treats those
+// cases as "no schema provided" and returns (nil, nil) so the caller
+// can take the schema-less path (used by validate_sql).
+//
+// On any shape error (wrong type at the array level, non-object item,
+// missing/empty sql, wrong type for label/sql) it returns a pre-built
+// tool error result that the handler should return verbatim.
+func extractSchemas(req mcp.CallToolRequest, mode schemasRequirement) ([]catalog.SchemaSource, *mcp.CallToolResult) {
+	args := req.GetArguments()
+	raw, exists := args[schemasParam]
+	if !exists || raw == nil {
+		if mode == schemasRequired {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s parameter is required", schemasParam))
+		}
+		return nil, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, mcp.NewToolResultError(fmt.Sprintf("%s parameter must be an array, got %T", schemasParam, raw))
+	}
+	if len(arr) == 0 {
+		if mode == schemasRequired {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s parameter must contain at least one entry", schemasParam))
+		}
+		return nil, nil
+	}
+
+	sources := make([]catalog.SchemaSource, 0, len(arr))
+	for i, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d] must be an object, got %T", schemasParam, i, item))
+		}
+
+		rawSQL, exists := obj["sql"]
+		if !exists {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d].sql is required", schemasParam, i))
+		}
+		sqlStr, ok := rawSQL.(string)
+		if !ok {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d].sql must be a string, got %T", schemasParam, i, rawSQL))
+		}
+		sqlStr = strings.TrimSpace(sqlStr)
+		if sqlStr == "" {
+			return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d].sql must not be empty", schemasParam, i))
+		}
+
+		var label string
+		if rawLabel, exists := obj["label"]; exists && rawLabel != nil {
+			label, ok = rawLabel.(string)
+			if !ok {
+				return nil, mcp.NewToolResultError(fmt.Sprintf("%s[%d].label must be a string, got %T", schemasParam, i, rawLabel))
+			}
+		}
+
+		sources = append(sources, catalog.SchemaSource{SQL: sqlStr, Label: label})
+	}
+	return sources, nil
+}
+
+// schemaLoadEnvelopeError converts a catalog.Load error into the
+// envelope's error shape. It mirrors cmd/root.go::renderSchemaLoadError:
+// pgerror.GetPGCode is consulted first so a parser-side SQLSTATE (e.g.
+// 42601 from a malformed CREATE TABLE) is propagated; failures with no
+// SQLSTATE — typically I/O — fall back to schemaLoadErrorCode.
+func schemaLoadEnvelopeError(err error) output.Error {
+	code := pgerror.GetPGCode(err).String()
+	if code == "" || code == "XXUUU" {
+		code = schemaLoadErrorCode
+	}
+	return output.Error{
+		Code:     code,
+		Severity: output.SeverityError,
+		Message:  err.Error(),
+		Category: diag.CategoryForCode(code),
+	}
+}
+
+// tableNotFoundError builds the 42P01 envelope entry for a missing
+// table. available is the catalog's full TableNames() slice; when
+// non-empty it is attached as the "available_tables" context so agents
+// can suggest a correction. When empty the context key is omitted
+// entirely so consumers do not have to special-case `null`.
+func tableNotFoundError(name string, available []string) output.Error {
+	err := output.Error{
+		Code:     undefinedTableCode,
+		Severity: output.SeverityError,
+		Message:  fmt.Sprintf("table %q not found", name),
+		Category: diag.CategoryForCode(undefinedTableCode),
+	}
+	if len(available) > 0 {
+		err.Context = map[string]any{"available_tables": available}
+	}
+	return err
+}
+
+// schemasItemSchema returns the JSON Schema fragment describing a
+// single entry of the schemas array. Shared between the three tool
+// definitions so the wire schema cannot drift.
+func schemasItemSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"label": map[string]any{
+				"type":        "string",
+				"description": "Optional human-readable name used in warnings/errors.",
+			},
+			"sql": map[string]any{
+				"type":        "string",
+				"description": "CREATE TABLE DDL statements for this source.",
+			},
+		},
+		"required":             []string{"sql"},
+		"additionalProperties": false,
+	}
+}

--- a/internal/mcp/tools/catalog_test.go
+++ b/internal/mcp/tools/catalog_test.go
@@ -1,0 +1,360 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
+)
+
+// findErrorByCode returns the first envelope error whose Code matches
+// the given SQLSTATE (or sentinel) and fails the test if none exists.
+// Useful when an envelope may carry warnings alongside the error of
+// interest and asserting on env.Errors[0] would be brittle.
+func findErrorByCode(t *testing.T, errs []output.Error, code string) output.Error {
+	t.Helper()
+	for _, e := range errs {
+		if e.Code == code {
+			return e
+		}
+	}
+	require.Failf(t, "envelope error not found", "no error with code %q in %+v", code, errs)
+	return output.Error{}
+}
+
+// usersDDL and ordersDDL are the canonical fixtures shared across the
+// catalog handler tests. Keeping them at package scope means each test
+// case only encodes the per-case differences (which schemas to load,
+// which table to query) rather than re-stating the DDL.
+const (
+	usersDDL  = "CREATE TABLE users (id INT PRIMARY KEY, email TEXT NOT NULL UNIQUE)"
+	ordersDDL = "CREATE TABLE orders (id INT PRIMARY KEY, user_id INT)"
+)
+
+func TestExtractSchemas(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            map[string]any
+		mode            schemasRequirement
+		expectedToolErr bool
+		expectedSources int
+		expectedSQL     string
+		expectedLabel   string
+	}{
+		{
+			name:            "valid two entries",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL, "label": "u"}, map[string]any{"sql": ordersDDL}}},
+			mode:            schemasRequired,
+			expectedSources: 2,
+		},
+		{
+			name:            "valid label omitted",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL}}},
+			mode:            schemasRequired,
+			expectedSources: 1,
+			expectedSQL:     usersDDL,
+		},
+		{
+			name:            "valid label provided is preserved verbatim",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL, "label": "  users-schema  "}}},
+			mode:            schemasRequired,
+			expectedSources: 1,
+			expectedLabel:   "  users-schema  ",
+		},
+		{
+			name:            "trims surrounding whitespace from sql",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": "  " + usersDDL + "\n"}}},
+			mode:            schemasRequired,
+			expectedSources: 1,
+			expectedSQL:     usersDDL,
+		},
+		{
+			name:            "missing required",
+			args:            map[string]any{},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "missing optional yields nil",
+			args:            map[string]any{},
+			mode:            schemasOptional,
+			expectedSources: 0,
+		},
+		{
+			name:            "not an array",
+			args:            map[string]any{schemasParam: "literal-string"},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty array required",
+			args:            map[string]any{schemasParam: []any{}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty array optional yields nil",
+			args:            map[string]any{schemasParam: []any{}},
+			mode:            schemasOptional,
+			expectedSources: 0,
+		},
+		{
+			name:            "item not an object",
+			args:            map[string]any{schemasParam: []any{"raw-string-instead-of-object"}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "missing sql key",
+			args:            map[string]any{schemasParam: []any{map[string]any{"label": "x"}}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "sql wrong type",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": 42}}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "sql whitespace-only",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": "   \n\t"}}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+		{
+			name:            "label wrong type",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL, "label": 7}}},
+			mode:            schemasRequired,
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			sources, toolErr := extractSchemas(req, tc.mode)
+
+			if tc.expectedToolErr {
+				require.NotNil(t, toolErr, "expected tool-level error")
+				require.Nil(t, sources)
+				return
+			}
+			require.Nil(t, toolErr)
+			require.Len(t, sources, tc.expectedSources)
+			if tc.expectedSQL != "" {
+				require.Equal(t, tc.expectedSQL, sources[0].SQL)
+			}
+			if tc.expectedLabel != "" {
+				require.Equal(t, tc.expectedLabel, sources[0].Label)
+			}
+		})
+	}
+}
+
+func TestListTablesHandler(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              map[string]any
+		expectedToolErr   bool
+		expectedEnvErrs   bool
+		expectedCode      string
+		expectedTables    []string
+		expectedWarnCount int
+	}{
+		{
+			name:           "two tables across two sources",
+			args:           map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL}, map[string]any{"sql": ordersDDL}}},
+			expectedTables: []string{"users", "orders"},
+		},
+		{
+			name:              "schema with no CREATE TABLE yields empty list and a warning",
+			args:              map[string]any{schemasParam: []any{map[string]any{"sql": "SELECT 1"}}},
+			expectedTables:    []string{},
+			expectedWarnCount: 1,
+		},
+		{
+			name:            "missing schemas yields tool error",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+		{
+			name:            "empty schemas array yields tool error",
+			args:            map[string]any{schemasParam: []any{}},
+			expectedToolErr: true,
+		},
+		{
+			name:            "malformed item yields tool error",
+			args:            map[string]any{schemasParam: []any{"not-an-object"}},
+			expectedToolErr: true,
+		},
+		{
+			name:            "DDL with parse error surfaces as envelope error",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": "CREATE TABLEE bad (id INT)"}}},
+			expectedEnvErrs: true,
+			expectedCode:    "42601",
+		},
+		{
+			name: "duplicate table names produce a schema_warning",
+			args: map[string]any{schemasParam: []any{
+				map[string]any{"sql": usersDDL},
+				map[string]any{"sql": usersDDL},
+			}},
+			expectedTables:    []string{"users"},
+			expectedWarnCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ListTablesHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierSchemaFile, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				return
+			}
+
+			var data struct {
+				Tables []string `json:"tables"`
+			}
+			require.NoError(t, json.Unmarshal(env.Data, &data))
+			require.Equal(t, tc.expectedTables, data.Tables)
+
+			// Empty slice must marshal as "[]" not "null" so clients
+			// don't need to special-case nil. Re-decode the raw JSON to
+			// catch a regression here.
+			require.NotContains(t, string(env.Data), "null")
+
+			require.Len(t, env.Errors, tc.expectedWarnCount)
+			for _, e := range env.Errors {
+				require.Equal(t, schemawarn.Code, e.Code)
+				require.Equal(t, output.SeverityWarning, e.Severity)
+			}
+		})
+	}
+}
+
+func TestDescribeTableHandler(t *testing.T) {
+	tests := []struct {
+		name                    string
+		args                    map[string]any
+		expectedToolErr         bool
+		expectedTableName       string
+		expectedNotFound        bool
+		expectedAvailableTables []string
+	}{
+		{
+			name:              "happy path",
+			args:              map[string]any{"table": "users", schemasParam: []any{map[string]any{"sql": usersDDL}}},
+			expectedTableName: "users",
+		},
+		{
+			name:              "case-insensitive lookup",
+			args:              map[string]any{"table": "USERS", schemasParam: []any{map[string]any{"sql": usersDDL}}},
+			expectedTableName: "users",
+		},
+		{
+			name: "table not found surfaces 42P01 with available_tables",
+			args: map[string]any{"table": "missing", schemasParam: []any{
+				map[string]any{"sql": usersDDL},
+				map[string]any{"sql": ordersDDL},
+			}},
+			expectedNotFound:        true,
+			expectedAvailableTables: []string{"users", "orders"},
+		},
+		{
+			name:             "table not found in empty catalog omits available_tables",
+			args:             map[string]any{"table": "missing", schemasParam: []any{map[string]any{"sql": "SELECT 1"}}},
+			expectedNotFound: true,
+		},
+		{
+			name:            "missing table param",
+			args:            map[string]any{schemasParam: []any{map[string]any{"sql": usersDDL}}},
+			expectedToolErr: true,
+		},
+		{
+			name:            "missing schemas param",
+			args:            map[string]any{"table": "users"},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := DescribeTableHandler(testParserVersion)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierSchemaFile, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedNotFound {
+				require.Nil(t, env.Data)
+				notFound := findErrorByCode(t, env.Errors, undefinedTableCode)
+				require.Equal(t, output.SeverityError, notFound.Severity)
+				if len(tc.expectedAvailableTables) > 0 {
+					// JSON round-trip turns []string into []any; build the
+					// expected slice in the same shape rather than asserting
+					// against the original []string.
+					expected := make([]any, len(tc.expectedAvailableTables))
+					for i, name := range tc.expectedAvailableTables {
+						expected[i] = name
+					}
+					require.Equal(t, expected, notFound.Context["available_tables"])
+				} else {
+					require.Nil(t, notFound.Context)
+				}
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			require.NotNil(t, env.Data)
+			var tbl catalog.Table
+			require.NoError(t, json.Unmarshal(env.Data, &tbl))
+			require.Equal(t, tc.expectedTableName, tbl.Name)
+			require.NotEmpty(t, tbl.Columns)
+		})
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -37,6 +37,8 @@ const (
 	FormatSQLToolName        = "format_sql"
 	DetectRiskyQueryToolName = "detect_risky_query"
 	ExplainSQLToolName       = "explain_sql"
+	ListTablesToolName       = "list_tables"
+	DescribeTableToolName    = "describe_table"
 )
 
 // TargetVersionParamName is the optional MCP tool parameter name that
@@ -94,6 +96,26 @@ func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
 func baseEnvelope(parserVersion, targetVersion string) output.Envelope {
 	env := output.Envelope{
 		Tier:             output.TierZeroConfig,
+		ParserVersion:    parserVersion,
+		ConnectionStatus: output.ConnectionDisconnected,
+	}
+	stampTargetVersion(&env, parserVersion, targetVersion)
+	return env
+}
+
+// schemaFileEnvelope returns a pre-populated Envelope for Tier 2
+// (schema_file, disconnected) tools — list_tables, describe_table,
+// and validate_sql when given an inline schemas argument. targetVersion
+// follows the same contract as baseEnvelope: empty means "no
+// target-version stamping," non-empty stamps the field and (when
+// MAJOR.MINOR diverges from parserVersion) appends a mismatch
+// warning. Tools that do not yet accept the target_version argument
+// (list_tables, describe_table) pass "" so they get today's behaviour
+// unchanged; validate_sql passes its resolved value so a client
+// supplying target_version alongside schemas still gets the stamping.
+func schemaFileEnvelope(parserVersion, targetVersion string) output.Envelope {
+	env := output.Envelope{
+		Tier:             output.TierSchemaFile,
 		ParserVersion:    parserVersion,
 		ConnectionStatus: output.ConnectionDisconnected,
 	}

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
 )
 
 const testParserVersion = "v0.26.2"
@@ -234,40 +235,138 @@ func TestParseSQLHandler(t *testing.T) {
 	}
 }
 
+// TestValidateSQLHandlerStampsTargetVersionOnSchemaFilePath locks in
+// the contract that when a client supplies both schemas and
+// target_version, the resolved target is stamped onto the Tier 2
+// envelope. The bug this guards against is a silent drop on the
+// schema_file path when both args are present.
+func TestValidateSQLHandlerStampsTargetVersionOnSchemaFilePath(t *testing.T) {
+	const usersDDL = "CREATE TABLE users (id INT PRIMARY KEY, email TEXT)"
+
+	handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECT id FROM users",
+		"schemas":        []any{map[string]any{"sql": usersDDL}},
+		"target_version": "v25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	// resolveTargetVersion canonicalises by stripping the leading "v",
+	// matching the CLI's --target-version handling.
+	require.Equal(t, "25.4", env.TargetVersion,
+		"target_version must be stamped even on the schema_file path")
+}
+
 func TestValidateSQLHandler(t *testing.T) {
+	const usersDDL = "CREATE TABLE users (id INT PRIMARY KEY, email TEXT)"
+
 	tests := []struct {
-		name            string
-		args            map[string]any
-		expectedToolErr bool
-		expectedValid   bool
-		expectedEnvErrs bool
-		expectedCode    string
+		name                   string
+		args                   map[string]any
+		expectedToolErr        bool
+		expectedValid          bool
+		expectedEnvErrs        bool
+		expectedCode           string
+		expectedTier           output.Tier
+		expectedNameResolution validateresult.CheckStatus
+		expectCapabilityWarn   bool
+		expectSchemaWarning    bool
 	}{
 		{
-			name:          "valid SQL",
-			args:          map[string]any{"sql": "SELECT 1"},
-			expectedValid: true,
+			name:                   "valid SQL without schema reports name_resolution skipped",
+			args:                   map[string]any{"sql": "SELECT 1"},
+			expectedValid:          true,
+			expectedTier:           output.TierZeroConfig,
+			expectedNameResolution: validateresult.CheckSkipped,
+			expectCapabilityWarn:   true,
 		},
 		{
 			name:            "syntax error",
 			args:            map[string]any{"sql": "SELECT FROM"},
 			expectedEnvErrs: true,
 			expectedCode:    "42601",
+			expectedTier:    output.TierZeroConfig,
 		},
 		{
 			name:            "type mismatch",
 			args:            map[string]any{"sql": "SELECT 1 + 'hello'"},
 			expectedEnvErrs: true,
+			expectedTier:    output.TierZeroConfig,
 		},
 		{
-			name:          "column ref does not false-positive",
-			args:          map[string]any{"sql": "SELECT a + 1 FROM t"},
-			expectedValid: true,
+			name:                   "column ref does not false-positive",
+			args:                   map[string]any{"sql": "SELECT a + 1 FROM t"},
+			expectedValid:          true,
+			expectedTier:           output.TierZeroConfig,
+			expectedNameResolution: validateresult.CheckSkipped,
+			expectCapabilityWarn:   true,
 		},
 		{
-			name:          "whitespace trimmed",
-			args:          map[string]any{"sql": "  SELECT 1  \n"},
-			expectedValid: true,
+			name:                   "whitespace trimmed",
+			args:                   map[string]any{"sql": "  SELECT 1  \n"},
+			expectedValid:          true,
+			expectedTier:           output.TierZeroConfig,
+			expectedNameResolution: validateresult.CheckSkipped,
+			expectCapabilityWarn:   true,
+		},
+		{
+			name: "schemas present and table resolves",
+			args: map[string]any{
+				"sql":     "SELECT id FROM users",
+				"schemas": []any{map[string]any{"sql": usersDDL}},
+			},
+			expectedValid:          true,
+			expectedTier:           output.TierSchemaFile,
+			expectedNameResolution: validateresult.CheckOK,
+		},
+		{
+			name: "schemas present and table missing yields 42P01",
+			args: map[string]any{
+				"sql":     "SELECT id FROM nope",
+				"schemas": []any{map[string]any{"sql": usersDDL}},
+			},
+			expectedEnvErrs: true,
+			expectedCode:    "42P01",
+			expectedTier:    output.TierSchemaFile,
+		},
+		{
+			name: "malformed schema DDL yields envelope parse error",
+			args: map[string]any{
+				"sql":     "SELECT 1",
+				"schemas": []any{map[string]any{"sql": "CREATE TABLEE bad (id INT)"}},
+			},
+			expectedEnvErrs: true,
+			expectedCode:    "42601",
+			expectedTier:    output.TierSchemaFile,
+		},
+		{
+			name: "duplicate-table schema surfaces schema_warning alongside successful resolution",
+			args: map[string]any{
+				"sql": "SELECT id FROM users",
+				"schemas": []any{
+					map[string]any{"sql": usersDDL},
+					map[string]any{"sql": usersDDL},
+				},
+			},
+			expectedValid:          true,
+			expectedTier:           output.TierSchemaFile,
+			expectedNameResolution: validateresult.CheckOK,
+			expectSchemaWarning:    true,
+		},
+		{
+			name: "empty schemas array still skips name resolution",
+			args: map[string]any{
+				"sql":     "SELECT 1",
+				"schemas": []any{},
+			},
+			expectedValid:          true,
+			expectedTier:           output.TierZeroConfig,
+			expectedNameResolution: validateresult.CheckSkipped,
+			expectCapabilityWarn:   true,
 		},
 		{
 			name:            "missing sql param",
@@ -277,6 +376,14 @@ func TestValidateSQLHandler(t *testing.T) {
 		{
 			name:            "empty sql",
 			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+		{
+			name: "malformed schemas yields tool error",
+			args: map[string]any{
+				"sql":     "SELECT 1",
+				"schemas": "not-an-array",
+			},
 			expectedToolErr: true,
 		},
 	}
@@ -298,7 +405,7 @@ func TestValidateSQLHandler(t *testing.T) {
 
 			env := requireEnvelope(t, res)
 			require.Equal(t, testParserVersion, env.ParserVersion)
-			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, tc.expectedTier, env.Tier)
 			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
 
 			if tc.expectedEnvErrs {
@@ -310,15 +417,27 @@ func TestValidateSQLHandler(t *testing.T) {
 				return
 			}
 
-			require.Empty(t, env.Errors)
 			require.NotNil(t, env.Data)
 
-			if tc.expectedValid {
-				var data struct {
-					Valid bool `json:"valid"`
-				}
-				require.NoError(t, json.Unmarshal(env.Data, &data))
-				require.True(t, data.Valid)
+			var result validateresult.Result
+			require.NoError(t, json.Unmarshal(env.Data, &result))
+			require.Equal(t, tc.expectedValid, result.Valid)
+			require.Equal(t, validateresult.CheckOK, result.Checks.Syntax)
+			require.Equal(t, validateresult.CheckOK, result.Checks.TypeCheck)
+			require.Equal(t, tc.expectedNameResolution, result.Checks.NameResolution)
+
+			switch {
+			case tc.expectCapabilityWarn:
+				require.Len(t, env.Errors, 1)
+				require.Equal(t, validateresult.CapabilityRequiredCode, env.Errors[0].Code)
+				require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+				require.Equal(t, validateresult.CapabilityNameResolution, env.Errors[0].Context["capability"])
+			case tc.expectSchemaWarning:
+				require.Len(t, env.Errors, 1)
+				require.Equal(t, "schema_warning", env.Errors[0].Code)
+				require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+			default:
+				require.Empty(t, env.Errors)
 			}
 		})
 	}

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -14,26 +14,44 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
 	"github.com/spilchen/sql-ai-tools/internal/semcheck"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
 )
 
 // ValidateSQLTool returns the MCP tool definition for validate_sql.
+// The optional schemas parameter mirrors the CLI's --schema flag: when
+// supplied, table references are resolved against the inline catalog
+// (Tier 2); when omitted, name resolution is skipped and a
+// capability_required warning is appended to the envelope so agents
+// can detect the missing capability rather than silently trust a
+// partial result. The optional target_version parameter follows the
+// shared per-call convention documented on TargetVersionParamName.
 func ValidateSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ValidateSQLToolName,
-		mcp.WithDescription("Validate SQL for syntax and type errors. Returns an envelope with {\"valid\": true} on success, or structured errors with SQLSTATE codes, severity, message, and source position on failure."),
+		mcp.WithDescription(`Validate SQL for syntax, type, and (with the schemas argument) name errors. Returns an envelope whose data is {"valid": true, "checks": {syntax, type_check, name_resolution}}; each check is "ok" or "skipped". Failures are reported as structured envelope errors with SQLSTATE codes, severity, message, and source position.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to validate")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+		mcp.WithArray(schemasParam,
+			mcp.Description("Optional inline schema sources for table name resolution; each {label, sql} maps to a catalog.SchemaSource. label is optional. Omit (or pass an empty array) to run syntax/type checks only — name resolution will be reported as skipped via a capability_required warning."),
+			mcp.Items(schemasItemSchema()),
+		),
 	)
 }
 
-// ValidateSQLHandler returns the handler for the validate_sql tool. It
-// parses the SQL, runs expression type checking, and returns the
-// standard output.Envelope used by all Tier 1 tools.
-// defaultTargetVersion is the server-level default; per-call
-// target_version arguments override it.
+// ValidateSQLHandler returns the handler for the validate_sql tool.
+// On the success path the envelope's tier reflects whether schemas
+// were supplied — schema_file when present, zero_config otherwise —
+// and the data payload always carries a validateresult.Result so
+// agents can branch on which phases ran. defaultTargetVersion is the
+// server-level default; per-call target_version arguments override it.
+// The resolved target is stamped onto the envelope on both tiers so
+// that supplying schemas does not silently discard a target_version
+// the client took the trouble to validate.
 func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
 	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sql, toolErr := extractSQL(req)
@@ -44,8 +62,17 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		sources, toolErr := extractSchemas(req, schemasOptional)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
-		env := baseEnvelope(parserVersion, target)
+		var env output.Envelope
+		if len(sources) == 0 {
+			env = baseEnvelope(parserVersion, target)
+		} else {
+			env = schemaFileEnvelope(parserVersion, target)
+		}
 
 		stmts, parseErr := parser.Parse(sql)
 		if parseErr != nil {
@@ -58,9 +85,33 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 			return envelopeResult(env)
 		}
 
-		data, err := json.Marshal(struct {
-			Valid bool `json:"valid"`
-		}{Valid: true})
+		checks := validateresult.Checks{
+			Syntax:    validateresult.CheckOK,
+			TypeCheck: validateresult.CheckOK,
+		}
+
+		if len(sources) == 0 {
+			checks.NameResolution = validateresult.CheckSkipped
+			env.Errors = append(env.Errors, validateresult.CapabilityRequiredError(
+				validateresult.CapabilityNameResolution,
+				"name resolution skipped: schemas not provided",
+				"pass the schemas argument to enable table name resolution",
+			))
+		} else {
+			cat, err := catalog.Load(sources)
+			if err != nil {
+				env.Errors = append(env.Errors, schemaLoadEnvelopeError(err))
+				return envelopeResult(env)
+			}
+			schemawarn.Append(&env, cat)
+			if nameErrs := semcheck.CheckTableNames(stmts, sql, cat); len(nameErrs) > 0 {
+				env.Errors = append(env.Errors, nameErrs...)
+				return envelopeResult(env)
+			}
+			checks.NameResolution = validateresult.CheckOK
+		}
+
+		data, err := json.Marshal(validateresult.Result{Valid: true, Checks: checks})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
 		}

--- a/internal/schemawarn/schemawarn.go
+++ b/internal/schemawarn/schemawarn.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package schemawarn bridges catalog loader warnings into the standard
+// envelope error stream. Both the CLI subcommands that consume a
+// catalog (validate, list-tables, describe) and the MCP tools that do
+// the same need to surface non-fatal loader diagnostics (skipped
+// statements, duplicate definitions) so agents see them alongside hard
+// errors. Centralizing the conversion keeps the wire code stable —
+// `schema_warning` — and avoids two surfaces drifting apart.
+package schemawarn
+
+import (
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// Code is the envelope error Code emitted for every catalog warning.
+// It is part of the wire contract: agents may filter or branch on it.
+const Code = "schema_warning"
+
+// Append copies any non-fatal issues recorded by the catalog loader
+// into env as warning-severity envelope entries. Call this once after
+// catalog.Load / catalog.LoadFiles. A nil cat is treated as "no
+// catalog loaded" and leaves env unchanged so handlers don't have to
+// guard a failed Load themselves; cat with no warnings is similarly
+// a no-op.
+func Append(env *output.Envelope, cat *catalog.Catalog) {
+	if cat == nil {
+		return
+	}
+	for _, w := range cat.Warnings() {
+		env.Errors = append(env.Errors, output.Error{
+			Code:     Code,
+			Severity: output.SeverityWarning,
+			Message:  w,
+		})
+	}
+}

--- a/internal/validateresult/validateresult.go
+++ b/internal/validateresult/validateresult.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package validateresult defines the JSON payload shape and shared
+// constants used by the SQL validation surfaces (the `crdb-sql validate`
+// CLI command and the `validate_sql` MCP tool). Centralizing these
+// symbols lets the two surfaces emit the same envelope so agents can
+// rely on a single contract — adding a new validation phase means
+// editing one place, not two.
+//
+// The package has a single inbound dependency (internal/output) and no
+// transitive deps on cmd or MCP code, so either surface can import it
+// without pulling in the other.
+package validateresult
+
+import "github.com/spilchen/sql-ai-tools/internal/output"
+
+// CheckStatus is the per-phase outcome reported in Checks. Defined as
+// a named string so call sites get compile-time checking against the
+// closed set of legal values — bare strings would let a typo like
+// "okay" reach the wire. JSON marshaling is unchanged.
+type CheckStatus string
+
+// CheckStatus values. A phase is either CheckOK (ran and passed) or
+// CheckSkipped (its prerequisite — typically --schema or the schemas
+// MCP argument — was missing). A failing phase aborts the request via
+// an envelope error, so a "fail" status never appears here.
+const (
+	CheckOK      CheckStatus = "ok"
+	CheckSkipped CheckStatus = "skipped"
+)
+
+// CapabilityRequiredCode is the envelope error Code (and Category) for
+// a skipped validation phase. Reusing one constant for both fields —
+// rather than defining two separate constants with the same literal —
+// makes drift impossible.
+const CapabilityRequiredCode = "capability_required"
+
+// CapabilityNameResolution is the canonical short identifier of the
+// table-name-resolution phase, embedded both in the warning's Context
+// and in the Checks field name so the two cannot drift.
+const CapabilityNameResolution = "name_resolution"
+
+// Checks records which validation phases ran on the success path.
+// Each field is one of CheckOK or CheckSkipped. Adding a phase means
+// adding a field here and updating both surfaces' rendering paths.
+type Checks struct {
+	Syntax         CheckStatus `json:"syntax"`
+	TypeCheck      CheckStatus `json:"type_check"`
+	NameResolution CheckStatus `json:"name_resolution"`
+}
+
+// Result is the success-path JSON payload for SQL validation. The
+// expanded shape (vs. a bare {valid: true}) exposes which phases ran,
+// so agents can tell whether name resolution was skipped due to a
+// missing schema.
+type Result struct {
+	Valid  bool   `json:"valid"`
+	Checks Checks `json:"checks"`
+}
+
+// CapabilityRequiredError builds the warning entry that signals a
+// validation phase was skipped because its prerequisite is missing.
+// capability is the short identifier of the skipped phase (e.g.
+// CapabilityNameResolution); message is the user-facing summary; hint
+// tells the user how to enable the phase. The result is appended to
+// the envelope's Errors list rather than aborting the request — the
+// CLI exit code stays 0 (or the MCP tool result stays successful)
+// because the phases that did run all passed.
+func CapabilityRequiredError(capability, message, hint string) output.Error {
+	return output.Error{
+		Code:     CapabilityRequiredCode,
+		Severity: output.SeverityWarning,
+		Message:  message,
+		Category: CapabilityRequiredCode,
+		Context: map[string]any{
+			"capability": capability,
+			"hint":       hint,
+		},
+	}
+}


### PR DESCRIPTION
Wrap the catalog-backed CLI commands list-tables (#12) and describe
(#11) as MCP tools so agents can introspect a schema without shelling
out, and lift validate_sql to optionally consume the same inline
schema for table name resolution.

The schemas argument is an array of {label, sql} objects mapped
directly to catalog.SchemaSource. Inline-only by design — MCP servers
may run remotely or sandboxed, so client-side file paths don't belong
in the contract. list_tables and describe_table require a non-empty
schemas array (Tier 2). validate_sql treats it as optional: when
present it runs name resolution (Tier 2); when absent it runs
syntax/types only (Tier 1) and emits a capability_required warning so
agents see that name resolution was skipped rather than silently
trusting a partial result. describe_table surfaces a missing table as
a structured 42P01 envelope error with an "available_tables" context
list rather than the CLI's generic internal_error, which suits the
MCP envelope's machine-consumption use case.

To keep the MCP and CLI surfaces in lockstep, the validate result
shape ({valid, checks: {syntax, type_check, name_resolution}}), the
capability_required warning helper, and the schema_warning loader
bridge move out of cmd into two small shared packages
(internal/validateresult and internal/schemawarn) that both surfaces
import. cmd/validate.go and cmd/root.go are refactored to use them so
the wire contract has a single source of truth.

Resolves: #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)