### PR TITLE
conn: add integration tests for Manager.Ping and crdb-sql ping

### DIFF
--- a/.claude/skills/dev-loop/SKILL.md
+++ b/.claude/skills/dev-loop/SKILL.md
@@ -60,6 +60,18 @@ make lint
 make test
 ```
 
+```bash
+make test-integration
+```
+
+`make test-integration` runs the build-tagged integration suite. The
+tests `t.Skip` cleanly when no cockroach binary is reachable, so this
+step is safe to run on a machine that has not installed cockroach. Set
+`COCKROACH_BIN=/path/to/cockroach` (or `CRDB_TEST_DSN=postgres://...`)
+to actually exercise the integration suite — these tests are
+intentionally not in CI, so the dev-loop is the place that catches
+regressions in cluster-touching code.
+
 ### 1b. Handle failures
 
 If any command fails:
@@ -231,6 +243,13 @@ make lint
 ```bash
 make test
 ```
+
+```bash
+make test-integration
+```
+
+(Same notes as Step 1a apply: integration tests skip cleanly without
+`COCKROACH_BIN` / `CRDB_TEST_DSN`.)
 
 If `make fmt` modified any files, stage and amend before proceeding:
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ STUBS_VERSION           ?= v26.2
 BUILTINS_JSON           := internal/builtinstubs/testdata/crdb_builtins_$(STUBS_VERSION).json
 BUILTINS_GEN            := internal/builtinstubs/stubs_$(subst .,_,$(STUBS_VERSION))_gen.go
 
-.PHONY: help build test fmt fmt-check vet lint clean tools tidy-check generate-builtins
+.PHONY: help build test test-integration fmt fmt-check vet lint clean tools tidy-check generate-builtins
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -27,6 +27,14 @@ build: ## Compile the binary into bin/.
 
 test: ## Run the Go test suite.
 	go test $(GO_PKGS)
+
+# Integration tests are gated behind the `integration` build tag and
+# require a real cockroach binary. Set COCKROACH_BIN to override the
+# default $PATH lookup. With neither COCKROACH_BIN nor CRDB_TEST_DSN
+# set, the tests t.Skip cleanly so this target is safe to run on
+# machines that have not installed cockroach.
+test-integration: ## Run integration tests (requires cockroach binary; set COCKROACH_BIN to override).
+	go test -tags integration -count=1 -timeout 180s $(GO_PKGS)
 
 fmt: ## Auto-format sources with gofmt.
 	gofmt -w $(GOFMT_FILES)

--- a/cmd/ping_integration_test.go
+++ b/cmd/ping_integration_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// Integration tests for `crdb-sql ping` exercising the full CLI path
+// against a real CockroachDB cluster. Build-tagged so `make test`
+// stays fast; run via `make test-integration`. The shared cluster is
+// provided by the cockroachtest harness (see
+// internal/testutil/cockroachtest); it spins up `cockroach demo
+// --background` once per test binary or honors CRDB_TEST_DSN.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// uuidPattern matches the canonical 8-4-4-4-12 hex-with-dashes UUID
+// form. ClusterID is rendered by crdb_internal.cluster_id() in
+// canonical form, so a regex match avoids depending on a uuid
+// package. Unanchored on purpose: the JSON envelope test matches
+// against an info.ClusterID substring inside `data`, and the text
+// test matches inside the `cluster_id: <uuid>` line.
+var uuidPattern = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+// versionPattern matches the leading prefix of a real CockroachDB
+// `version()` string. Tighter than a Contains check; tolerates the
+// CCL/OSS variation between demo build flavors.
+var versionPattern = regexp.MustCompile(`CockroachDB (CCL|OSS) v\d+\.\d+`)
+
+func TestMain(m *testing.M) { cockroachtest.RunTests(m) }
+
+// TestIntegrationPingCmdText covers the default text output: three
+// lines listing cluster_id, version, and connection_status.
+func TestIntegrationPingCmdText(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"ping", "--dsn", cluster.DSN})
+
+	require.NoError(t, root.Execute())
+
+	out := stdout.String()
+	require.Regexp(t, `cluster_id: `+uuidPattern.String(), out)
+	require.Regexp(t, `version: `+versionPattern.String(), out)
+	require.Contains(t, out, "connection_status: connected")
+}
+
+// TestIntegrationPingCmdJSON covers the structured envelope output:
+// tier=connected, connection_status=connected, no errors, and Data
+// decodes into a populated ClusterInfo.
+func TestIntegrationPingCmdJSON(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"ping", "--output", "json", "--dsn", cluster.DSN})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionConnected, env.ConnectionStatus)
+	require.Empty(t, env.Errors)
+
+	var info conn.ClusterInfo
+	require.NoError(t, json.Unmarshal(env.Data, &info))
+	require.Regexp(t, uuidPattern, info.ClusterID,
+		"cluster ID should be a canonical UUID")
+	require.Regexp(t, versionPattern, info.Version,
+		"version should look like CockroachDB CCL/OSS vN.N…")
+}
+
+// TestIntegrationPingCmdConnectionFailureText verifies the text-mode
+// error path. RenderError returns the underlying error unchanged in
+// text mode (see internal/output/render.go), so cobra/main.go own
+// the user-visible "Error: ..." print. The test pins two contracts:
+// (1) Execute returns a non-nil non-ErrRendered error carrying the
+// "connect to CockroachDB" prefix, and (2) stdout stays empty
+// because the success-path text writer was never invoked.
+func TestIntegrationPingCmdConnectionFailureText(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	badDSN := withPort(t, cluster.DSN, 1)
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"ping", "--dsn", badDSN})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, output.ErrRendered,
+		"text mode must return the raw error, not the JSON-rendered sentinel")
+	require.Contains(t, strings.ToLower(err.Error()), "connect to cockroachdb")
+	require.Empty(t, stdout.String(),
+		"text mode must not print any partial cluster info on the failure path")
+}
+
+// TestIntegrationPingCmdConnectionFailureJSON verifies the
+// disconnected-envelope path: a bad-port variant of the live DSN
+// makes the command surface a structured error rather than crash, and
+// connection_status is reported as disconnected.
+func TestIntegrationPingCmdConnectionFailureJSON(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	badDSN := withPort(t, cluster.DSN, 1)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"ping", "--output", "json", "--dsn", badDSN})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, strings.ToLower(env.Errors[0].Message), "connect to cockroachdb")
+}
+
+// withPort returns a copy of dsn with its host port replaced by
+// newPort. Used to fabricate a closed-port DSN from the live one.
+func withPort(t *testing.T, dsn string, newPort int) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	host := u.Hostname()
+	u.Host = host + ":" + strconv.Itoa(newPort)
+	return u.String()
+}

--- a/internal/conn/manager_integration_test.go
+++ b/internal/conn/manager_integration_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// Integration tests for the conn.Manager exercising a real
+// CockroachDB cluster. Build-tagged so `make test` stays fast; run via
+// `make test-integration`. The shared cluster is provided by the
+// cockroachtest harness, which spins up `cockroach demo --background`
+// once per test binary (or honors CRDB_TEST_DSN).
+//
+// "Bad credentials" is intentionally not covered: the demo cluster
+// runs with --insecure and accepts any user, so an auth-rejection
+// assertion would be unstable. Wrong-port, unreachable-host, and
+// malformed-DSN cover the connection-failure surface deterministically.
+
+package conn_test
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// uuidPattern matches the canonical 8-4-4-4-12 hex-with-dashes UUID
+// form, anchored so a stray UUID-shaped substring elsewhere in a
+// future ClusterID format cannot satisfy the assertion. We match
+// against a regex rather than depending on a uuid package:
+// ClusterID is documented to be the cluster_id() string, which is
+// always rendered in canonical form.
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// versionPattern matches the leading prefix of a real CockroachDB
+// `version()` string ("CockroachDB CCL v25.x..." or
+// "CockroachDB OSS v..."). Tighter than a Contains check: catches a
+// regression that swaps in a different distribution string while
+// still tolerating the CCL/OSS variation between demo build flavors.
+var versionPattern = regexp.MustCompile(`^CockroachDB (CCL|OSS) v\d+\.\d+`)
+
+func TestMain(m *testing.M) { cockroachtest.RunTests(m) }
+
+// TestIntegrationManagerPing covers the happy path: NewManager + Ping
+// returns a populated ClusterInfo against a real cluster.
+func TestIntegrationManagerPing(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	info, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	require.Regexp(t, uuidPattern, info.ClusterID,
+		"cluster ID should be a canonical UUID")
+	require.Regexp(t, versionPattern, info.Version,
+		"version should look like CockroachDB CCL/OSS vN.N…")
+}
+
+// TestIntegrationManagerPingAfterCloseReconnects pins the lazy
+// reconnect contract in manager.go: Close clears the cached
+// connection (m.conn = nil) and the next Ping re-dials transparently
+// rather than erroring. Without this test, a future change that adds
+// a "closed" sentinel state could silently break either side of the
+// contract — either failing reuse or breaking lazy reconnect — with
+// no test coverage.
+func TestIntegrationManagerPingAfterCloseReconnects(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	first, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Close(ctx))
+
+	second, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, first.ClusterID, second.ClusterID,
+		"reconnect after Close should land on the same cluster")
+}
+
+// TestIntegrationManagerPingTwice verifies the connection-reuse
+// contract: a second Ping reuses the lazy-connect connection rather
+// than dialing again, and returns the same cluster ID.
+func TestIntegrationManagerPingTwice(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	first, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	second, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	require.Equal(t, first.ClusterID, second.ClusterID,
+		"cluster ID should be stable across Ping calls")
+}
+
+// TestIntegrationManagerCloseAfterPing covers the documented
+// idempotency of Close: a second Close on a Manager whose connection
+// has already been released must be a no-op.
+func TestIntegrationManagerCloseAfterPing(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := mgr.Ping(ctx)
+	require.NoError(t, err)
+	require.NoError(t, mgr.Close(ctx))
+	require.NoError(t, mgr.Close(ctx),
+		"Close should be a no-op on a Manager whose connection was already released")
+}
+
+// TestIntegrationManagerPingFailures table-drives the
+// connection-failure surface. Each case rewrites the live DSN to
+// produce a deterministic dial failure; the assertion targets the
+// wrapped "connect to CockroachDB" prefix from manager.connect.
+func TestIntegrationManagerPingFailures(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+
+	tests := []struct {
+		name              string
+		dsn               func(live string) string
+		expectedErrSubstr string
+	}{
+		{
+			name:              "wrong port",
+			dsn:               rewritePort(1),
+			expectedErrSubstr: "connect to CockroachDB",
+		},
+		{
+			name: "unreachable host",
+			// 198.51.100.0/24 is reserved for documentation (RFC 5737)
+			// and is guaranteed to be unroutable, so this case fails
+			// with a deterministic dial timeout rather than a DNS
+			// lookup error that could vary by resolver.
+			dsn:               rewriteHost("198.51.100.1"),
+			expectedErrSubstr: "connect to CockroachDB",
+		},
+		{
+			name:              "malformed dsn",
+			dsn:               func(string) string { return "not-a-postgres-url" },
+			expectedErrSubstr: "connect to CockroachDB",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := conn.NewManager(tc.dsn(cluster.DSN))
+			t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+			// 5s is enough to fail-closed locally without making the
+			// unreachable-host case wait out the kernel's full TCP
+			// retry budget.
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			_, err := mgr.Ping(ctx)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErrSubstr)
+		})
+	}
+}
+
+// rewritePort returns a DSN-rewriter that swaps the host port to the
+// given value. Used to fabricate a closed-port DSN from a live one.
+func rewritePort(newPort int) func(string) string {
+	return func(live string) string {
+		u, err := url.Parse(live)
+		if err != nil {
+			return live + ":bad"
+		}
+		host := u.Hostname()
+		u.Host = host + ":" + strconv.Itoa(newPort)
+		return u.String()
+	}
+}
+
+// rewriteHost returns a DSN-rewriter that swaps the host portion of
+// the URL to the given value, preserving the original port.
+func rewriteHost(newHost string) func(string) string {
+	return func(live string) string {
+		u, err := url.Parse(live)
+		if err != nil {
+			return "postgres://" + newHost + ":26257/defaultdb"
+		}
+		port := u.Port()
+		if port == "" {
+			u.Host = newHost
+		} else {
+			u.Host = newHost + ":" + port
+		}
+		return u.String()
+	}
+}

--- a/internal/testutil/cockroachtest/cluster.go
+++ b/internal/testutil/cockroachtest/cluster.go
@@ -1,0 +1,480 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package cockroachtest spins up an in-memory single-node CockroachDB
+// cluster (via `cockroach demo --background`) for use by integration
+// tests in this module. It is the only place in the codebase that
+// shells out to a real cockroach binary; integration tests under
+// `//go:build integration` consume it through Shared / RunTests.
+//
+// Lifecycle:
+//
+//   - Start launches a demo cluster, blocks until it has written its
+//     listening URL, and returns a *Cluster whose DSN field is a usable
+//     postgres URL. Stop sends SIGINT, waits up to 10s for graceful
+//     exit, then escalates to SIGKILL. On a Start failure the harness
+//     has already killed any partially-started process and removed the
+//     temp directory before returning.
+//
+//   - Shared and RunTests provide the per-test-binary pattern used by
+//     integration test packages: one cluster is started on the first
+//     Shared call and torn down by RunTests when the test binary exits.
+//
+// Binary resolution (in order):
+//
+//  1. COCKROACH_BIN environment variable.
+//  2. `cockroach` on $PATH.
+//
+// If neither resolves to an executable file, Start returns
+// ErrBinaryNotFound and Shared translates that into t.Skip so CI
+// machines without a cockroach binary stay green.
+//
+// CRDB_TEST_DSN bypass: when CRDB_TEST_DSN is set, Shared returns a
+// Cluster with only DSN populated and a no-op Stop. This lets a
+// developer point integration tests at an already-running cluster
+// without paying the demo startup cost.
+package cockroachtest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Default tuning constants. defaultStartTimeout is overridable via
+// WithStartTimeout; defaultStopTimeout (the SIGINT-grace deadline
+// before SIGKILL escalation) and urlPollInterval are not exposed —
+// they have no plausible test-driven reason to differ across callers.
+const (
+	defaultStartTimeout = 30 * time.Second
+	defaultStopTimeout  = 10 * time.Second
+	urlPollInterval     = 100 * time.Millisecond
+)
+
+// ErrBinaryNotFound is returned by Start when no cockroach binary can
+// be located via COCKROACH_BIN or $PATH. Callers (typically Shared)
+// translate this into t.Skipf with a message explaining how to enable
+// the integration tests.
+var ErrBinaryNotFound = errors.New(
+	"cockroach binary not found (set COCKROACH_BIN or put cockroach on PATH)")
+
+// Cluster represents a running `cockroach demo` instance owned by the
+// test process. Construct with Start; release with Stop. The exported
+// DSN field is the postgres URL the demo cluster wrote to its
+// listening-url-file and is safe to read after Start returns.
+//
+// A Cluster is single-use: once Stop has been called, the cluster
+// cannot be restarted. Tests that need multiple clusters call Start
+// multiple times (each invocation gets its own tempdir and process).
+//
+// Concurrency: a single monitor goroutine started by Start owns
+// cmd.Wait() and signals process exit via the waitDone channel. All
+// other code paths (premature-exit detection during startup, Stop's
+// graceful-shutdown wait) observe exit by selecting on waitDone, so
+// there is exactly one Wait caller and no double-wait race.
+type Cluster struct {
+	// DSN is the postgres connection string for the running demo node.
+	// Populated by Start before it returns; never modified afterward.
+	DSN string
+
+	// cmd is the demo subprocess. Owned by Start, the monitor
+	// goroutine, and Stop; integration tests do not interact with it.
+	cmd *exec.Cmd
+
+	// logBuf captures combined stdout+stderr from the demo. It is a
+	// concurrency-safe wrapper because cmd's internal goroutines write
+	// to it while Logs() may read concurrently from a test goroutine.
+	logBuf *lockedBuf
+
+	// tmpDir holds the URL file and store directory. Removed by Stop.
+	tmpDir string
+
+	// waitDone closes when the cmd.Wait monitor goroutine returns.
+	// waitErr holds the Wait result; the write happens-before the
+	// close, so any reader that has observed waitDone closed may
+	// safely read waitErr. Used by Start's failure path to surface
+	// the subprocess exit code/signal in the wrapped error
+	// ("exit status 1" vs "signal: killed" tells you whether crdb
+	// crashed, the OOM killer killed it, or a flag was rejected).
+	waitDone chan struct{}
+	waitErr  error
+
+	// stopOnce ensures Stop is idempotent: once a teardown has been
+	// performed, repeat calls are no-ops returning the original error.
+	stopOnce sync.Once
+	stopErr  error
+}
+
+// lockedBuf is a concurrency-safe bytes.Buffer wrapper. exec.Cmd's
+// internal stdout/stderr-copy goroutines write to it; Logs() reads
+// from a test goroutine. bytes.Buffer alone would race.
+type lockedBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *lockedBuf) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *lockedBuf) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+// startOpts holds the resolved Option values for Start.
+type startOpts struct {
+	startTimeout time.Duration
+	extraArgs    []string
+}
+
+// Option configures Start.
+type Option interface {
+	apply(*startOpts)
+}
+
+type optionFunc func(*startOpts)
+
+func (f optionFunc) apply(o *startOpts) { f(o) }
+
+// WithStartTimeout overrides the default 30s timeout Start uses
+// while polling for the demo cluster's listening-url-file. This
+// governs only URL-file appearance, not full SQL readiness — that
+// readiness is the caller's concern (typically a Ping retry loop).
+// Demo startup on a loaded CI machine can be slower than 30s; bump
+// this if Start times out.
+func WithStartTimeout(d time.Duration) Option {
+	return optionFunc(func(o *startOpts) { o.startTimeout = d })
+}
+
+// WithExtraArgs appends additional command-line arguments to the
+// `cockroach demo` invocation, after the harness's own flags. Use
+// this for tests that need a non-default demo configuration; do not
+// pass any flag that Start already sets (see the args slice in
+// Start). Multiple WithExtraArgs calls accumulate; arguments appear
+// in call order.
+func WithExtraArgs(args ...string) Option {
+	return optionFunc(func(o *startOpts) {
+		o.extraArgs = append(o.extraArgs, args...)
+	})
+}
+
+// Start launches an in-memory single-node demo cluster in the
+// background. It blocks until the cluster has written its listening
+// URL to a private temp file (default 30s timeout, configurable via
+// WithStartTimeout). On success the returned Cluster's DSN is a valid
+// postgres URL and the caller is responsible for invoking Stop. On
+// failure, any partially-started process has been killed and the
+// temp directory removed before Start returns.
+//
+// Start honors COCKROACH_BIN; if unset, it looks up `cockroach` on
+// $PATH. Returns ErrBinaryNotFound when neither resolves.
+func Start(ctx context.Context, opts ...Option) (*Cluster, error) {
+	resolved := startOpts{startTimeout: defaultStartTimeout}
+	for _, o := range opts {
+		o.apply(&resolved)
+	}
+
+	binary, err := resolveBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "cockroachtest-")
+	if err != nil {
+		return nil, fmt.Errorf("create tempdir: %w", err)
+	}
+	urlPath := filepath.Join(tmpDir, "listen.url")
+
+	args := []string{
+		"demo",
+		"--background",
+		"--no-example-database",
+		"--insecure",
+		"--disable-demo-license",
+		"--listening-url-file=" + urlPath,
+		"--sql-port=0",
+		"--http-port=0",
+	}
+	args = append(args, resolved.extraArgs...)
+
+	logBuf := &lockedBuf{}
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stdout = logBuf
+	cmd.Stderr = logBuf
+
+	if err := cmd.Start(); err != nil {
+		startErr := fmt.Errorf("start cockroach demo: %w", err)
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			return nil, errors.Join(startErr, fmt.Errorf("remove tmpdir %q: %w", tmpDir, rmErr))
+		}
+		return nil, startErr
+	}
+
+	c := &Cluster{
+		cmd:      cmd,
+		logBuf:   logBuf,
+		tmpDir:   tmpDir,
+		waitDone: make(chan struct{}),
+	}
+
+	// Single Wait owner: the monitor goroutine started here is the
+	// only caller of cmd.Wait(). waitForURL and Stop observe exit by
+	// selecting on waitDone, never by calling Wait themselves.
+	go func() {
+		c.waitErr = cmd.Wait()
+		close(c.waitDone)
+	}()
+
+	dsn, err := waitForURL(ctx, urlPath, c.waitDone, resolved.startTimeout)
+	if err != nil {
+		// Kill the partially-started process (if it is still alive)
+		// and clean up the tmpdir so callers don't have to. The
+		// wrapped error captures the process exit and the full
+		// subprocess log so a CI failure is debuggable from the test
+		// output alone — without these, "exited before writing
+		// listening URL" is uselessly opaque.
+		stopErr := c.Stop()
+		// Stop synchronously drains the monitor goroutine on every
+		// reachable path here (cmd.Start succeeded, so the monitor
+		// is running and shutdown waits on waitDone), but we
+		// re-observe the channel close explicitly so the read of
+		// c.waitErr does not depend on shutdown's internal drain
+		// remaining unchanged across future refactors.
+		<-c.waitDone
+		exitInfo := "exit 0"
+		if c.waitErr != nil {
+			exitInfo = c.waitErr.Error()
+		}
+		wrapped := fmt.Errorf("%w (process exit: %s)\nDemo logs:\n%s", err, exitInfo, c.Logs())
+		if stopErr != nil {
+			wrapped = errors.Join(wrapped, fmt.Errorf("teardown after Start failure: %w", stopErr))
+		}
+		return nil, wrapped
+	}
+	c.DSN = dsn
+	return c, nil
+}
+
+// Stop sends SIGINT to the demo process and waits up to 10s for it to
+// exit. If the process does not exit in time, Stop sends SIGKILL and
+// the returned error reports that the graceful shutdown deadline was
+// exceeded. Stop also removes the cluster's tempdir; either failure
+// (shutdown or tmpdir removal) is surfaced via errors.Join so neither
+// is silently lost. Stop is idempotent: subsequent calls return the
+// original error without re-executing the teardown. The captured
+// stdout/stderr remains accessible via Logs() after Stop returns.
+func (c *Cluster) Stop() error {
+	c.stopOnce.Do(func() {
+		shutdownErr := c.shutdown()
+		var rmErr error
+		if c.tmpDir != "" {
+			if err := os.RemoveAll(c.tmpDir); err != nil {
+				rmErr = fmt.Errorf("remove tmpdir %q: %w", c.tmpDir, err)
+			}
+		}
+		c.stopErr = errors.Join(shutdownErr, rmErr)
+	})
+	return c.stopErr
+}
+
+// Logs returns a snapshot of the demo process's combined stdout and
+// stderr. For clusters constructed via the CRDB_TEST_DSN bypass
+// (which never spawns a subprocess) it returns an empty string with
+// no special marker; callers diagnosing a failure should treat empty
+// output as "no subprocess to capture from". When the buffer is
+// present, Logs is safe to call concurrently with the running
+// subprocess: writes from the cmd's stdout/stderr-copy goroutines
+// are mutex-serialized in lockedBuf.
+func (c *Cluster) Logs() string {
+	if c.logBuf == nil {
+		return ""
+	}
+	return c.logBuf.String()
+}
+
+// shutdown signals the demo process and waits for exit. SIGINT first
+// with a defaultStopTimeout grace period; SIGKILL after. Returns nil
+// when the process is already gone or was never spawned. Returns a
+// non-nil error when the SIGINT deadline expires, capturing the
+// SIGKILL outcome so a hung crdb is debuggable rather than silently
+// papered over.
+func (c *Cluster) shutdown() error {
+	if c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+
+	// If the monitor goroutine has already observed exit (premature
+	// crash, or a prior Signal), there is nothing to signal — just
+	// return.
+	select {
+	case <-c.waitDone:
+		return nil
+	default:
+	}
+
+	// Phase 1: SIGINT and bounded grace period. Demo with --background
+	// is documented to shut down on SIGINT/SIGTERM; the SIGKILL path
+	// is a safety net for hung processes, not the expected case.
+	if err := c.cmd.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("signal cockroach demo: %w", err)
+	}
+
+	select {
+	case <-c.waitDone:
+		// A non-zero exit from a SIGINT'd cockroach is expected; we do
+		// not bubble it up as a test failure.
+		return nil
+	case <-time.After(defaultStopTimeout):
+		killErr := c.cmd.Process.Kill()
+		<-c.waitDone
+		if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
+			return fmt.Errorf("cockroach demo did not exit on SIGINT within %s; SIGKILL also failed: %w", defaultStopTimeout, killErr)
+		}
+		return fmt.Errorf("cockroach demo did not exit on SIGINT within %s; sent SIGKILL", defaultStopTimeout)
+	}
+}
+
+// resolveBinary picks the cockroach binary using the documented
+// COCKROACH_BIN -> PATH fallback. Returns ErrBinaryNotFound when no
+// candidate resolves to an executable file.
+func resolveBinary() (string, error) {
+	if envBin := os.Getenv("COCKROACH_BIN"); envBin != "" {
+		info, err := os.Stat(envBin)
+		if err != nil || info.IsDir() {
+			return "", fmt.Errorf("%w: COCKROACH_BIN=%q", ErrBinaryNotFound, envBin)
+		}
+		return envBin, nil
+	}
+	path, err := exec.LookPath("cockroach")
+	if err != nil {
+		return "", ErrBinaryNotFound
+	}
+	return path, nil
+}
+
+// waitForURL polls urlPath until the demo process has written a
+// non-empty URL or the timeout elapses. If the process exits before
+// writing the file (e.g., flag rejection), waitForURL returns
+// promptly via the procExited channel rather than waiting out the
+// full timeout. The caller passes the Cluster's waitDone channel; the
+// Wait owner is the goroutine started in Start.
+func waitForURL(ctx context.Context, urlPath string, procExited <-chan struct{}, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		// Read the file unconditionally; an empty/missing file is the
+		// "not ready yet" signal and we just keep polling.
+		if data, err := os.ReadFile(urlPath); err == nil {
+			url := strings.TrimSpace(string(data))
+			if url != "" {
+				return url, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("waiting for cockroach demo URL: %w", ctx.Err())
+		case <-procExited:
+			return "", errors.New("cockroach demo exited before writing listening URL")
+		case <-time.After(urlPollInterval):
+			if time.Now().After(deadline) {
+				return "", fmt.Errorf("timed out after %s waiting for cockroach demo to write %s", timeout, urlPath)
+			}
+		}
+	}
+}
+
+// Per-test-binary shared cluster. The first Shared call starts a
+// cluster (or resolves CRDB_TEST_DSN); subsequent calls in the same
+// test binary return the same instance. RunTests tears it down.
+var (
+	sharedMu      sync.Mutex
+	sharedCluster *Cluster
+	sharedErr     error
+	sharedStarted bool
+)
+
+// Shared returns the per-test-binary cluster, starting one on the
+// first call. CRDB_TEST_DSN takes precedence: if set, Shared returns a
+// Cluster whose DSN is the env value and whose Stop is a no-op.
+//
+// Behavior on missing binary: when neither CRDB_TEST_DSN nor a
+// resolvable cockroach binary is available, Shared calls t.Skipf and
+// returns nil. On a real *testing.T, Skipf invokes runtime.Goexit, so
+// the nil return is only observable to test doubles that override
+// Skipf (e.g. the recordingTB used in cluster_test.go). Production
+// callers can rely on Shared either returning a usable *Cluster or
+// never returning.
+//
+// Tests using Shared must wire their TestMain through RunTests so the
+// cluster is cleanly torn down at exit.
+func Shared(t testing.TB) *Cluster {
+	t.Helper()
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+
+	if sharedStarted {
+		if sharedErr != nil {
+			t.Skipf("cockroachtest: shared cluster unavailable: %v", sharedErr)
+			return nil
+		}
+		return sharedCluster
+	}
+	sharedStarted = true
+
+	if dsn := os.Getenv("CRDB_TEST_DSN"); dsn != "" {
+		sharedCluster = &Cluster{DSN: dsn}
+		return sharedCluster
+	}
+
+	c, err := Start(context.Background())
+	if errors.Is(err, ErrBinaryNotFound) {
+		sharedErr = err
+		t.Skipf("cockroachtest: %v; set COCKROACH_BIN or CRDB_TEST_DSN to enable integration tests", err)
+		return nil
+	}
+	if err != nil {
+		sharedErr = err
+		t.Fatalf("cockroachtest: failed to start cluster: %v", err)
+		return nil
+	}
+	sharedCluster = c
+	return sharedCluster
+}
+
+// RunTests is the TestMain helper for integration test packages. It
+// runs the standard test suite via m.Run and then tears down any
+// shared cluster that Shared created. Call from each integration test
+// package as:
+//
+//	func TestMain(m *testing.M) { cockroachtest.RunTests(m) }
+//
+// RunTests calls os.Exit, mirroring the standard TestMain contract.
+// Teardown errors are written to stderr before os.Exit because
+// m.Run has already returned and t.Log is unavailable; without this,
+// a hung-shutdown or tmpdir-cleanup failure would silently exit 0.
+func RunTests(m *testing.M) {
+	code := m.Run()
+	sharedMu.Lock()
+	c := sharedCluster
+	sharedMu.Unlock()
+	if c != nil {
+		if err := c.Stop(); err != nil {
+			fmt.Fprintf(os.Stderr, "cockroachtest: shared cluster teardown failed: %v\n", err)
+		}
+	}
+	os.Exit(code)
+}

--- a/internal/testutil/cockroachtest/cluster_test.go
+++ b/internal/testutil/cockroachtest/cluster_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cockroachtest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartReturnsErrBinaryNotFound exercises the binary-resolution
+// failure path. Start is documented to return ErrBinaryNotFound when
+// neither COCKROACH_BIN nor `cockroach` on $PATH resolves; this test
+// pins COCKROACH_BIN to a non-existent path and clears PATH so the
+// fallback also misses.
+func TestStartReturnsErrBinaryNotFound(t *testing.T) {
+	t.Setenv("COCKROACH_BIN", "/definitely/not/a/real/path/cockroach")
+	t.Setenv("PATH", "")
+
+	_, err := Start(context.Background())
+	require.ErrorIs(t, err, ErrBinaryNotFound)
+}
+
+// TestStartReturnsErrBinaryNotFoundWithoutEnvVar covers the second
+// half of the resolution flow: COCKROACH_BIN unset, no cockroach on
+// PATH. We empty PATH so exec.LookPath cannot find anything.
+func TestStartReturnsErrBinaryNotFoundWithoutEnvVar(t *testing.T) {
+	t.Setenv("COCKROACH_BIN", "")
+	t.Setenv("PATH", "")
+
+	_, err := Start(context.Background())
+	require.ErrorIs(t, err, ErrBinaryNotFound)
+}
+
+// TestStartTimesOutWhenURLNeverAppears verifies that Start gives up
+// after WithStartTimeout if the binary runs but never writes the
+// listening-url-file. The fake binary just sleeps; Start should
+// return a timeout error and clean up the partial process.
+func TestStartTimesOutWhenURLNeverAppears(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary harness uses /bin/sh; not portable to Windows")
+	}
+	fake := writeShellBinary(t, "exec sleep 30")
+	t.Setenv("COCKROACH_BIN", fake)
+
+	_, err := Start(context.Background(), WithStartTimeout(300*time.Millisecond))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+}
+
+// TestStartDetectsPrematureExit verifies the short-circuit when the
+// fake binary exits before writing the URL file. Start should return
+// promptly (well under the configured timeout) rather than polling
+// for the full duration.
+func TestStartDetectsPrematureExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary harness uses /bin/sh; not portable to Windows")
+	}
+	fake := writeShellBinary(t, "exit 0")
+	t.Setenv("COCKROACH_BIN", fake)
+
+	deadline := time.Now().Add(5 * time.Second)
+	_, err := Start(context.Background(), WithStartTimeout(30*time.Second))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exited before writing listening URL")
+	require.True(t, time.Now().Before(deadline),
+		"premature-exit detection should be near-instant, not wait for the timeout")
+}
+
+// TestSharedSkipsWhenNoBinary verifies Shared's t.Skipf path. The
+// shared-state reset keeps the test independent of execution order
+// inside this package.
+func TestSharedSkipsWhenNoBinary(t *testing.T) {
+	t.Setenv("COCKROACH_BIN", "/definitely/not/a/real/path/cockroach")
+	t.Setenv("PATH", "")
+	t.Setenv("CRDB_TEST_DSN", "")
+	resetSharedState()
+
+	rec := &recordingTB{TB: t}
+	c := Shared(rec)
+	require.Nil(t, c)
+	require.True(t, rec.skipped, "expected Shared to call Skipf when binary is absent")
+	require.Contains(t, rec.skipMsg, "binary not found")
+}
+
+// TestSharedHonorsCRDBTestDSN pins the documented escape hatch: when
+// CRDB_TEST_DSN is set, Shared returns a Cluster wrapping the env
+// value and never spawns a subprocess (even if the binary lookup
+// would have failed). Stop must be a no-op for the bypass shape.
+func TestSharedHonorsCRDBTestDSN(t *testing.T) {
+	const dsn = "postgres://example/dummy"
+	t.Setenv("COCKROACH_BIN", "/definitely/not/a/real/path/cockroach")
+	t.Setenv("PATH", "")
+	t.Setenv("CRDB_TEST_DSN", dsn)
+	resetSharedState()
+
+	rec := &recordingTB{TB: t}
+	c := Shared(rec)
+	require.NotNil(t, c)
+	require.False(t, rec.skipped, "Shared must not Skip when CRDB_TEST_DSN is set")
+	require.Equal(t, dsn, c.DSN)
+	require.Empty(t, c.Logs(), "bypass cluster has no subprocess to capture from")
+	require.NoError(t, c.Stop(), "Stop on a CRDB_TEST_DSN cluster must be a no-op")
+	require.NoError(t, c.Stop(), "Stop must remain a no-op on repeat invocation")
+}
+
+// TestStopIsIdempotentAndCleansUpTmpdir pins two related contracts in
+// one test: Stop is safe to call repeatedly (sync.Once), and the
+// tmpdir is removed after the first successful Stop. Uses a fake
+// binary that writes a fabricated URL then sleeps so Start succeeds
+// without needing a real cockroach.
+func TestStopIsIdempotentAndCleansUpTmpdir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary harness uses /bin/sh; not portable to Windows")
+	}
+	// The harness invokes the binary with `demo --background ...
+	// --listening-url-file=<path> ...`. Parse the path from $@ by
+	// finding the --listening-url-file= flag (long-form, single arg)
+	// and write a fake DSN to it before sleeping.
+	body := `for arg in "$@"; do
+  case "$arg" in
+    --listening-url-file=*)
+      printf 'postgres://fake@127.0.0.1:1/defaultdb\n' > "${arg#--listening-url-file=}"
+      ;;
+  esac
+done
+exec sleep 30`
+	fake := writeShellBinary(t, body)
+	t.Setenv("COCKROACH_BIN", fake)
+
+	c, err := Start(context.Background(), WithStartTimeout(5*time.Second))
+	require.NoError(t, err)
+	require.NotEmpty(t, c.DSN)
+
+	tmpDir := c.tmpDir
+	require.DirExists(t, tmpDir)
+
+	require.NoError(t, c.Stop())
+	require.NoDirExists(t, tmpDir, "tmpdir must be removed after Stop")
+
+	require.NoError(t, c.Stop(), "Stop must be idempotent")
+}
+
+// writeShellBinary creates an executable shell script in a per-test
+// temp dir and returns its absolute path. The body is appended after
+// the `#!/bin/sh` shebang. Suitable for use as a stand-in
+// COCKROACH_BIN that simulates a hung or misbehaving binary.
+func writeShellBinary(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fake-cockroach-"+strconv.Itoa(os.Getpid()))
+	contents := "#!/bin/sh\n" + body + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o755))
+	return path
+}
+
+// resetSharedState clears the package-level shared-cluster singleton.
+// Tests use it to avoid order-dependence when exercising Shared.
+func resetSharedState() {
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+	sharedCluster = nil
+	sharedErr = nil
+	sharedStarted = false
+}
+
+// recordingTB wraps a testing.TB and intercepts Skipf so a unit test
+// can assert on the skip outcome without actually skipping itself.
+// All other testing.TB methods delegate to the embedded value.
+type recordingTB struct {
+	testing.TB
+	skipped bool
+	skipMsg string
+}
+
+func (r *recordingTB) Skipf(format string, args ...any) {
+	r.skipped = true
+	r.skipMsg = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingTB) Helper() {}


### PR DESCRIPTION
Issue #62 asked for the first integration tests against a real CockroachDB cluster. Today the `Manager.Ping` path and the `crdb-sql ping` subcommand are only covered by unit tests with bad DSNs — the happy path (a populated `ClusterInfo`, a `connection_status: connected` envelope) has never been exercised end-to-end, so a regression in either layer would slip through `make test`.

This PR introduces a small reusable harness that spins up `cockroach demo --background` once per test binary, plus build-tagged integration tests that consume it.

- `internal/testutil/cockroachtest` spawns the demo cluster, polls the `--listening-url-file` for the DSN, and tears the process down on exit. Binary lookup is `COCKROACH_BIN` → `$PATH`; missing-binary surfaces as `ErrBinaryNotFound` which `Shared` translates to `t.Skipf` so machines without cockroach stay green.
- `CRDB_TEST_DSN` bypasses demo spin-up entirely, letting a developer point integration tests at an already-running cluster.
- `internal/conn/manager_integration_test.go` covers the `Ping` happy path (canonical UUID; version matches `CockroachDB (CCL|OSS) v\d+\.\d+`), connection reuse across two `Pings`, idempotent `Close`, lazy reconnect after `Close`, and three deterministic failure modes (wrong port, unreachable RFC 5737 host, malformed DSN).
- `cmd/ping_integration_test.go` exercises the full CLI: text output, JSON envelope, text-mode failure path, and JSON disconnected-envelope on a closed-port DSN.

The "bad credentials" case from the issue is intentionally dropped: demo runs `--insecure` and accepts any user, so an auth-rejection assertion would be unstable.

Tests are gated by `//go:build integration` and a new `make test-integration` target so `make test` stays fast. Integration tests are intentionally not in CI (they would require shipping a cockroach binary), so the `dev-loop` skill runs `make test-integration` after `make test` in both pre-commit and post-rebase verification.

Resolves: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)