### PR TITLE
diag: enrich cluster-side errors with SQLSTATE in envelopes

### DIFF
--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 )
@@ -62,7 +63,7 @@ connection string is read from --dsn or CRDB_DSN (flag wins).`,
 
 			result, err := mgr.Explain(cmd.Context(), sql)
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
 			}
 
 			baseEnv.ConnectionStatus = output.ConnectionConnected

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
@@ -45,7 +46,7 @@ CRDB_DSN environment variable (flag takes precedence).`,
 
 			info, err := mgr.Ping(cmd.Context())
 			if err != nil {
-				return r.RenderError(baseEnv, err)
+				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, ""))
 			}
 
 			baseEnv.ConnectionStatus = output.ConnectionConnected

--- a/internal/diag/category.go
+++ b/internal/diag/category.go
@@ -14,6 +14,9 @@ const (
 	CategoryUnknownTable       = "unknown_table"
 	CategoryUnknownFunction    = "unknown_function"
 	CategoryAmbiguousReference = "ambiguous_reference"
+	CategoryPermissionDenied   = "permission_denied"
+	CategoryConnectionError    = "connection_error"
+	CategoryQueryCanceled      = "query_canceled"
 )
 
 // codeCategory maps exact 5-character SQLSTATE codes to categories.
@@ -29,17 +32,27 @@ var codeCategory = map[string]string{
 	"42P08": CategoryAmbiguousReference, // ambiguous_parameter
 	"42P09": CategoryAmbiguousReference, // ambiguous_alias
 	"42P10": CategoryUnknownColumn,      // invalid_column_reference
+	"42501": CategoryPermissionDenied,   // insufficient_privilege
+	"57014": CategoryQueryCanceled,      // query_canceled (statement timeout / cancel request)
 }
 
 // classCategory maps the 2-character SQLSTATE class prefix to a
 // fallback category used when the exact code is not in codeCategory.
-// Class 42 ("Syntax Error or Access Rule Violation") includes
-// access-rule codes like 42501 (insufficient_privilege), but this
-// tool only sees parser-generated errors where the syntax_error
-// fallback is appropriate.
+//
+// Class 42 ("Syntax Error or Access Rule Violation") covers both
+// parser-generated syntax errors and cluster-side access-rule errors;
+// the syntax_error fallback fits the syntax case, and exact-code
+// entries (e.g. 42501 → permission_denied) handle the access-rule
+// subset that flows through diag.FromClusterError.
+//
+// Class 08 ("Connection Exception") is populated entirely via the
+// class-level fallback because the specific subcodes (08000, 08001,
+// 08006, ...) all describe the same agent-facing concern: the client
+// could not establish or maintain a session with the cluster.
 var classCategory = map[string]string{
-	"42": CategorySyntaxError,  // Syntax Error or Access Rule Violation
-	"22": CategoryTypeMismatch, // Data Exception
+	"42": CategorySyntaxError,     // Syntax Error or Access Rule Violation
+	"22": CategoryTypeMismatch,    // Data Exception
+	"08": CategoryConnectionError, // Connection Exception
 }
 
 // CategoryForCode returns the agent-facing category string for the

--- a/internal/diag/category_test.go
+++ b/internal/diag/category_test.go
@@ -28,10 +28,14 @@ func TestCategoryForCode(t *testing.T) {
 		{name: "ambiguous parameter", code: "42P08", expectedCategory: "ambiguous_reference"},
 		{name: "ambiguous alias", code: "42P09", expectedCategory: "ambiguous_reference"},
 		{name: "invalid column reference", code: "42P10", expectedCategory: "unknown_column"},
+		{name: "insufficient privilege", code: "42501", expectedCategory: "permission_denied"},
+		{name: "query canceled", code: "57014", expectedCategory: "query_canceled"},
 
 		// Class-level fallback.
-		{name: "unmapped class-42 falls back to syntax_error", code: "42501", expectedCategory: "syntax_error"},
+		{name: "unmapped class-42 falls back to syntax_error", code: "42999", expectedCategory: "syntax_error"},
 		{name: "data exception class", code: "22012", expectedCategory: "type_mismatch"},
+		{name: "connection class fallback", code: "08000", expectedCategory: "connection_error"},
+		{name: "connection failure subcode", code: "08006", expectedCategory: "connection_error"},
 
 		// Unknown codes return empty.
 		{name: "unknown class returns empty", code: "99999", expectedCategory: ""},

--- a/internal/diag/error.go
+++ b/internal/diag/error.go
@@ -17,9 +17,11 @@
 package diag
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
@@ -83,5 +85,58 @@ func FromParseError(err error, fullSQL string) output.Error {
 		Message:  err.Error(),
 		Position: ExtractPosition(detail, fullSQL),
 		Category: CategoryForCode(code),
+	}
+}
+
+// FromClusterError converts a cluster-side error into a structured
+// output.Error.
+//
+// When err's chain contains a *pgconn.PgError (a pgwire protocol
+// error from the server), Code, Severity, Message, Category, and
+// Position (when fullSQL is supplied and the server reported a
+// position) are populated from it. Any error whose chain does not
+// contain a *pgconn.PgError falls back to the generic internal_error
+// shape so callers always get a single envelope schema.
+//
+// fullSQL is the originating statement; pass "" when no statement is
+// associated with the call. The pgwire Position field is a 1-based
+// character index into the original query, so it is only meaningful
+// when fullSQL is provided.
+func FromClusterError(err error, fullSQL string) output.Error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return output.Error{
+			Code:     "internal_error",
+			Severity: output.SeverityError,
+			Message:  err.Error(),
+		}
+	}
+
+	// Prefer the unlocalized severity so the wire string is stable
+	// across server locales; fall back to the localized field, then
+	// to the protocol default.
+	sev := pgErr.SeverityUnlocalized
+	if sev == "" {
+		sev = pgErr.Severity
+	}
+	if sev == "" {
+		sev = string(output.SeverityError)
+	}
+
+	var pos *output.Position
+	if fullSQL != "" && pgErr.Position > 0 {
+		// pgwire Position is a 1-based character index; the rest of
+		// this package works in byte offsets, so translate runes to
+		// bytes here. ASCII-only SQL is a no-op cost path.
+		byteOffset := CharIndexToByteOffset(fullSQL, int(pgErr.Position)-1)
+		pos = PositionFromByteOffset(fullSQL, byteOffset)
+	}
+
+	return output.Error{
+		Code:     pgErr.Code,
+		Severity: output.Severity(sev),
+		Message:  pgErr.Message,
+		Position: pos,
+		Category: CategoryForCode(pgErr.Code),
 	}
 }

--- a/internal/diag/error_test.go
+++ b/internal/diag/error_test.go
@@ -6,9 +6,12 @@
 package diag
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
@@ -75,6 +78,182 @@ func TestFromParseError(t *testing.T) {
 			require.Equal(t, tc.expectedSeverity, diagErr.Severity)
 			require.Contains(t, diagErr.Message, tc.expectedMsgSub)
 
+			require.Equal(t, tc.expectedCategory, diagErr.Category)
+
+			if tc.expectedPos == nil {
+				require.Nil(t, diagErr.Position)
+			} else {
+				require.NotNil(t, diagErr.Position)
+				require.Equal(t, *tc.expectedPos, *diagErr.Position)
+			}
+		})
+	}
+}
+
+func TestFromClusterError(t *testing.T) {
+	tests := []struct {
+		name             string
+		err              error
+		fullSQL          string
+		expectedCode     string
+		expectedSeverity output.Severity
+		expectedMessage  string
+		expectedCategory string
+		expectedPos      *output.Position
+	}{
+		{
+			name: "undefined table populates code, message, and category",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42P01",
+				Message:             `relation "doesnotexist" does not exist`,
+			},
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  `relation "doesnotexist" does not exist`,
+			expectedCategory: "unknown_table",
+		},
+		{
+			name: "permission denied maps to permission_denied category",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42501",
+				Message:             "permission denied for table users",
+			},
+			expectedCode:     "42501",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "permission denied for table users",
+			expectedCategory: "permission_denied",
+		},
+		{
+			name: "connection failure falls back to class-level connection_error",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "FATAL",
+				Code:                "08006",
+				Message:             "connection terminated",
+			},
+			expectedCode:     "08006",
+			expectedSeverity: output.SeverityFatal,
+			expectedMessage:  "connection terminated",
+			expectedCategory: "connection_error",
+		},
+		{
+			name: "wrapped pgwire error is unwrapped via errors.As",
+			err: fmt.Errorf("query cluster info: %w", &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42P01",
+				Message:             "relation does not exist",
+			}),
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "relation does not exist",
+			expectedCategory: "unknown_table",
+		},
+		{
+			name: "position populated when fullSQL and Position supplied",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42P01",
+				Message:             "relation does not exist",
+				Position:            15,
+			},
+			fullSQL:          "SELECT * FROM doesnotexist",
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "relation does not exist",
+			expectedCategory: "unknown_table",
+			expectedPos: &output.Position{
+				Line:       1,
+				Column:     15,
+				ByteOffset: 14,
+			},
+		},
+		{
+			name: "multibyte identifier shifts byte offset past character index",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42703",
+				Message:             "column does not exist",
+				// 'é' is 2 bytes in UTF-8; the column 'x' is the 29th
+				// character (1-based) but the 30th byte (1-based).
+				// Without char→byte translation Column would be 29.
+				Position: 29,
+			},
+			fullSQL:          `SELECT * FROM "tbl_é" WHERE x=1`,
+			expectedCode:     "42703",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "column does not exist",
+			expectedCategory: "unknown_column",
+			expectedPos: &output.Position{
+				Line:       1,
+				Column:     30,
+				ByteOffset: 29,
+			},
+		},
+		{
+			name: "position omitted when Position is zero with fullSQL set",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42P01",
+				Message:             "relation does not exist",
+				Position:            0,
+			},
+			fullSQL:          "SELECT * FROM doesnotexist",
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "relation does not exist",
+			expectedCategory: "unknown_table",
+		},
+		{
+			name: "position omitted when fullSQL is empty",
+			err: &pgconn.PgError{
+				SeverityUnlocalized: "ERROR",
+				Code:                "42P01",
+				Message:             "relation does not exist",
+				Position:            15,
+			},
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "relation does not exist",
+			expectedCategory: "unknown_table",
+		},
+		{
+			name: "empty severity defaults to ERROR",
+			err: &pgconn.PgError{
+				Code:    "42P01",
+				Message: "relation does not exist",
+			},
+			expectedCode:     "42P01",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "relation does not exist",
+			expectedCategory: "unknown_table",
+		},
+		{
+			name: "localized severity used when unlocalized is empty",
+			err: &pgconn.PgError{
+				Severity: "WARNING",
+				Code:     "01000",
+				Message:  "warning from cluster",
+			},
+			expectedCode:     "01000",
+			expectedSeverity: output.SeverityWarning,
+			expectedMessage:  "warning from cluster",
+		},
+		{
+			name:             "non-pgwire error falls back to internal_error",
+			err:              errors.New("dial tcp 127.0.0.1:1: connect: connection refused"),
+			expectedCode:     "internal_error",
+			expectedSeverity: output.SeverityError,
+			expectedMessage:  "dial tcp 127.0.0.1:1: connect: connection refused",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diagErr := FromClusterError(tc.err, tc.fullSQL)
+			require.Equal(t, tc.expectedCode, diagErr.Code)
+			require.Equal(t, tc.expectedSeverity, diagErr.Severity)
+			require.Equal(t, tc.expectedMessage, diagErr.Message)
 			require.Equal(t, tc.expectedCategory, diagErr.Category)
 
 			if tc.expectedPos == nil {

--- a/internal/diag/position.go
+++ b/internal/diag/position.go
@@ -105,6 +105,25 @@ func PositionFromByteOffset(fullSQL string, byteOffset int) *output.Position {
 	}
 }
 
+// CharIndexToByteOffset converts a 0-based UTF-8 character (rune) index
+// within sql into a 0-based byte offset. Used to translate the pgwire
+// protocol's character-based Position field into the byte offset the
+// rest of this package operates on. Negative indices clamp to 0;
+// indices past the rune count clamp to len(sql).
+func CharIndexToByteOffset(sql string, charIdx int) int {
+	if charIdx <= 0 {
+		return 0
+	}
+	var count int
+	for i := range sql {
+		if count == charIdx {
+			return i
+		}
+		count++
+	}
+	return len(sql)
+}
+
 // lineColumn converts a 0-based byte offset within sql into a 1-based
 // line and column. The column counts bytes from the last newline (or
 // start of string), not runes, matching the CockroachDB parser's

--- a/internal/diag/position_test.go
+++ b/internal/diag/position_test.go
@@ -129,6 +129,30 @@ func TestExtractPosition(t *testing.T) {
 	}
 }
 
+func TestCharIndexToByteOffset(t *testing.T) {
+	tests := []struct {
+		name           string
+		sql            string
+		charIdx        int
+		expectedOffset int
+	}{
+		{name: "negative clamps to zero", sql: "abc", charIdx: -5, expectedOffset: 0},
+		{name: "zero is start of string", sql: "abc", charIdx: 0, expectedOffset: 0},
+		{name: "ascii midstring is identity", sql: "SELECT 1", charIdx: 7, expectedOffset: 7},
+		{name: "multibyte rune adds bytes", sql: `"é"x`, charIdx: 3, expectedOffset: 4},
+		{name: "exact end of string", sql: "abc", charIdx: 3, expectedOffset: 3},
+		{name: "past end clamps to len", sql: "abc", charIdx: 99, expectedOffset: 3},
+		{name: "empty string clamps to zero", sql: "", charIdx: 5, expectedOffset: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CharIndexToByteOffset(tc.sql, tc.charIdx)
+			require.Equal(t, tc.expectedOffset, got)
+		})
+	}
+}
+
 func TestLineColumn(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
@@ -65,11 +66,7 @@ func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 
 		result, err := mgr.Explain(ctx, sql)
 		if err != nil {
-			env.Errors = []output.Error{{
-				Code:     "internal_error",
-				Severity: output.SeverityError,
-				Message:  err.Error(),
-			}}
+			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
 			return envelopeResult(env)
 		}
 

--- a/internal/output/envelope_test.go
+++ b/internal/output/envelope_test.go
@@ -320,6 +320,79 @@ func TestRenderError(t *testing.T) {
 	})
 }
 
+// TestRenderErrorEntry pins the structured-error variant: the supplied
+// Error is appended verbatim (preserving Code/Category/Position that
+// callers like diag.FromClusterError populate), text mode still passes
+// failure through, and the same EPIPE / Data-clearing / append /
+// errors.Join semantics as RenderError apply.
+func TestRenderErrorEntry(t *testing.T) {
+	origFailure := errors.New("query cluster info: relation does not exist")
+	enriched := Error{
+		Code:     "42P01",
+		Severity: SeverityError,
+		Message:  "relation does not exist",
+		Category: "unknown_table",
+		Position: &Position{Line: 1, Column: 15, ByteOffset: 14},
+	}
+
+	t.Run("json mode emits supplied entry verbatim", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatJSON, Out: &buf}
+		env := Envelope{
+			ParserVersion:    "v0.26.2",
+			ConnectionStatus: ConnectionDisconnected,
+			Data:             json.RawMessage(`{"binary_version":"dev"}`),
+		}
+		err := r.RenderErrorEntry(env, origFailure, enriched)
+		require.ErrorIs(t, err, ErrRendered)
+
+		var got Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Len(t, got.Errors, 1)
+		require.Equal(t, "42P01", got.Errors[0].Code)
+		require.Equal(t, "unknown_table", got.Errors[0].Category)
+		require.Equal(t, "relation does not exist", got.Errors[0].Message)
+		require.NotNil(t, got.Errors[0].Position)
+		require.Equal(t, *enriched.Position, *got.Errors[0].Position)
+		require.Empty(t, got.Data, "Data must be cleared on error path")
+	})
+
+	t.Run("text mode returns original failure unchanged", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatText, Out: &buf}
+		err := r.RenderErrorEntry(Envelope{}, origFailure, enriched)
+		require.ErrorIs(t, err, origFailure)
+		require.Empty(t, buf.String(), "text mode must not write anything")
+	})
+
+	t.Run("write failure preserves original via errors.Join", func(t *testing.T) {
+		writeErr := errors.New("disk full")
+		r := Renderer{Format: FormatJSON, Out: fakeWriter{err: writeErr}}
+		err := r.RenderErrorEntry(Envelope{}, origFailure, enriched)
+		require.ErrorIs(t, err, origFailure)
+		require.ErrorContains(t, err, "render error envelope")
+		require.False(t, errors.Is(err, ErrRendered))
+	})
+
+	t.Run("pre-existing errors preserved via append", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := Renderer{Format: FormatJSON, Out: &buf}
+		existing := Error{Code: "42703", Severity: SeverityWarning, Message: "column not found"}
+		env := Envelope{
+			ConnectionStatus: ConnectionDisconnected,
+			Errors:           []Error{existing},
+		}
+		err := r.RenderErrorEntry(env, origFailure, enriched)
+		require.ErrorIs(t, err, ErrRendered)
+
+		var got Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Len(t, got.Errors, 2)
+		require.Equal(t, "42703", got.Errors[0].Code)
+		require.Equal(t, "42P01", got.Errors[1].Code)
+	})
+}
+
 // TestSeverityValues pins the wire string for every Severity constant.
 // Agents key off these literals (they match the PostgreSQL fe/be
 // protocol severity names); a typo here would silently change the

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -116,14 +116,32 @@ func (r Renderer) Render(env Envelope, textFn func(io.Writer) error) error {
 // the consumer abandoned the pipe, so no output channel remains and
 // the best we can do is exit non-zero.
 func (r Renderer) RenderError(env Envelope, failure error) error {
-	if r.Format != FormatJSON {
-		return failure
-	}
-	env.Errors = append(env.Errors, Error{
+	return r.RenderErrorEntry(env, failure, Error{
 		Code:     "internal_error",
 		Severity: SeverityError,
 		Message:  failure.Error(),
 	})
+}
+
+// RenderErrorEntry is the structured-error variant of RenderError for
+// callers that have already constructed an Error themselves. The
+// supplied entry is appended verbatim to env.Errors instead of the
+// generic internal_error shape RenderError synthesizes; this lets
+// callers preserve enriched fields (e.g. SQLSTATE Code, Category,
+// Position) that the generic synthesis would not populate.
+//
+// failure is still required so the text-mode return path stays
+// consistent: text mode bypasses the envelope and returns failure
+// unchanged. entry.Message and failure.Error() are not required to
+// match — JSON consumers see entry, text consumers see failure. All
+// other contract points (ErrRendered sentinel, Data clearing, append
+// semantics on pre-existing errors, errors.Join on render failure)
+// match RenderError.
+func (r Renderer) RenderErrorEntry(env Envelope, failure error, entry Error) error {
+	if r.Format != FormatJSON {
+		return failure
+	}
+	env.Errors = append(env.Errors, entry)
 	env.Data = nil
 	if err := r.Render(env, nil); err != nil {
 		return errors.Join(failure, fmt.Errorf("render error envelope: %w", err))


### PR DESCRIPTION
Cluster-side errors returned by internal/conn.Manager (Ping, Explain)
previously collapsed to a hardcoded `Code: "internal_error"` envelope
entry in both the CLI render path and the MCP explain handler. Agents
and CLI consumers had no way to branch on cause: an undefined table,
a permission failure, and a connect timeout all looked identical on
the wire.

The parser path already produces structured Code/Severity/Message/
Position/Category via diag.FromParseError. This commit adds a parallel
helper diag.FromClusterError that walks the error chain via errors.As
for *pgconn.PgError and maps its fields into the same output.Error
shape. Non-pgwire failures (connect refused, context cancellation)
fall back to the existing internal_error shape so callers keep a
single envelope schema.

The category map gains explicit entries for 42501 (permission_denied)
and 57014 (query_canceled), plus an 08 class fallback
(connection_error) so connection exceptions surface a stable
agent-facing category regardless of subcode.

Wiring: a new Renderer.RenderErrorEntry method accepts a pre-built
Error (output cannot import diag without a cycle), and the cluster-
call branches in cmd/ping.go, cmd/explain.go, and the MCP
explain_sql handler route through it. Other RenderError sites
(missing DSN, marshal failures) intentionally stay on the
internal_error shape — they are genuinely internal.

Resolves: #88