### PR TITLE
format: add --color highlighting and shell-prompt stripping

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
@@ -19,6 +20,50 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 )
 
+// colorMode is the value space accepted by --color. It mirrors the
+// convention used by git, ls, ripgrep, and similar tools.
+//
+//	auto   — colorize when stdout is a terminal and --output is text
+//	always — colorize regardless of stdout type (text mode only)
+//	never  — never colorize
+//
+// JSON output never receives ANSI escapes regardless of mode, because
+// agent consumers must be able to round-trip the envelope through JSON
+// parsers without re-encoding pitfalls.
+type colorMode string
+
+const (
+	colorAuto   colorMode = "auto"
+	colorAlways colorMode = "always"
+	colorNever  colorMode = "never"
+)
+
+func parseColorMode(s string) (colorMode, error) {
+	switch colorMode(s) {
+	case colorAuto, colorAlways, colorNever:
+		return colorMode(s), nil
+	default:
+		return "", fmt.Errorf("invalid --color %q: valid choices are %q, %q, %q",
+			s, colorAuto, colorAlways, colorNever)
+	}
+}
+
+// isTerminal reports whether w is a character device — the standard
+// proxy for "user is looking at this in a terminal". Returns false for
+// any writer that is not an *os.File (e.g. a bytes.Buffer in tests, or
+// a pipe), which is the safe default for --color=auto.
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
 // newFormatCmd builds the `crdb-sql format` subcommand. It reads SQL
 // from the -e flag, a positional file argument, or stdin, parses it
 // with the CockroachDB parser, and re-emits it in canonical
@@ -27,17 +72,33 @@ import (
 // This is a Tier 1 (zero-config) command: it works offline with no
 // schema files or cluster connection.
 func newFormatCmd(state *rootState) *cobra.Command {
-	var expr string
+	var (
+		expr      string
+		colorFlag string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "format [file]",
 		Short: "Pretty-print SQL statements",
 		Long: `Parse SQL and re-emit it in canonical pretty-printed form using the
 CockroachDB parser's built-in formatter. Input is read from the -e flag
-(inline SQL), a positional file argument, or stdin.`,
+(inline SQL), a positional file argument, or stdin.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, so transcripts paste in unmodified.
+
+Use --color=always|never|auto to control ANSI syntax highlighting in
+text mode. The default (auto) colorizes only when stdout is a terminal.
+JSON output is never colorized.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			mode, err := parseColorMode(colorFlag)
 			if err != nil {
 				return r.RenderError(baseEnv, err)
 			}
@@ -47,7 +108,7 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 				return r.RenderError(baseEnv, err)
 			}
 
-			sql = strings.TrimSpace(sql)
+			sql = strings.TrimSpace(sqlformat.StripShellPrompts(sql))
 
 			formatted, err := sqlformat.Format(sql)
 			if err != nil {
@@ -60,6 +121,16 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 				return r.RenderError(baseEnv, err)
 			}
 
+			// JSON payload is always uncolored. Text path opt-in by
+			// mode + TTY. The decision happens here (not inside the
+			// textFn closure) so it is visible to the reader.
+			textOut := formatted
+			useColor := mode == colorAlways ||
+				(mode == colorAuto && isTerminal(cmd.OutOrStdout()))
+			if useColor {
+				textOut = sqlformat.Highlight(formatted)
+			}
+
 			data, err := json.Marshal(struct {
 				FormattedSQL string `json:"formatted_sql"`
 			}{FormattedSQL: formatted})
@@ -69,13 +140,15 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 			baseEnv.Data = data
 
 			return r.Render(baseEnv, func(w io.Writer) error {
-				_, werr := fmt.Fprintln(w, formatted)
+				_, werr := fmt.Fprintln(w, textOut)
 				return werr
 			})
 		},
 	}
 
 	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to format")
+	cmd.Flags().StringVar(&colorFlag, "color", string(colorAuto),
+		"ANSI syntax highlighting in text output: auto|always|never")
 
 	return cmd
 }

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -186,6 +186,122 @@ func TestFormatCmdEmptyInput(t *testing.T) {
 	require.Error(t, root.Execute())
 }
 
+// TestFormatCmdStripsShellPrompts verifies that pasted output from a
+// cockroach sql REPL session is auto-stripped before parsing.
+func TestFormatCmdStripsShellPrompts(t *testing.T) {
+	pasted := "root@:26257/defaultdb> SELECT id,\n" +
+		"                    ->   name\n" +
+		"                    -> FROM users;\n"
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(pasted))
+	root.SetArgs([]string{"format"})
+
+	require.NoError(t, root.Execute())
+	require.Contains(t, stdout.String(), "SELECT id, name FROM users")
+}
+
+// TestFormatCmdColorAlways verifies --color=always emits ANSI escapes
+// in text mode even when stdout is not a TTY (the test buffer never is).
+func TestFormatCmdColorAlways(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "select 1", "--color", "always"})
+
+	require.NoError(t, root.Execute())
+	require.Contains(t, stdout.String(), "\x1b[", "--color=always must emit ANSI escapes")
+}
+
+// TestFormatCmdColorNeverAndAuto verifies --color=never and --color=auto
+// both produce uncolored output when stdout is a buffer (auto's TTY
+// check returns false for non-*os.File writers).
+func TestFormatCmdColorNeverAndAuto(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{name: "never", flag: "never"},
+		{name: "auto with non-TTY stdout", flag: "auto"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newRootCmd()
+			var stdout bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&bytes.Buffer{})
+			root.SetArgs([]string{"format", "-e", "select 1", "--color", tc.flag})
+
+			require.NoError(t, root.Execute())
+			require.NotContains(t, stdout.String(), "\x1b[",
+				"--color=%s must not emit ANSI escapes", tc.flag)
+		})
+	}
+}
+
+// TestFormatCmdColorAutoNoTTY verifies that --color=auto's TTY check
+// returns false for a real *os.File pointing at a regular file (the
+// non-character-device path of isTerminal). This complements the
+// non-*os.File case in TestFormatCmdColorNeverAndAuto.
+func TestFormatCmdColorAutoNoTTY(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "out.txt"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	root := newRootCmd()
+	root.SetOut(f)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "select 1", "--color", "auto"})
+
+	require.NoError(t, root.Execute())
+	require.NoError(t, f.Sync())
+
+	got, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	require.NotContains(t, string(got), "\x1b[",
+		"--color=auto on a regular file must not emit ANSI escapes")
+}
+
+// TestFormatCmdColorNeverInJSON verifies that JSON output is never
+// colorized regardless of --color, since the envelope is consumed by
+// machines.
+func TestFormatCmdColorNeverInJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "select 1", "--color", "always", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.NotContains(t, stdout.String(), "\x1b[", "JSON envelope must never contain ANSI escapes")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	var payload struct {
+		FormattedSQL string `json:"formatted_sql"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Equal(t, "SELECT 1", payload.FormattedSQL)
+}
+
+// TestFormatCmdColorInvalid verifies that an unknown --color value is
+// rejected with a clear error message.
+func TestFormatCmdColorInvalid(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"format", "-e", "select 1", "--color", "rainbow"})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid --color")
+}
+
 // TestFormatCmdConflictingInput verifies that -e and a file arg together
 // produce an error.
 func TestFormatCmdConflictingInput(t *testing.T) {

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -46,6 +46,11 @@ func FormatSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHan
 
 		env := baseEnvelope(parserVersion, target)
 
+		// Auto-clean cockroach sql REPL prompts the same way the CLI
+		// format subcommand does, so MCP clients pasting transcripts
+		// get the same forgiving behavior.
+		sql = sqlformat.StripShellPrompts(sql)
+
 		formatted, err := sqlformat.Format(sql)
 		if err != nil {
 			env.Errors = []output.Error{diag.FromParseError(err, sql)}

--- a/internal/sqlformat/highlight.go
+++ b/internal/sqlformat/highlight.go
@@ -1,0 +1,159 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlformat
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/scanner"
+)
+
+// ANSI SGR escape sequences used by Highlight. Bundled here so a future
+// theming option only needs to swap this table; callers never construct
+// escape sequences directly.
+const (
+	ansiReset     = "\x1b[0m"
+	ansiKeyword   = "\x1b[1;36m" // bold cyan
+	ansiStringLit = "\x1b[32m"   // green
+	ansiNumberLit = "\x1b[35m"   // magenta
+)
+
+// firstKeywordTokenID is the lowest token ID assigned to a SQL keyword
+// in lexbase/tokens.go. Token IDs below it are reserved for the lexer's
+// non-keyword categories (IDENT, SCONST, BCONST, BITCONST, ICONST,
+// FCONST, PLACEHOLDER, the multi-char operators, and ERROR). Above this
+// boundary, the alphabetical block of ~1500 keywords (ABORT, ABSOLUTE,
+// …) accounts for nearly all token IDs; a small tail of synthetic
+// tokens (HELPTOKEN, POSTFIXOP, UMINUS, the *_LA lookahead pseudo-
+// tokens) sits above the keyword block but never appears in
+// formatter-produced output as all-uppercase letter text, so the
+// isAllUpperLetters check in colorFor disambiguates without us having
+// to enumerate them. The boundary value is taken from lexbase.ABORT,
+// the alphabetically-first keyword.
+const firstKeywordTokenID = lexbase.ABORT
+
+// Highlight returns formatted with ANSI SGR escape sequences wrapping
+// SQL keywords (bold cyan), string literals (green), and numeric
+// literals (magenta). Identifiers, punctuation, and whitespace are
+// emitted uncolored. The function preserves byte ranges between tokens
+// verbatim, so the visible (de-escaped) output is byte-identical to
+// formatted.
+//
+// Tokenization is performed with scanner.Inspect, which yields token
+// start/end offsets into formatted. If any token comes back as ERROR
+// or as the incomplete-token sentinel (negative ID, documented in
+// scanner.Inspect), Highlight returns formatted unchanged rather than
+// emit a half-colored garbage string. In normal use this fallback
+// never fires because callers feed already-validated SQL, but the
+// defensive check protects against bounds-violating slices if a future
+// caller passes hand-constructed input.
+//
+// Highlight is intended for terminal output only. JSON envelopes must
+// never contain escape sequences, so callers gate this behind a
+// text-mode + TTY check.
+func Highlight(formatted string) string {
+	if formatted == "" {
+		return formatted
+	}
+
+	tokens := scanner.Inspect(formatted)
+	for _, tok := range tokens {
+		// ERROR signals a scan failure; ID < 0 is the incomplete-token
+		// sentinel scanner.Inspect appends when input ends mid-token.
+		// Either case means downstream slicing on tok.Start/tok.End
+		// would be unsound, so fall back to the uncolored input.
+		if tok.ID == lexbase.ERROR || tok.ID < 0 {
+			return formatted
+		}
+	}
+
+	var (
+		buf     strings.Builder
+		lastEnd int32
+	)
+	buf.Grow(len(formatted) + len(tokens)*8)
+
+	for _, tok := range tokens {
+		// scanner.Inspect appends a sentinel token with ID 0 at EOF.
+		// It carries no text and must be skipped before color logic
+		// runs, otherwise the trailing-text copy below would be
+		// duplicated.
+		if tok.ID == 0 {
+			break
+		}
+
+		if tok.Start > lastEnd {
+			buf.WriteString(formatted[lastEnd:tok.Start])
+		}
+
+		text := formatted[tok.Start:tok.End]
+		if color := colorFor(tok.ID, text); color != "" {
+			buf.WriteString(color)
+			buf.WriteString(text)
+			buf.WriteString(ansiReset)
+		} else {
+			buf.WriteString(text)
+		}
+		lastEnd = tok.End
+	}
+
+	if int(lastEnd) < len(formatted) {
+		buf.WriteString(formatted[lastEnd:])
+	}
+	return buf.String()
+}
+
+// colorFor returns the ANSI SGR prefix for a token, or the empty
+// string if the token should be emitted uncolored. Empty-string return
+// signals the caller to skip the wrap-with-reset path; it is not a
+// default color.
+//
+// Keyword classification is deliberately conservative. CockroachDB's
+// lexer assigns keyword IDs to many words that are also valid
+// identifiers in PostgreSQL grammar (USERS, NAME, USER, COMMENT, KEY,
+// VALUE, …). Coloring every keyword-ID token would highlight a table
+// named "users" or a column named "name" as if it were a SQL keyword,
+// which is visually noisy and misleading. We sidestep this by
+// piggy-backing on the pretty-printer's own decision: keywords used
+// grammatically as keywords are emitted UPPERCASE, identifiers are
+// emitted in their original case (or quoted). So a keyword-ID token is
+// colored only when its text is all-uppercase letters in the formatted
+// output. This is a heuristic, not a parse-aware classification, but
+// it matches the formatter's contract and avoids identifier mis-color.
+func colorFor(id int32, text string) string {
+	switch id {
+	case lexbase.SCONST, lexbase.BCONST, lexbase.BITCONST:
+		return ansiStringLit
+	case lexbase.ICONST, lexbase.FCONST:
+		return ansiNumberLit
+	}
+	if id >= firstKeywordTokenID && isAllUpperLetters(text) {
+		return ansiKeyword
+	}
+	return ""
+}
+
+// isAllUpperLetters reports whether s is non-empty and every letter
+// rune in s is uppercase. Non-letter runes (digits, underscores) are
+// ignored so that words like "INT8" still classify as keyword-shaped.
+func isAllUpperLetters(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasLetter := false
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		hasLetter = true
+		if !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return hasLetter
+}

--- a/internal/sqlformat/highlight_test.go
+++ b/internal/sqlformat/highlight_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlformat
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ansiSGR matches any ANSI SGR escape sequence so tests can strip
+// coloring before comparing visible content.
+var ansiSGR = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiSGR.ReplaceAllString(s, "")
+}
+
+func TestHighlight_VisibleContentUnchanged(t *testing.T) {
+	tests := []string{
+		"SELECT 1",
+		"SELECT id, name FROM users",
+		"SELECT 1;\nSELECT 2",
+		"INSERT INTO t VALUES (1, 'hello', 3.14)",
+		"SELECT * FROM t WHERE x = 'a''b'",
+		"SELECT 'café', 'naïve' FROM t",
+	}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			require.Equal(t, in, stripANSI(Highlight(in)),
+				"Highlight must preserve visible bytes after stripping ANSI escapes")
+		})
+	}
+}
+
+func TestHighlight_KeywordColored(t *testing.T) {
+	got := Highlight("SELECT 1")
+	require.Contains(t, got, ansiKeyword+"SELECT"+ansiReset)
+}
+
+func TestHighlight_StringLiteralColored(t *testing.T) {
+	got := Highlight("SELECT 'hello'")
+	require.Contains(t, got, ansiStringLit+"'hello'"+ansiReset)
+}
+
+func TestHighlight_NumericLiteralColored(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		token string
+	}{
+		{name: "integer", input: "SELECT 42", token: "42"},
+		{name: "float", input: "SELECT 3.14", token: "3.14"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Contains(t, Highlight(tc.input), ansiNumberLit+tc.token+ansiReset)
+		})
+	}
+}
+
+func TestHighlight_IdentifierUncolored(t *testing.T) {
+	got := Highlight("SELECT users")
+	// The bare identifier "users" must not be wrapped in any color.
+	require.NotContains(t, got, ansiKeyword+"users")
+	require.NotContains(t, got, ansiStringLit+"users")
+	require.NotContains(t, got, ansiNumberLit+"users")
+	// And it must be present verbatim.
+	require.Contains(t, got, "users")
+}
+
+func TestHighlight_PunctuationUncolored(t *testing.T) {
+	got := Highlight("SELECT 1, 2")
+	// Comma must not be wrapped in any of the open-color escapes. (It
+	// will follow ansiReset from the preceding number; that's expected.)
+	for _, color := range []string{ansiKeyword, ansiStringLit, ansiNumberLit} {
+		require.NotContains(t, got, color+",", "comma must not be opened with %q", color)
+	}
+}
+
+func TestHighlight_MultiStatementSeparatorPreserved(t *testing.T) {
+	got := Highlight("SELECT 1;\nSELECT 2")
+	require.Equal(t, "SELECT 1;\nSELECT 2", stripANSI(got))
+	want := ansiKeyword + "SELECT" + ansiReset
+	matches := regexp.MustCompile(regexp.QuoteMeta(want)).FindAllString(got, -1)
+	require.Len(t, matches, 2, "both SELECT keywords must be colored")
+}
+
+func TestHighlight_TokenizationFailureFallsBack(t *testing.T) {
+	// An unterminated string literal causes the scanner to emit ERROR.
+	// Highlight must return the input unchanged rather than emit a
+	// half-colored output.
+	in := "SELECT 'unterminated"
+	require.Equal(t, in, Highlight(in))
+}
+
+func TestHighlight_EmptyInput(t *testing.T) {
+	require.Equal(t, "", Highlight(""))
+}

--- a/internal/sqlformat/strip.go
+++ b/internal/sqlformat/strip.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlformat
+
+import (
+	"regexp"
+	"strings"
+)
+
+// primaryPromptRE matches a cockroach sql REPL primary prompt at the
+// start of a line. The structure is:
+//
+//	<user>@<host-info>><SP?>
+//
+// where:
+//   - user is a SQL identifier-shaped name (root, app_user, marc.smith, …);
+//   - host-info is any non-space, non-'>' run that precedes the closing
+//     '>' (covers host:port/db, host/db, empty host as in
+//     ":26257/defaultdb", and the OPEN/ERROR connection-state word that
+//     newer cockroach sql builds insert before '>', e.g.
+//     "root@:26257/defaultdb OPEN>").
+//
+// The optional trailing space following '>' is the single space the
+// REPL prints between prompt and command.
+var primaryPromptRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*@[^\s>]*(?:[ \t]+[A-Za-z]+)?> ?`)
+
+// continuationPromptRE matches a continuation prompt anchored at the
+// start of a line, allowing the leading whitespace the REPL inserts to
+// right-align '>' under the primary prompt:
+//
+//	-> SELECT 2;
+//
+// The optional trailing space mirrors primaryPromptRE.
+var continuationPromptRE = regexp.MustCompile(`^[ \t]*-> ?`)
+
+// StripShellPrompts removes cockroach sql REPL prompt prefixes from
+// pasted input. Two prompt forms are recognized:
+//
+//	<user>@<host-info>><SP>     // primary prompt (any user)
+//	<pad>-><SP>                 // continuation prompt (right-aligned)
+//
+// Continuation lines are stripped only after a primary prompt has
+// already been seen earlier in the input. This guards SQL-only pastes
+// that legitimately contain the JSON field-access operator '->' at line
+// start (e.g. "  -> 'key'") from being mangled. A transcript paste
+// always starts with a primary prompt, so the guard does not interfere
+// with the intended use case.
+//
+// The function is a no-op when the input contains no prompts. Lines
+// without a recognized prompt — including blank lines and lines inside
+// multi-line string literals — pass through unchanged.
+//
+// Limitation: a multi-line string literal whose interior line happens
+// to begin with a primary-prompt-shaped sequence will be incorrectly
+// stripped. This is exceedingly rare in REPL transcripts and not worth
+// the complexity of full lexer-aware line classification at this layer.
+func StripShellPrompts(sql string) string {
+	if sql == "" {
+		return sql
+	}
+
+	lines := strings.SplitAfter(sql, "\n")
+	var (
+		buf         strings.Builder
+		seenPrimary bool
+	)
+	buf.Grow(len(sql))
+
+	for _, line := range lines {
+		if loc := primaryPromptRE.FindStringIndex(line); loc != nil {
+			seenPrimary = true
+			buf.WriteString(line[loc[1]:])
+			continue
+		}
+		if seenPrimary {
+			if loc := continuationPromptRE.FindStringIndex(line); loc != nil {
+				buf.WriteString(line[loc[1]:])
+				continue
+			}
+		}
+		buf.WriteString(line)
+	}
+	return buf.String()
+}

--- a/internal/sqlformat/strip_test.go
+++ b/internal/sqlformat/strip_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sqlformat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripShellPrompts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "no prompt is a no-op",
+			input:    "SELECT 1;\nSELECT 2;\n",
+			expected: "SELECT 1;\nSELECT 2;\n",
+		},
+		{
+			name:     "single primary prompt with root user",
+			input:    "root@:26257/defaultdb> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name:     "primary prompt with non-root user",
+			input:    "app@host:26257/defaultdb> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name:     "primary prompt with dotted username",
+			input:    "marc.smith@host:26257/db> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name:     "primary prompt with underscore username",
+			input:    "app_user@host/db> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name:     "primary prompt with OPEN state word",
+			input:    "root@:26257/defaultdb OPEN> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name:     "primary prompt with ERROR state word",
+			input:    "root@:26257/defaultdb ERROR> SELECT 1;\n",
+			expected: "SELECT 1;\n",
+		},
+		{
+			name: "padded continuation prompts after primary",
+			input: "root@:26257/defaultdb> SELECT id,\n" +
+				"                    ->   name,\n" +
+				"                    ->   email\n" +
+				"                    -> FROM users;\n",
+			expected: "SELECT id,\n  name,\n  email\nFROM users;\n",
+		},
+		{
+			name:     "continuation without preceding primary is left alone",
+			input:    "SELECT data\n  -> 'key'\nFROM t;\n",
+			expected: "SELECT data\n  -> 'key'\nFROM t;\n",
+		},
+		{
+			name: "multi-statement transcript",
+			input: "root@:26257/defaultdb> SELECT 1;\n" +
+				"root@:26257/defaultdb> SELECT 2;\n",
+			expected: "SELECT 1;\nSELECT 2;\n",
+		},
+		{
+			name:     "primary prompt mid-line is not stripped",
+			input:    "-- see root@host:26257/db> for details\n",
+			expected: "-- see root@host:26257/db> for details\n",
+		},
+		{
+			name:     "blank lines are preserved",
+			input:    "root@:26257/defaultdb> SELECT 1;\n\nroot@:26257/defaultdb> SELECT 2;\n",
+			expected: "SELECT 1;\n\nSELECT 2;\n",
+		},
+		{
+			name:     "trailing prompt with no command",
+			input:    "root@:26257/defaultdb>\n",
+			expected: "\n",
+		},
+		{
+			name:     "no trailing newline",
+			input:    "root@:26257/defaultdb> SELECT 1",
+			expected: "SELECT 1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripShellPrompts(tc.input)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestStripShellPromptsRoundTripsThroughFormat verifies that a pasted
+// REPL transcript, after stripping, parses and pretty-prints cleanly.
+// This is the end-to-end contract callers (cmd/format, MCP format_sql)
+// rely on.
+func TestStripShellPromptsRoundTripsThroughFormat(t *testing.T) {
+	pasted := "root@:26257/defaultdb> SELECT id,\n" +
+		"                    ->   name\n" +
+		"                    -> FROM users;\n"
+
+	formatted, err := Format(StripShellPrompts(pasted))
+	require.NoError(t, err)
+	require.Contains(t, formatted, "SELECT id, name FROM users")
+}


### PR DESCRIPTION
Polish for the Tier 1 `format` command (design doc §User Interfaces).

ANSI syntax highlighting is added behind `--color={auto,always,never}`,
defaulting to `auto`. Auto mode colorizes only when stdout is a terminal,
matching the convention used by git/ls/ripgrep. JSON envelopes are never
colorized regardless of mode, since agents must round-trip the payload
through JSON parsers. `Highlight` uses `scanner.Inspect` to obtain token
offsets and wraps keywords (bold cyan), string literals (green), and
numeric literals (magenta) in ANSI SGR escapes. Identifiers and
punctuation pass through uncolored.

Keyword classification is a heuristic: many CockroachDB tokens have
keyword IDs but are valid identifiers in PostgreSQL grammar (USERS,
NAME, USER, COMMENT, ...). Coloring every keyword-ID token would
highlight a table named `users` or a column named `name` as if it were
a SQL keyword. We sidestep this by piggy-backing on the pretty-printer's
own decision: a keyword-ID token is colored only when its text in the
formatted output is all uppercase. This avoids parse-aware
classification while still producing accurate highlighting.

Pasted output from a `cockroach sql` REPL session is auto-cleaned before
parsing. Two prompt forms are recognized:

```
<user>@<host-info>><SP>     primary prompt (any user)
<pad>-><SP>                 continuation prompt (right-aligned)
```

The user portion accepts any SQL identifier (`root`, `app_user`,
`marc.smith`, ...) and the host-info portion absorbs the `OPEN`/`ERROR`
connection-state word that newer `cockroach sql` builds emit.
Continuation prompts are stripped only after a primary prompt has been
seen earlier in the input, so SQL-only pastes containing the JSON `->`
operator at line start are left untouched.

The MCP `format_sql` tool also calls `StripShellPrompts` so MCP clients
pasting transcripts get the same forgiving behavior. The MCP tool does
not get a color flag because terminal coloring is not meaningful for an
MCP client.

Resolves: #27