### PR TITLE
mcp: add stdio integration tests for all registered tools

### DIFF
--- a/internal/mcp/integration_test.go
+++ b/internal/mcp/integration_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// End-to-end integration tests for the `crdb-sql mcp` stdio server.
+// These spawn the real binary, drive it as an MCP client over JSON-RPC,
+// and assert the envelope shape returned by every registered tool. The
+// goal is to catch regressions that unit tests cannot — broken tool
+// registration, transport serialization bugs, mark3labs/mcp-go upgrade
+// incompatibilities — by exercising the same path Claude Code uses.
+//
+// The binary is built once per test binary into a temp dir; a fresh
+// subprocess and MCP client are spawned per top-level test, so failure
+// in one test cannot poison another. The single cluster-dependent test
+// (explain_sql) calls cockroachtest.Shared, which skips cleanly when
+// COCKROACH_BIN / CRDB_TEST_DSN are absent — so this file runs under
+// `make test` and additionally exercises explain_sql under
+// `make test-integration`.
+
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// modulePath is the module root that buildBinary compiles into the
+// test temp dir. The integration suite builds its own binary rather
+// than reusing whatever `make build` produced so the tests are
+// self-contained — they do not require a prior make invocation and
+// cannot be silently invalidated by a stale bin/crdb-sql.
+const modulePath = "github.com/spilchen/sql-ai-tools"
+
+// callTimeout bounds every Tier 1/2 tools/call round-trip. These
+// complete in milliseconds; five seconds leaves headroom for a loaded
+// CI runner without masking a hung subprocess. Tier 3 (explain_sql)
+// uses its own larger timeout at the call site because a cold-cluster
+// EXPLAIN can exceed callTimeout.
+const callTimeout = 5 * time.Second
+
+// initTimeout bounds the MCP initialize handshake. Larger than
+// callTimeout because cold subprocess startup plus the initialize
+// round-trip can be noticeably slower than steady-state tool calls
+// on loaded CI.
+const initTimeout = 10 * time.Second
+
+// Shared build state. Populated once by buildBinary on the first call
+// (typically from TestMain); subsequent callers get the cached
+// (binPath, buildErr) atomically through buildOnce.
+//
+//   - binPath is the absolute path to the built crdb-sql binary, or
+//     "" if the build failed.
+//   - buildErr is nil on success or the wrapped go-build error
+//     (including captured stderr) on failure.
+//   - buildOnce gates the build so concurrent or repeat callers do
+//     not re-invoke `go build`.
+var (
+	binPath   string
+	buildErr  error
+	buildOnce sync.Once
+)
+
+// TestMain builds the crdb-sql binary once into a temp directory and
+// then defers to cockroachtest.RunTests so the (optional) shared
+// CockroachDB cluster used by the explain_sql test is torn down on
+// exit. Build failures abort the test binary with a clear message
+// rather than letting every individual test fail with the same error.
+//
+// The temp directory containing the binary is intentionally not
+// removed: cockroachtest.RunTests calls os.Exit, which bypasses
+// deferred cleanup. The OS reaps os.TempDir() entries eventually, and
+// the binary is small.
+func TestMain(m *testing.M) {
+	if err := buildBinary(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration test setup: %v\n", err)
+		os.Exit(1)
+	}
+	cockroachtest.RunTests(m)
+}
+
+// buildBinary compiles the crdb-sql binary into a temp directory and
+// records the path in binPath. Idempotent via sync.Once so callers
+// outside TestMain pay the cost at most once. On failure the returned
+// error embeds the go-build stderr so CI output points directly at
+// the compilation problem rather than just "exit status 1".
+func buildBinary() error {
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "crdb-sql-mcp-int-")
+		if err != nil {
+			buildErr = fmt.Errorf("mkdir temp: %w", err)
+			return
+		}
+		out := filepath.Join(dir, "crdb-sql")
+		// Capture stderr separately so a failed build surfaces the
+		// compiler diagnostics in the wrapped error rather than
+		// scattering them across the test runner's output.
+		var stderr bytes.Buffer
+		cmd := exec.Command("go", "build", "-o", out, modulePath)
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			buildErr = fmt.Errorf("go build: %w\n%s", err, stderr.String())
+			return
+		}
+		binPath = out
+	})
+	return buildErr
+}
+
+// newMCPClient spawns a fresh `crdb-sql mcp` subprocess, runs the MCP
+// initialize handshake, and registers a t.Cleanup to close the client
+// (which kills the subprocess) and dump the subprocess's stderr on a
+// failed test. Each top-level test gets its own client to keep
+// failures isolated.
+//
+// The subprocess inherits the parent process env (passed as nil to
+// NewStdioMCPClient) so COCKROACH_BIN / CRDB_TEST_DSN reach the
+// explain_sql Tier 3 path. Replacing nil with []string{} would
+// silently break the explain test on systems where those vars are
+// the only way to reach a cluster.
+func newMCPClient(t *testing.T) *client.Client {
+	t.Helper()
+	require.NoError(t, buildBinary(), "build crdb-sql binary")
+
+	c, err := client.NewStdioMCPClient(binPath, nil /* env */, "mcp")
+	require.NoError(t, err, "spawn crdb-sql mcp")
+
+	// Drain the subprocess stderr into a buffer so a panic, log line,
+	// or unexpected diagnostic from the server is visible to the
+	// developer when the test fails. Without this, a transport-level
+	// failure shows up as a generic "tools/call X failed" with no
+	// hint at what the server actually printed — defeating the
+	// purpose of an integration suite that exists to catch product
+	// regressions in the stdio loop.
+	var stderr bytes.Buffer
+	stderrDone := make(chan struct{})
+	if r, ok := client.GetStderr(c); ok {
+		go func() {
+			defer close(stderrDone)
+			_, _ = io.Copy(&stderr, r)
+		}()
+	} else {
+		close(stderrDone)
+	}
+
+	t.Cleanup(func() {
+		// Errors on Close are not test failures — the subprocess may
+		// already have exited cleanly — but we surface them via t.Log
+		// alongside any captured stderr so a developer chasing a
+		// failure sees what the server printed before dying.
+		if err := c.Close(); err != nil {
+			t.Logf("close MCP client: %v", err)
+		}
+		<-stderrDone
+		if t.Failed() && stderr.Len() > 0 {
+			t.Logf("crdb-sql mcp stderr:\n%s", stderr.String())
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeout)
+	defer cancel()
+
+	var req mcp.InitializeRequest
+	req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	req.Params.ClientInfo = mcp.Implementation{Name: "crdb-sql-int-test", Version: "0.0.0"}
+	_, err = c.Initialize(ctx, req)
+	require.NoError(t, err, "MCP initialize handshake")
+
+	return c
+}
+
+// callTool issues a tools/call request with the given name and
+// arguments under the standard callTimeout. Returns the raw
+// CallToolResult so callers can inspect IsError before decoding the
+// envelope.
+func callTool(t *testing.T, c *client.Client, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+
+	var req mcp.CallToolRequest
+	req.Params.Name = name
+	req.Params.Arguments = args
+	res, err := c.CallTool(ctx, req)
+	require.NoError(t, err, "tools/call %s", name)
+	return res
+}
+
+// decodeEnvelope extracts the single TextContent from a successful
+// tool result and unmarshals it as an output.Envelope. Fails the test
+// if the result is a tool-level error or if the content shape is not
+// what every tool in this server emits (one TextContent of JSON).
+func decodeEnvelope(t *testing.T, res *mcp.CallToolResult) output.Envelope {
+	t.Helper()
+	require.False(t, res.IsError, "expected envelope-shaped success result, got tool error: %s", textOf(res))
+	require.Len(t, res.Content, 1, "expected exactly one content element")
+	tc, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &env), "unmarshal envelope: %s", tc.Text)
+	return env
+}
+
+// textOf returns the concatenated text of a CallToolResult's
+// TextContent entries. Used in assertion messages so a failed
+// envelope-shape check shows the actual server text.
+func textOf(res *mcp.CallToolResult) string {
+	var s string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			s += tc.Text
+		}
+	}
+	return s
+}

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Per-tool integration assertions for the MCP stdio server. Helpers
+// and lifecycle live in integration_test.go. Each top-level test
+// runs against a fresh subprocess so a hung handler or panic in one
+// test does not cascade.
+
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	internalmcp "github.com/spilchen/sql-ai-tools/internal/mcp"
+	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
+)
+
+// expectedTools enumerates every tool the server registers in
+// internal/mcp/server.go. Kept here (rather than imported from the
+// server) so the registration set must be updated in two places — a
+// removed s.AddTool() line fails this test loudly, and a newly added
+// tool that someone forgets to list here also fails, forcing the
+// list to stay in sync with reality.
+var expectedTools = []string{
+	internalmcp.PingToolName,
+	tools.ParseSQLToolName,
+	tools.ValidateSQLToolName,
+	tools.FormatSQLToolName,
+	tools.DetectRiskyQueryToolName,
+	tools.ExplainSQLToolName,
+	tools.ListTablesToolName,
+	tools.DescribeTableToolName,
+}
+
+// usersSchema is the inline CREATE TABLE used by the catalog-based
+// tools (list_tables, describe_table, validate_sql with schemas).
+const usersSchema = `CREATE TABLE users (id INT PRIMARY KEY, name STRING NOT NULL);`
+
+// TestIntegrationToolsListed locks in the registered tool surface.
+// Adding or removing a tool in internal/mcp/server.go without
+// updating expectedTools fails this test.
+func TestIntegrationToolsListed(t *testing.T) {
+	c := newMCPClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), callTimeout)
+	defer cancel()
+
+	res, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		got = append(got, tool.Name)
+	}
+	require.ElementsMatch(t, expectedTools, got)
+}
+
+// TestIntegrationPing covers the health-check tool. ping is the only
+// tool that does not return an output.Envelope — it returns
+// {ok, parser_version} directly — so it gets its own decode path.
+func TestIntegrationPing(t *testing.T) {
+	c := newMCPClient(t)
+	res := callTool(t, c, internalmcp.PingToolName, nil)
+	require.False(t, res.IsError, "ping returned tool error: %s", textOf(res))
+
+	require.Len(t, res.Content, 1)
+	tc, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	var payload struct {
+		OK            bool   `json:"ok"`
+		ParserVersion string `json:"parser_version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &payload))
+	require.True(t, payload.OK)
+	require.NotEmpty(t, payload.ParserVersion, "parser_version must be stamped")
+}
+
+// TestIntegrationParseSQL covers the success and parse-error paths
+// for parse_sql. The success case asserts the envelope's data carries
+// at least one classified statement; the error case asserts a 42601
+// SQLSTATE with position lands in env.Errors while the tool itself
+// still returns IsError=false. (Tool-level errors — missing required
+// params — surface as IsError=true; see TestIntegrationValidateSQL.)
+func TestIntegrationParseSQL(t *testing.T) {
+	c := newMCPClient(t)
+
+	tests := []struct {
+		name              string
+		sql               string
+		expectedErrCode   string // empty means success path
+		expectedFirstTag  string // only checked on success path
+		expectedFirstType string // only checked on success path
+	}{
+		{
+			name:              "valid select",
+			sql:               "SELECT 1",
+			expectedFirstTag:  "SELECT",
+			expectedFirstType: "DML",
+		},
+		{
+			name:            "syntax error",
+			sql:             "SELEC * FROM t",
+			expectedErrCode: "42601",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callTool(t, c, tools.ParseSQLToolName, map[string]any{"sql": tc.sql})
+			env := decodeEnvelope(t, res)
+			assertTier1Envelope(t, env)
+
+			if tc.expectedErrCode != "" {
+				assertEnvelopeError(t, env, tc.expectedErrCode)
+				return
+			}
+
+			require.Empty(t, env.Errors, "success path must have no errors")
+			require.NotEmpty(t, env.Data, "success path must populate data")
+			var stmts []struct {
+				StatementType string `json:"statement_type"`
+				Tag           string `json:"tag"`
+			}
+			require.NoError(t, json.Unmarshal(env.Data, &stmts))
+			require.NotEmpty(t, stmts)
+			require.Equal(t, tc.expectedFirstTag, stmts[0].Tag)
+			require.Equal(t, tc.expectedFirstType, stmts[0].StatementType)
+		})
+	}
+}
+
+// TestIntegrationValidateSQL covers the dual-tier behavior of
+// validate_sql plus its tool-level error path. Tier 1 (no schemas)
+// returns a capability_required warning; Tier 2 (with schemas)
+// reports name_resolution=ok. A type error is reported as an
+// envelope error; a missing required parameter is a tool-level error
+// (IsError=true) per the discipline in internal/mcp/tools/tools.go.
+func TestIntegrationValidateSQL(t *testing.T) {
+	c := newMCPClient(t)
+
+	t.Run("tier 1 zero config skips name resolution", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{"sql": "SELECT 1"})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierZeroConfig, env.Tier)
+		require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+		// The capability_required warning is the only envelope entry on
+		// the zero-config success path.
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, validateresult.CapabilityRequiredCode, env.Errors[0].Code)
+		require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+
+		var result validateresult.Result
+		require.NoError(t, json.Unmarshal(env.Data, &result))
+		require.True(t, result.Valid)
+		require.Equal(t, validateresult.CheckOK, result.Checks.Syntax)
+		require.Equal(t, validateresult.CheckOK, result.Checks.TypeCheck)
+		require.Equal(t, validateresult.CheckSkipped, result.Checks.NameResolution)
+	})
+
+	t.Run("tier 2 with schemas runs name resolution", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{
+			"sql":     "SELECT id FROM users",
+			"schemas": []any{map[string]any{"sql": usersSchema}},
+		})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierSchemaFile, env.Tier)
+		require.Empty(t, env.Errors, "clean validate must have no envelope errors")
+
+		var result validateresult.Result
+		require.NoError(t, json.Unmarshal(env.Data, &result))
+		require.True(t, result.Valid)
+		require.Equal(t, validateresult.CheckOK, result.Checks.NameResolution)
+	})
+
+	t.Run("type mismatch surfaces as envelope error", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{"sql": "SELECT 1 + 'abc'"})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierZeroConfig, env.Tier)
+		require.NotEmpty(t, env.Errors, "type-check failure must populate envelope errors")
+		// Type errors carry a SQLSTATE from the parser/type checker;
+		// avoid pinning the exact code so a parser bump that refines
+		// the diagnosis (e.g. 42883 → 42804) does not break the test.
+		require.NotEmpty(t, env.Errors[0].Code)
+		require.Equal(t, output.SeverityError, env.Errors[0].Severity)
+	})
+
+	t.Run("missing sql parameter is tool error", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{})
+		require.True(t, res.IsError, "missing required param must surface as tool error, got: %s", textOf(res))
+	})
+}
+
+// TestIntegrationFormatSQL covers pretty-printing on the happy path
+// and parse-error reporting. The success case asserts the data
+// payload exposes formatted_sql; the error case asserts a 42601 with
+// position.
+func TestIntegrationFormatSQL(t *testing.T) {
+	c := newMCPClient(t)
+
+	t.Run("formats valid select", func(t *testing.T) {
+		res := callTool(t, c, tools.FormatSQLToolName, map[string]any{"sql": "select   1"})
+		env := decodeEnvelope(t, res)
+		assertTier1Envelope(t, env)
+		require.Empty(t, env.Errors)
+
+		var data struct {
+			FormattedSQL string `json:"formatted_sql"`
+		}
+		require.NoError(t, json.Unmarshal(env.Data, &data))
+		require.NotEmpty(t, data.FormattedSQL)
+		// The formatter normalizes whitespace, so the doubled space
+		// from the input must not survive into the output.
+		require.NotContains(t, data.FormattedSQL, "select   1")
+	})
+
+	t.Run("syntax error in envelope", func(t *testing.T) {
+		res := callTool(t, c, tools.FormatSQLToolName, map[string]any{"sql": "SELEC * FROM t"})
+		env := decodeEnvelope(t, res)
+		assertTier1Envelope(t, env)
+		assertEnvelopeError(t, env, "42601")
+	})
+}
+
+// TestIntegrationDetectRiskyQuery asserts the tool returns a non-empty
+// findings array for an obvious risky pattern (DROP TABLE) and an
+// empty array for a clean SELECT. Specific rule codes are intentionally
+// not pinned — the rule registry is expected to grow.
+func TestIntegrationDetectRiskyQuery(t *testing.T) {
+	c := newMCPClient(t)
+
+	tests := []struct {
+		name             string
+		sql              string
+		expectedFindings bool
+	}{
+		{name: "clean select has no findings", sql: "SELECT id FROM users WHERE id = 1", expectedFindings: false},
+		{name: "drop table flagged as risky", sql: "DROP TABLE users", expectedFindings: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callTool(t, c, tools.DetectRiskyQueryToolName, map[string]any{"sql": tc.sql})
+			env := decodeEnvelope(t, res)
+			assertTier1Envelope(t, env)
+			require.Empty(t, env.Errors)
+
+			var findings []map[string]any
+			require.NoError(t, json.Unmarshal(env.Data, &findings))
+			if tc.expectedFindings {
+				require.NotEmpty(t, findings, "expected at least one risky-pattern finding")
+			} else {
+				require.Empty(t, findings)
+			}
+		})
+	}
+}
+
+// TestIntegrationListTables covers list_tables on both the happy path
+// (schemas yield a non-empty tables array) and the missing-required-
+// parameter path (tool error). schemas is required for list_tables so
+// omitting it is an infrastructure error, not an envelope error.
+func TestIntegrationListTables(t *testing.T) {
+	c := newMCPClient(t)
+
+	t.Run("inline schemas yield tables", func(t *testing.T) {
+		res := callTool(t, c, tools.ListTablesToolName, map[string]any{
+			"schemas": []any{map[string]any{"sql": usersSchema}},
+		})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierSchemaFile, env.Tier)
+		require.Empty(t, env.Errors)
+
+		var data struct {
+			Tables []string `json:"tables"`
+		}
+		require.NoError(t, json.Unmarshal(env.Data, &data))
+		require.Contains(t, data.Tables, "users")
+	})
+
+	t.Run("missing schemas is tool error", func(t *testing.T) {
+		res := callTool(t, c, tools.ListTablesToolName, map[string]any{})
+		require.True(t, res.IsError, "missing required schemas must surface as tool error, got: %s", textOf(res))
+	})
+}
+
+// TestIntegrationDescribeTable covers the catalog hit/miss split.
+// A hit returns the table struct in env.Data; a miss returns a
+// structured 42P01 envelope error whose Context.available_tables
+// names the loaded tables, so agents can suggest a correction. The
+// miss subtest verifies the loaded "users" table appears in that
+// list — an empty or wrong-shaped value would silently pass a
+// key-only check.
+func TestIntegrationDescribeTable(t *testing.T) {
+	c := newMCPClient(t)
+	schemas := []any{map[string]any{"sql": usersSchema}}
+
+	t.Run("known table returns description", func(t *testing.T) {
+		res := callTool(t, c, tools.DescribeTableToolName, map[string]any{
+			"table":   "users",
+			"schemas": schemas,
+		})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierSchemaFile, env.Tier)
+		require.Empty(t, env.Errors)
+
+		var tbl struct {
+			Name    string           `json:"name"`
+			Columns []map[string]any `json:"columns"`
+		}
+		require.NoError(t, json.Unmarshal(env.Data, &tbl))
+		require.Equal(t, "users", tbl.Name)
+		require.NotEmpty(t, tbl.Columns)
+	})
+
+	t.Run("unknown table is 42P01 envelope error", func(t *testing.T) {
+		res := callTool(t, c, tools.DescribeTableToolName, map[string]any{
+			"table":   "missing",
+			"schemas": schemas,
+		})
+		env := decodeEnvelope(t, res)
+		require.Equal(t, output.TierSchemaFile, env.Tier)
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, "42P01", env.Errors[0].Code)
+		require.Equal(t, output.SeverityError, env.Errors[0].Severity)
+		// JSON arrays come back as []any; the value must include the
+		// actual loaded table so a correction-suggestion path can
+		// render it. A key-only assertion would let an empty slice
+		// (catalog-population bug) silently pass.
+		avail, ok := env.Errors[0].Context["available_tables"].([]any)
+		require.True(t, ok, "available_tables must be a JSON array")
+		require.Contains(t, avail, "users")
+	})
+}
+
+// TestIntegrationExplainSQL exercises the only Tier 3 tool. It is
+// gated on cockroachtest.Shared, which skips cleanly when neither
+// COCKROACH_BIN nor CRDB_TEST_DSN is set, so this test runs as part
+// of `make test-integration` but is a clean skip under `make test`.
+func TestIntegrationExplainSQL(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	c := newMCPClient(t)
+
+	// EXPLAIN can take longer than the default callTimeout on a cold
+	// cluster, so issue this call directly with a generous timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var req mcp.CallToolRequest
+	req.Params.Name = tools.ExplainSQLToolName
+	req.Params.Arguments = map[string]any{
+		"sql": "SELECT 1",
+		"dsn": cluster.DSN,
+	}
+	res, err := c.CallTool(ctx, req)
+	require.NoError(t, err)
+
+	env := decodeEnvelope(t, res)
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionConnected, env.ConnectionStatus)
+	require.Empty(t, env.Errors, "EXPLAIN of SELECT 1 must succeed")
+	require.NotEmpty(t, env.Data, "EXPLAIN must populate data")
+}
+
+// assertTier1Envelope checks the two invariants every Tier 1 tool
+// upholds: tier=zero_config and connection_status=disconnected.
+// ParserVersion is also asserted non-empty so a regression that drops
+// the version stamping fails loudly.
+func assertTier1Envelope(t *testing.T, env output.Envelope) {
+	t.Helper()
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+}
+
+// assertEnvelopeError asserts the envelope reports at least one error
+// with the given SQLSTATE code, ERROR severity, and a non-nil
+// Position. Position is unconditional because every caller is a
+// parser-error path — and parser errors that don't know where they
+// failed are themselves a regression.
+func assertEnvelopeError(t *testing.T, env output.Envelope, code string) {
+	t.Helper()
+	require.NotEmpty(t, env.Errors, "expected an envelope error")
+	first := env.Errors[0]
+	require.Equal(t, code, first.Code)
+	require.Equal(t, output.SeverityError, first.Severity)
+	require.NotNil(t, first.Position, "parser errors must carry source position")
+}


### PR DESCRIPTION
Unit tests under internal/mcp/tools cover individual handlers, but
nothing exercises the end-to-end JSON-RPC round-trip: a typo in
s.AddTool, a transport serialization regression, or an mcp-go upgrade
incompatibility would compile, pass make test, and only blow up when a
real client connected.

Add internal/mcp/integration_test.go that builds bin/crdb-sql once into
a temp dir and spawns it as an MCP subprocess via the mark3labs/mcp-go
stdio client. Each top-level test gets a fresh subprocess so failures
stay isolated. Coverage:

  - tools/list locks in the eight registered tool names so a missing
    AddTool line surfaces as a diff, not a silent omission
  - ping, parse_sql, format_sql, detect_risky_query, list_tables,
    describe_table: success and error paths, asserting Tier,
    ConnectionStatus, ParserVersion, envelope errors, and per-tool
    Data payload shape
  - validate_sql: tier 1 (capability_required warning), tier 2 (with
    schemas, name_resolution=ok), type-mismatch envelope error, and
    missing-required-parameter tool error
  - explain_sql: gated by cockroachtest.Shared, which skips cleanly
    without COCKROACH_BIN/CRDB_TEST_DSN — runs as part of make test
    when cockroach is on PATH and is exercised by make test-integration
    otherwise

The file is not build-tagged so make test runs it on every developer
machine and in CI; explain_sql is the only subtest that may skip.

Resolves: #73