### PR TITLE
summarize: add structured AST-only SQL summary tool

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,6 +147,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newDescribeCmd(state))
 	root.AddCommand(newListTablesCmd(state))
 	root.AddCommand(newRiskCmd(state))
+	root.AddCommand(newSummarizeCmd(state))
 	root.AddCommand(newExplainCmd(state))
 	root.AddCommand(newMCPCmd(state))
 	return root

--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -1,0 +1,146 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+	"github.com/spilchen/sql-ai-tools/internal/summarize"
+)
+
+// newSummarizeCmd builds the `crdb-sql summarize` subcommand. It reads
+// SQL from the -e flag, a positional file argument, or stdin, parses
+// it with the CockroachDB parser, and emits a per-statement structured
+// summary: operation, tables, predicates, joins, mutated columns, and
+// a delegated risk level.
+//
+// This is a Tier 1 (zero-config) command: it works offline with no
+// schema files or cluster connection.
+func newSummarizeCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "summarize [file]",
+		Short: "Structured summary of SQL statements",
+		Long: `Produce a structured per-statement summary of SQL: operation
+(SELECT/INSERT/UPDATE/DELETE/UPSERT/OTHER), tables touched, top-level
+WHERE predicates, joins, columns mutated by DML, and a risk level
+delegated to the same rules as 'crdb-sql risk'. Input is read from the
+-e flag, a positional file argument, or stdin.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			summaries, err := summarize.Summarize(sql)
+			if err != nil {
+				return renderParseError(r, baseEnv, err, sql)
+			}
+
+			data, err := json.Marshal(summaries)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				return renderSummariesText(w, summaries)
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to summarize")
+
+	return cmd
+}
+
+// renderSummariesText prints one labeled block per statement. A blank
+// line separates blocks so multi-statement output is easy to scan.
+// Empty fields are rendered as "(none)" rather than blank so a quick
+// visual scan distinguishes "no joins" from "joins were not analyzed".
+func renderSummariesText(w io.Writer, summaries []summarize.Summary) error {
+	for i, s := range summaries {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if err := renderSummaryText(w, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderSummaryText(w io.Writer, s summarize.Summary) error {
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	rows := []struct {
+		label string
+		value string
+	}{
+		{"operation", string(s.Operation)},
+		{"tag", s.Tag},
+		{"tables", joinOrNone(s.Tables)},
+		{"joins", joinSummaryStrings(s.Joins)},
+		{"predicates", joinOrNone(s.Predicates)},
+		{"affected_columns", joinOrNone(s.AffectedColumns)},
+		{"risk", string(s.RiskLevel)},
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(tw, "%s:\t%s\n", row.label, row.value); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func joinOrNone(items []string) string {
+	if len(items) == 0 {
+		return "(none)"
+	}
+	return strings.Join(items, ", ")
+}
+
+// joinSummaryStrings flattens the structured Join entries into a
+// single comma-separated line for the text view; the JSON output
+// preserves the structured form for agents that want to consume it.
+func joinSummaryStrings(joins []summarize.Join) string {
+	if len(joins) == 0 {
+		return "(none)"
+	}
+	parts := make([]string, len(joins))
+	for i, j := range joins {
+		left := j.Left
+		if left == "" {
+			left = "?"
+		}
+		right := j.Right
+		if right == "" {
+			right = "?"
+		}
+		if j.Condition == "" {
+			parts[i] = fmt.Sprintf("%s %s %s", j.Type, left, right)
+			continue
+		}
+		parts[i] = fmt.Sprintf("%s %s %s ON %s", j.Type, left, right, j.Condition)
+	}
+	return strings.Join(parts, "; ")
+}

--- a/cmd/summarize_test.go
+++ b/cmd/summarize_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+	"github.com/spilchen/sql-ai-tools/internal/summarize"
+)
+
+// TestSummarizeCmdText exercises the text output path end-to-end with
+// the issue's demo SQL.
+func TestSummarizeCmdText(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("DELETE FROM orders WHERE status='x'"))
+	root.SetArgs([]string{"summarize"})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "operation:")
+	require.Contains(t, got, "DELETE")
+	require.Contains(t, got, "orders")
+	require.Contains(t, got, "status = 'x'")
+}
+
+// TestSummarizeCmdJSONIssueDemo verifies that the issue's demo
+// command produces the documented JSON shape exactly.
+func TestSummarizeCmdJSONIssueDemo(t *testing.T) {
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"summarize", "-e", "DELETE FROM orders WHERE status='x'", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+	require.Empty(t, stderr.String(), "JSON mode must not write to stderr")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierZeroConfig, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.NotEmpty(t, env.ParserVersion)
+	require.Empty(t, env.Errors)
+
+	var summaries []summarize.Summary
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 1)
+
+	s := summaries[0]
+	require.Equal(t, summarize.OpDelete, s.Operation)
+	require.Equal(t, []string{"orders"}, s.Tables)
+	require.Equal(t, []string{"status = 'x'"}, s.Predicates)
+	require.Empty(t, s.Joins)
+	require.Empty(t, s.AffectedColumns)
+	require.Equal(t, risk.SeverityInfo, s.RiskLevel)
+}
+
+// TestSummarizeCmdRiskDelegation verifies that summarize's risk_level
+// matches what the risk subcommand would produce for the same SQL.
+func TestSummarizeCmdRiskDelegation(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"summarize", "-e", "DELETE FROM orders", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var summaries []summarize.Summary
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 1)
+	require.Equal(t, risk.SeverityCritical, summaries[0].RiskLevel)
+}
+
+// TestSummarizeCmdFileArg verifies reading SQL from a file argument.
+func TestSummarizeCmdFileArg(t *testing.T) {
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "input.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("UPDATE t SET a=1 WHERE id=2"), 0644))
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"summarize", sqlFile, "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var summaries []summarize.Summary
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 1)
+	require.Equal(t, summarize.OpUpdate, summaries[0].Operation)
+	require.Equal(t, []string{"a"}, summaries[0].AffectedColumns)
+}
+
+// TestSummarizeCmdMultiStatement verifies that each statement gets
+// its own summary in the JSON payload.
+func TestSummarizeCmdMultiStatement(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"summarize", "-e", "SELECT 1 FROM a JOIN b ON a.id=b.id; DROP TABLE foo", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var summaries []summarize.Summary
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 2)
+	require.Equal(t, summarize.OpSelect, summaries[0].Operation)
+	require.Len(t, summaries[0].Joins, 1)
+	require.Equal(t, summarize.OpOther, summaries[1].Operation)
+	require.Equal(t, "DROP TABLE", summaries[1].Tag)
+	require.Equal(t, risk.SeverityCritical, summaries[1].RiskLevel)
+}
+
+// TestSummarizeCmdParseErrorJSON verifies that invalid SQL in JSON
+// mode produces an envelope with errors and nil data.
+func TestSummarizeCmdParseErrorJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader("SELECTT 1"))
+	root.SetArgs([]string{"summarize", "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Nil(t, env.Data)
+}
+
+// TestSummarizeCmdEmptyInput verifies that empty stdin produces an
+// error (matching the rest of the SQL-consuming subcommands).
+func TestSummarizeCmdEmptyInput(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(""))
+	root.SetArgs([]string{"summarize"})
+
+	require.Error(t, root.Execute())
+}

--- a/internal/summarize/summarize.go
+++ b/internal/summarize/summarize.go
@@ -1,0 +1,300 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package summarize produces a structured, AST-only description of a
+// SQL statement: the operation, the tables it touches, the WHERE
+// predicates, the joins, the columns it mutates, and a delegated risk
+// level from the risk package.
+//
+// It is the deterministic "what does this statement do?" companion to
+// the risk package's "what is dangerous about it?". Like risk, it
+// works purely from the cockroachdb-parser AST and never connects to a
+// cluster.
+//
+// Example:
+//
+//	s, _ := summarize.Summarize("DELETE FROM orders WHERE status='x'")
+//	// s[0].Operation == OpDelete
+//	// s[0].Tables    == []string{"orders"}
+//	// s[0].Predicates == []string{"status = 'x'"}
+//	// s[0].RiskLevel == risk.SeverityInfo
+package summarize
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+)
+
+// Operation classifies the top-level kind of a statement. The values
+// are part of the wire format — adding new ones is fine, renaming
+// existing ones is a breaking change.
+type Operation string
+
+// Operation values. OpOther is the catch-all for statement kinds that
+// summarize does not structurally decompose; the StatementTag is
+// surfaced via Summary.Tag so agents can still distinguish e.g.
+// DROP TABLE from CREATE TABLE.
+const (
+	OpSelect Operation = "SELECT"
+	OpInsert Operation = "INSERT"
+	OpUpsert Operation = "UPSERT"
+	OpUpdate Operation = "UPDATE"
+	OpDelete Operation = "DELETE"
+	OpOther  Operation = "OTHER"
+)
+
+// Summary is the per-statement result returned by Summarize. It is the
+// JSON-serializable shape embedded in both the CLI envelope's Data
+// field and any future MCP tool result.
+//
+// Field discipline:
+//   - Tables, Predicates, Joins, AffectedColumns are emitted as empty
+//     JSON arrays rather than null when there are no entries, so
+//     consumers can iterate without nil checks.
+//   - AffectedColumns contains only columns mutated by DML (INSERT
+//     explicit column list, UPDATE SET targets). It is empty for
+//     DELETE and SELECT. See issue #100 for tracking expansion to
+//     all referenced columns.
+//   - RiskLevel is the highest severity reported by risk.Analyze for
+//     the statement; risk.SeverityInfo is the baseline meaning "no
+//     risks detected", not "an info-level risk was detected".
+type Summary struct {
+	Operation       Operation     `json:"operation"`
+	Tag             string        `json:"tag"`
+	Tables          []string      `json:"tables"`
+	Predicates      []string      `json:"predicates"`
+	Joins           []Join        `json:"joins"`
+	AffectedColumns []string      `json:"affected_columns"`
+	RiskLevel       risk.Severity `json:"risk_level"`
+	Position        risk.Position `json:"position"`
+}
+
+// Join describes one JOIN clause inside a statement.
+//
+// Left and Right are best-effort table names: they hold the bare table
+// name (or alias when present) when the side resolves to an
+// AliasedTableExpr backed by a TableName, and are empty for nested
+// joins or subquery sources.
+//
+// Condition holds the rendered ON expression, "USING (col1, col2)",
+// "NATURAL", or empty for a CROSS join.
+type Join struct {
+	Type      string `json:"type"`
+	Left      string `json:"left,omitempty"`
+	Right     string `json:"right,omitempty"`
+	Condition string `json:"condition,omitempty"`
+}
+
+// Summarize parses sql and returns one Summary per statement, in
+// source order. Parse errors are returned to the caller; partial
+// summaries are not produced.
+func Summarize(sql string) ([]Summary, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	summaries := make([]Summary, 0, len(stmts))
+	offset := 0
+	for _, stmt := range stmts {
+		pos := positionFromSQL(sql, stmt.SQL, &offset)
+		s := summarizeStatement(stmt.AST)
+		s.Position = pos
+		s.RiskLevel = riskLevelFor(stmt.SQL)
+		summaries = append(summaries, s)
+	}
+	return summaries, nil
+}
+
+// summarizeStatement summarizes one already-parsed statement. Position
+// and RiskLevel are left at their zero values; the public Summarize
+// entry point fills them in because both require the full SQL text.
+func summarizeStatement(stmt tree.Statement) Summary {
+	s := Summary{
+		Tag:             stmt.StatementTag(),
+		Tables:          collectTables(stmt),
+		Predicates:      []string{},
+		Joins:           []Join{},
+		AffectedColumns: []string{},
+	}
+
+	switch n := stmt.(type) {
+	case *tree.Select:
+		s.Operation = OpSelect
+		s.Predicates = wherePredicates(selectWhere(n))
+		s.Joins = collectJoins(stmt)
+	case *tree.Insert:
+		if n.OnConflict.IsUpsertAlias() {
+			s.Operation = OpUpsert
+		} else {
+			s.Operation = OpInsert
+		}
+		s.AffectedColumns = nameListToStrings(n.Columns)
+		// INSERT ... SELECT can have a WHERE inside the embedded
+		// SELECT; surface those predicates so agents see the full
+		// row-selection footprint.
+		if n.Rows != nil {
+			s.Predicates = wherePredicates(selectWhere(n.Rows))
+			s.Joins = collectJoins(n.Rows)
+		}
+	case *tree.Update:
+		s.Operation = OpUpdate
+		s.Predicates = wherePredicates(n.Where)
+		s.AffectedColumns = updateTargets(n.Exprs)
+		s.Joins = collectJoins(stmt)
+	case *tree.Delete:
+		s.Operation = OpDelete
+		s.Predicates = wherePredicates(n.Where)
+		s.Joins = collectJoins(stmt)
+	default:
+		s.Operation = OpOther
+	}
+	return s
+}
+
+// selectWhere returns the WHERE clause attached to the leaf
+// SelectClause inside a Select, or nil for set operations
+// (UNION/INTERSECT/EXCEPT) and VALUES clauses, which have no top-level
+// WHERE.
+func selectWhere(sel *tree.Select) *tree.Where {
+	if sel == nil {
+		return nil
+	}
+	sc, ok := sel.Select.(*tree.SelectClause)
+	if !ok {
+		return nil
+	}
+	return sc.Where
+}
+
+// wherePredicates renders w as one string per top-level conjunct,
+// splitting on AndExpr. Returns the empty slice when w is nil so
+// JSON callers see [] rather than null. Conjuncts are rendered with
+// FmtSimple to match how a human would write them
+// (e.g. "status = 'x'", not "status = 'x':::STRING").
+func wherePredicates(w *tree.Where) []string {
+	if w == nil || w.Expr == nil {
+		return []string{}
+	}
+	var out []string
+	walkConjuncts(w.Expr, &out)
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+func walkConjuncts(expr tree.Expr, out *[]string) {
+	if and, ok := expr.(*tree.AndExpr); ok {
+		walkConjuncts(and.Left, out)
+		walkConjuncts(and.Right, out)
+		return
+	}
+	*out = append(*out, tree.AsStringWithFlags(expr, tree.FmtSimple))
+}
+
+// updateTargets returns the LHS column names of an UPDATE's SET list,
+// in source order. Tuple assignments ("(a, b) = (1, 2)") flatten into
+// individual names.
+func updateTargets(exprs tree.UpdateExprs) []string {
+	var out []string
+	for _, e := range exprs {
+		if e == nil {
+			continue
+		}
+		out = append(out, nameListToStrings(e.Names)...)
+	}
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+// nameListToStrings is NameList.ToStrings normalized to never return
+// nil — JSON consumers expect []string{} for "no names".
+func nameListToStrings(names tree.NameList) []string {
+	if len(names) == 0 {
+		return []string{}
+	}
+	return names.ToStrings()
+}
+
+// riskLevelFor delegates to risk.Analyze and reduces the findings to
+// the highest severity seen. risk.SeverityInfo is the "no risks
+// detected" baseline; we never invent findings here.
+//
+// risk.Analyze re-parses stmtSQL internally. We pass the per-statement
+// SQL substring produced by our own earlier parse, so a re-parse error
+// is not expected in practice; if one occurs we collapse to
+// SeverityInfo rather than fail the whole summary, since the structured
+// fields above are still valid and a missing risk_level is less bad
+// than dropping the entire statement. Note that this path is silent —
+// a future change should consider surfacing risk-analysis failures as
+// envelope warnings.
+func riskLevelFor(stmtSQL string) risk.Severity {
+	findings, err := risk.Analyze(stmtSQL)
+	if err != nil {
+		return risk.SeverityInfo
+	}
+	highest := risk.SeverityInfo
+	for _, f := range findings {
+		if severityRank(f.Severity) > severityRank(highest) {
+			highest = f.Severity
+		}
+	}
+	return highest
+}
+
+// severityRank orders severities from least to most urgent so we can
+// reduce a findings slice to its peak. The constants are strings whose
+// lexical order doesn't match severity, so we map them explicitly.
+// Renaming a Severity value here without updating registry.go is a
+// silent bug — keep this switch in sync with risk.Severity*.
+func severityRank(s risk.Severity) int {
+	switch s {
+	case risk.SeverityCritical:
+		return 5
+	case risk.SeverityHigh:
+		return 4
+	case risk.SeverityMedium:
+		return 3
+	case risk.SeverityLow:
+		return 2
+	case risk.SeverityInfo:
+		return 1
+	}
+	return 0
+}
+
+// positionFromSQL is duplicated from the unexported helper of the same
+// name in the risk package. Promoting it to a shared helper is not yet
+// justified by a third caller; consolidate when one appears.
+//
+// On a fallback (stmtSQL not located in fullSQL — e.g. a parser
+// round-trip mismatch where AST.SQL is no longer byte-identical to the
+// source) we still advance *offset past the missing statement so
+// subsequent statements don't all collapse to the same byte offset.
+// Position.Line == 0 signals the fallback; consumers can treat it as
+// "unknown" rather than the misleading 1:1.
+func positionFromSQL(fullSQL, stmtSQL string, offset *int) risk.Position {
+	idx := strings.Index(fullSQL[*offset:], stmtSQL)
+	if idx < 0 {
+		pos := risk.Position{Line: 0, Column: 0, ByteOffset: *offset}
+		*offset += len(stmtSQL)
+		return pos
+	}
+	byteOff := *offset + idx
+	*offset = byteOff + len(stmtSQL)
+
+	prefix := fullSQL[:byteOff]
+	line := strings.Count(prefix, "\n") + 1
+	lastNL := strings.LastIndex(prefix, "\n") // works when lastNL == -1 (no newlines)
+	col := byteOff - lastNL
+	return risk.Position{Line: line, Column: col, ByteOffset: byteOff}
+}

--- a/internal/summarize/summarize_test.go
+++ b/internal/summarize/summarize_test.go
@@ -1,0 +1,364 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package summarize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/risk"
+)
+
+// TestSummarize covers the structured fields produced for a range of
+// statement shapes. Each case exercises one concern; the issue demo
+// has its own dedicated case so a regression there is obvious.
+func TestSummarize(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		expectedOp       Operation
+		expectedTag      string
+		expectedTables   []string
+		expectedPreds    []string
+		expectedJoins    []Join
+		expectedAffected []string
+		expectedRisk     risk.Severity
+	}{
+		{
+			name:             "issue demo: delete with WHERE",
+			sql:              "DELETE FROM orders WHERE status='x'",
+			expectedOp:       OpDelete,
+			expectedTables:   []string{"orders"},
+			expectedPreds:    []string{"status = 'x'"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "delete without WHERE delegates risk",
+			sql:              "DELETE FROM orders",
+			expectedOp:       OpDelete,
+			expectedTables:   []string{"orders"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityCritical,
+		},
+		{
+			name:             "insert with explicit column list",
+			sql:              "INSERT INTO t (a, b) VALUES (1, 2)",
+			expectedOp:       OpInsert,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"a", "b"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "insert without column list leaves affected empty",
+			sql:              "INSERT INTO t VALUES (1, 2)",
+			expectedOp:       OpInsert,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "upsert short form detected",
+			sql:              "UPSERT INTO t (a) VALUES (1)",
+			expectedOp:       OpUpsert,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"a"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "update set targets become affected columns",
+			sql:              "UPDATE t SET a=1, b=2 WHERE id=3",
+			expectedOp:       OpUpdate,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{"id = 3"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"a", "b"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "select WHERE splits on top-level AND",
+			sql:              "SELECT 1 FROM t WHERE a=1 AND b>2 AND c IS NULL",
+			expectedOp:       OpSelect,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{"a = 1", "b > 2", "c IS NULL"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "select star raises low risk",
+			sql:              "SELECT * FROM t",
+			expectedOp:       OpSelect,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityLow,
+		},
+		{
+			name:           "inner join with ON",
+			sql:            "SELECT 1 FROM a JOIN b ON a.id=b.id",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "INNER", Left: "a", Right: "b", Condition: "a.id = b.id"},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:           "left join with USING",
+			sql:            "SELECT 1 FROM a LEFT JOIN b USING (id)",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "LEFT", Left: "a", Right: "b", Condition: "USING (id)"},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:           "three-way join produces two join entries",
+			sql:            "SELECT 1 FROM a JOIN b ON a.id=b.id JOIN c ON b.id=c.id",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b", "c"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "INNER", Left: "a", Right: "b", Condition: "a.id = b.id"},
+				{Type: "INNER", Left: "", Right: "c", Condition: "b.id = c.id"},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "schema-qualified table renders bare name",
+			sql:              "SELECT 1 FROM public.users",
+			expectedOp:       OpSelect,
+			expectedTables:   []string{"users"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "CTE alias excluded from tables",
+			sql:              "WITH x AS (SELECT 1 FROM t) SELECT 2 FROM x",
+			expectedOp:       OpSelect,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			// The walker visits projection → WHERE → FROM, so the
+			// subquery's table appears before the outer FROM table.
+			// The ordering is intentional and documented on
+			// collectTables.
+			name:             "subquery tables roll up",
+			sql:              "SELECT 1 FROM t WHERE id IN (SELECT id FROM u)",
+			expectedOp:       OpSelect,
+			expectedTables:   []string{"u", "t"},
+			expectedPreds:    []string{"id IN (SELECT id FROM u)"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "DDL fallback to OTHER with tag and risk",
+			sql:              "DROP TABLE foo",
+			expectedOp:       OpOther,
+			expectedTag:      "DROP TABLE",
+			expectedTables:   []string{},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityCritical,
+		},
+		{
+			// NATURAL JOIN must not flatten to plain INNER — agents
+			// reading just Type need to see that no equality predicate
+			// was declared.
+			name:           "natural join surfaces in type",
+			sql:            "SELECT 1 FROM a NATURAL JOIN b",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "NATURAL", Left: "a", Right: "b", Condition: "NATURAL"},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:           "natural left join combines markers",
+			sql:            "SELECT 1 FROM a NATURAL LEFT JOIN b",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "NATURAL LEFT", Left: "a", Right: "b", Condition: "NATURAL"},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:           "cross join has empty condition",
+			sql:            "SELECT 1 FROM a CROSS JOIN b",
+			expectedOp:     OpSelect,
+			expectedTables: []string{"a", "b"},
+			expectedPreds:  []string{},
+			expectedJoins: []Join{
+				{Type: "CROSS", Left: "a", Right: "b", Condition: ""},
+			},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			// DELETE ... USING must collect both the target and the
+			// USING tables; otherwise change-impact analysis would
+			// silently drop the second table.
+			name:             "delete using collects both tables",
+			sql:              "DELETE FROM a USING b WHERE a.id=b.id",
+			expectedOp:       OpDelete,
+			expectedTables:   []string{"a", "b"},
+			expectedPreds:    []string{"a.id = b.id"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			name:             "update from collects both tables",
+			sql:              "UPDATE a SET x=b.y FROM b WHERE a.id=b.id",
+			expectedOp:       OpUpdate,
+			expectedTables:   []string{"a", "b"},
+			expectedPreds:    []string{"a.id = b.id"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"x"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			// Only the bare UPSERT keyword is OpUpsert; the explicit
+			// ON CONFLICT DO UPDATE form stays as OpInsert because
+			// OnConflict.IsUpsertAlias() distinguishes them.
+			name:             "explicit on conflict do update stays as insert",
+			sql:              "INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a=2",
+			expectedOp:       OpInsert,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"a"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+		{
+			// Tuple SET targets flatten into individual column names
+			// per updateTargets's documented contract.
+			name:             "tuple update flattens to individual columns",
+			sql:              "UPDATE t SET (a,b)=(1,2) WHERE id=3",
+			expectedOp:       OpUpdate,
+			expectedTables:   []string{"t"},
+			expectedPreds:    []string{"id = 3"},
+			expectedJoins:    []Join{},
+			expectedAffected: []string{"a", "b"},
+			expectedRisk:     risk.SeverityInfo,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summaries, err := Summarize(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, summaries, 1)
+
+			s := summaries[0]
+			require.Equal(t, tc.expectedOp, s.Operation)
+			if tc.expectedTag != "" {
+				require.Equal(t, tc.expectedTag, s.Tag)
+			}
+			require.Equal(t, tc.expectedTables, s.Tables)
+			require.Equal(t, tc.expectedPreds, s.Predicates)
+			require.Equal(t, tc.expectedJoins, s.Joins)
+			require.Equal(t, tc.expectedAffected, s.AffectedColumns)
+			require.Equal(t, tc.expectedRisk, s.RiskLevel)
+		})
+	}
+}
+
+// TestSummarizeMultiStatement verifies that each statement gets its
+// own summary in source order with its own position.
+func TestSummarizeMultiStatement(t *testing.T) {
+	summaries, err := Summarize("SELECT 1 FROM t; DELETE FROM u")
+	require.NoError(t, err)
+	require.Len(t, summaries, 2)
+
+	require.Equal(t, OpSelect, summaries[0].Operation)
+	require.Equal(t, []string{"t"}, summaries[0].Tables)
+	require.Equal(t, 0, summaries[0].Position.ByteOffset)
+
+	require.Equal(t, OpDelete, summaries[1].Operation)
+	require.Equal(t, []string{"u"}, summaries[1].Tables)
+	require.Equal(t, risk.SeverityCritical, summaries[1].RiskLevel)
+	require.Greater(t, summaries[1].Position.ByteOffset, summaries[0].Position.ByteOffset)
+}
+
+// TestSummarizeParseError surfaces parse failures to the caller
+// rather than silently producing an empty result.
+func TestSummarizeParseError(t *testing.T) {
+	_, err := Summarize("SELECTT 1")
+	require.Error(t, err)
+}
+
+// TestRiskLevelReduction verifies that riskLevelFor reduces a
+// statement's findings to the highest severity. Tested through the
+// public Summarize path so we exercise the real risk registry rather
+// than mocking it.
+func TestRiskLevelReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		sql          string
+		expectedRisk risk.Severity
+	}{
+		{
+			name:         "no findings → info baseline",
+			sql:          "SELECT id FROM t WHERE id = 1",
+			expectedRisk: risk.SeverityInfo,
+		},
+		{
+			name:         "low only",
+			sql:          "SELECT * FROM t WHERE id = 1",
+			expectedRisk: risk.SeverityLow,
+		},
+		{
+			name:         "critical wins over low (DROP plus SELECT *)",
+			sql:          "SELECT * FROM t; DROP TABLE t",
+			expectedRisk: risk.SeverityCritical,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summaries, err := Summarize(tc.sql)
+			require.NoError(t, err)
+			// For multi-statement cases each summary carries its own
+			// risk; verify the last one (where DROP lives) so the
+			// table reads naturally.
+			require.NotEmpty(t, summaries)
+			require.Equal(t, tc.expectedRisk, summaries[len(summaries)-1].RiskLevel)
+		})
+	}
+}

--- a/internal/summarize/walk.go
+++ b/internal/summarize/walk.go
@@ -1,0 +1,243 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package summarize
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// collectTables returns the bare names of every table the statement
+// reads or writes, deduplicated case-insensitively. Order matches the
+// parser's AST traversal of the statement — for SelectClause that
+// means projection, then various clauses (WHERE, GROUP BY, HAVING,
+// …), then FROM tables — so a table referenced inside a WHERE or
+// GROUP BY subquery appears before the outer FROM table. The order
+// is stable for a given input but should be treated by consumers as
+// unordered. CTE names declared by WITH clauses and table aliases are
+// excluded; numeric "[123 AS t]" table refs are skipped because they
+// have no resolvable name.
+func collectTables(stmt tree.Statement) []string {
+	v := newTableCollector()
+	bindCTEs(v, stmt)
+	tree.WalkStmt(v, stmt)
+	if len(v.ordered) == 0 {
+		return []string{}
+	}
+	return v.ordered
+}
+
+// collectJoins walks stmt and returns one Join entry per JOIN clause
+// found anywhere in the statement (including inside subqueries).
+// Order is depth-first post-order, which for left-deep join chains
+// (`a JOIN b JOIN c`) matches the lexical order: inner join first,
+// outer join last.
+func collectJoins(stmt tree.Statement) []Join {
+	v := &joinCollector{}
+	tree.WalkStmt(v, stmt)
+	if len(v.joins) == 0 {
+		return []Join{}
+	}
+	return v.joins
+}
+
+// bindCTEs preloads CTE alias names into the table collector's scope
+// so references like `SELECT * FROM x` (where x is a CTE alias) do
+// not appear in the tables list. We mirror the per-CTE walk that
+// internal/semcheck/names.go does for catalog resolution.
+func bindCTEs(v *tableCollector, stmt tree.Statement) {
+	w := withClause(stmt)
+	if w == nil {
+		return
+	}
+	for _, cte := range w.CTEList {
+		if cte == nil {
+			continue
+		}
+		if name := string(cte.Name.Alias); name != "" {
+			v.scope[strings.ToLower(name)] = struct{}{}
+		}
+	}
+}
+
+func withClause(stmt tree.Statement) *tree.With {
+	switch s := stmt.(type) {
+	case *tree.Select:
+		return s.With
+	case *tree.Insert:
+		return s.With
+	case *tree.Update:
+		return s.With
+	case *tree.Delete:
+		return s.With
+	}
+	return nil
+}
+
+// tableCollector implements tree.ExtendedVisitor to gather table
+// names. ExtendedVisitor (rather than plain Visitor) is required
+// because WalkStmt with a plain Visitor skips TableExpr subtrees,
+// which is exactly where table references live.
+//
+// Lifecycle: one collector per top-level statement. The seen map
+// dedupes case-insensitively; ordered preserves first-seen order so
+// JSON output is stable and matches what a human reading the SQL
+// would expect.
+type tableCollector struct {
+	seen    map[string]struct{}
+	scope   map[string]struct{}
+	ordered []string
+}
+
+func newTableCollector() *tableCollector {
+	return &tableCollector{
+		seen:  make(map[string]struct{}),
+		scope: make(map[string]struct{}),
+	}
+}
+
+var _ tree.ExtendedVisitor = (*tableCollector)(nil)
+
+func (v *tableCollector) VisitPre(expr tree.Expr) (bool, tree.Expr)          { return true, expr }
+func (v *tableCollector) VisitPost(expr tree.Expr) tree.Expr                 { return expr }
+func (v *tableCollector) VisitTablePost(e tree.TableExpr) tree.TableExpr     { return e }
+func (v *tableCollector) VisitStatementPost(s tree.Statement) tree.Statement { return s }
+
+func (v *tableCollector) VisitStatementPre(stmt tree.Statement) (bool, tree.Statement) {
+	// Subqueries can introduce their own CTEs; bind them before the
+	// body is walked so nested references don't leak into tables.
+	bindCTEs(v, stmt)
+	return true, stmt
+}
+
+func (v *tableCollector) VisitTablePre(expr tree.TableExpr) (bool, tree.TableExpr) {
+	switch t := expr.(type) {
+	case *tree.AliasedTableExpr:
+		if t.As.Alias != "" {
+			v.scope[strings.ToLower(string(t.As.Alias))] = struct{}{}
+		}
+		return true, expr
+	case *tree.TableName:
+		v.add(t.Table())
+		return false, expr
+	case *tree.TableRef:
+		// Numeric "[123 AS t]" form has no resolvable name.
+		return false, expr
+	}
+	return true, expr
+}
+
+func (v *tableCollector) add(name string) {
+	if name == "" {
+		return
+	}
+	key := strings.ToLower(name)
+	if _, dup := v.seen[key]; dup {
+		return
+	}
+	if _, scoped := v.scope[key]; scoped {
+		return
+	}
+	v.seen[key] = struct{}{}
+	v.ordered = append(v.ordered, name)
+}
+
+// joinCollector gathers JoinTableExpr nodes via ExtendedVisitor. We
+// recurse rather than stop at JOIN nodes so that nested joins
+// (e.g. `a JOIN b ON ... JOIN c ON ...`) all surface as separate
+// Join entries.
+type joinCollector struct {
+	joins []Join
+}
+
+var _ tree.ExtendedVisitor = (*joinCollector)(nil)
+
+func (v *joinCollector) VisitPre(expr tree.Expr) (bool, tree.Expr) { return true, expr }
+func (v *joinCollector) VisitPost(expr tree.Expr) tree.Expr        { return expr }
+func (v *joinCollector) VisitStatementPre(s tree.Statement) (bool, tree.Statement) {
+	return true, s
+}
+func (v *joinCollector) VisitStatementPost(s tree.Statement) tree.Statement { return s }
+func (v *joinCollector) VisitTablePre(expr tree.TableExpr) (bool, tree.TableExpr) {
+	return true, expr
+}
+
+// VisitTablePost records the join after children are visited so a
+// left-deep chain like `a JOIN b ON ... JOIN c ON ...` produces
+// [(a,b), (_,c)] rather than [(_,c), (a,b)] — i.e. the order a human
+// reader would expect.
+func (v *joinCollector) VisitTablePost(expr tree.TableExpr) tree.TableExpr {
+	if j, ok := expr.(*tree.JoinTableExpr); ok {
+		v.joins = append(v.joins, joinFrom(j))
+	}
+	return expr
+}
+
+// joinFrom builds a Join from a parsed JoinTableExpr.
+//
+// Type combines the parser's JoinType (INNER/LEFT/RIGHT/FULL/CROSS)
+// with the natural-join marker. A NATURAL INNER JOIN renders as
+// "NATURAL", a NATURAL LEFT JOIN as "NATURAL LEFT", etc. — so an
+// agent reading just Type still sees that no equality predicate was
+// declared, instead of the join silently looking like a regular
+// INNER. The parser leaves JoinType empty for the default INNER, which
+// we promote to "INNER" so the JSON output never has a blank type.
+func joinFrom(j *tree.JoinTableExpr) Join {
+	jt := j.JoinType
+	if jt == "" {
+		jt = tree.AstInner
+	}
+	if _, isNatural := j.Cond.(tree.NaturalJoinCond); isNatural {
+		if jt == tree.AstInner {
+			jt = "NATURAL"
+		} else {
+			jt = "NATURAL " + jt
+		}
+	}
+	return Join{
+		Type:      jt,
+		Left:      tableNameOf(j.Left),
+		Right:     tableNameOf(j.Right),
+		Condition: joinCondString(j.Cond),
+	}
+}
+
+// tableNameOf returns the bare table name (or alias) of a join side
+// when it's a simple table reference, and "" for nested joins or
+// subqueries — the renderer would otherwise emit a multi-line
+// expression that's not useful as an identifier.
+func tableNameOf(t tree.TableExpr) string {
+	switch e := t.(type) {
+	case *tree.AliasedTableExpr:
+		if e.As.Alias != "" {
+			return string(e.As.Alias)
+		}
+		return tableNameOf(e.Expr)
+	case *tree.TableName:
+		return e.Table()
+	case *tree.ParenTableExpr:
+		return tableNameOf(e.Expr)
+	}
+	return ""
+}
+
+// joinCondString renders a JoinCond into the conventional SQL form.
+// Returns "" for a nil cond (CROSS JOIN), so JSON omitempty drops the
+// field entirely for those joins.
+func joinCondString(c tree.JoinCond) string {
+	switch cond := c.(type) {
+	case nil:
+		return ""
+	case tree.NaturalJoinCond:
+		return "NATURAL"
+	case *tree.OnJoinCond:
+		return tree.AsStringWithFlags(cond.Expr, tree.FmtSimple)
+	case *tree.UsingJoinCond:
+		return "USING (" + tree.AsStringWithFlags(&cond.Cols, tree.FmtSimple) + ")"
+	}
+	return ""
+}


### PR DESCRIPTION
Add a new `crdb-sql summarize` subcommand that walks the parsed AST
and returns a per-statement structured summary: operation
(SELECT/INSERT/UPDATE/DELETE/UPSERT/OTHER), tables touched, top-level
WHERE predicates split on AND, joins with type/sides/condition,
columns mutated by DML, and a risk_level delegated to the existing
risk package.

This is the deterministic "what does this statement do?" companion to
\`crdb-sql risk\` ("what's dangerous about it?"). The structured output
gives an LLM agent the facts it needs to describe a statement or
gate on it without re-parsing SQL or hallucinating; no templated
natural-language summary is included because the structured fields
are themselves the deliverable.

Scope notes:
- affected_columns covers DML mutations only (INSERT explicit column
  list, UPDATE SET LHS); DELETE and SELECT are empty. Expansion to
  all referenced columns is tracked in #100.
- The summarize_sql MCP tool wiring is split out into #99.
- CTE aliases and table aliases are excluded from the tables list.
- NATURAL JOIN surfaces in Type (e.g. \`NATURAL\`, \`NATURAL LEFT\`)
  rather than being flattened to plain INNER, so consumers see that
  no equality predicate was declared.
- Tables order follows AST traversal (projection then various
  clauses, then FROM); stable for a given input but should be
  treated by consumers as unordered.

Resolves: #25
Informs: #99, #100

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)