### PR TITLE
risk: add sql_safe_updates-derived rules for locking and schema changes

### DIFF
--- a/internal/risk/rules.go
+++ b/internal/risk/rules.go
@@ -35,8 +35,39 @@ func DefaultRules() []Rule {
 		deleteNoWhereRule,
 		updateNoWhereRule,
 		dropTableRule,
+		dropDatabaseRule,
+		alterTableDropColumnRule,
+		selectForUpdateNoWhereRule,
+		selectForShareNoWhereRule,
 		selectStarRule,
 	}
+}
+
+// selectHasLockingStrength reports whether sel carries a locking clause
+// with the given strength (e.g. FOR UPDATE, FOR SHARE).
+func selectHasLockingStrength(sel *tree.Select, strength tree.LockingStrength) bool {
+	for _, item := range sel.Locking {
+		if item != nil && item.Strength == strength {
+			return true
+		}
+	}
+	return false
+}
+
+// selectHasWhere reports whether the inner SelectClause of sel has a
+// WHERE clause. For non-SelectClause inner statements (UNION, VALUES,
+// ParenSelect, etc.) it conservatively returns false even though such
+// shapes can carry a meaningful predicate, e.g. `(SELECT id FROM t
+// WHERE id=1) FOR UPDATE`. This means the FOR UPDATE / FOR SHARE rules
+// will flag those as missing-WHERE — a deliberate trade-off in favor
+// of a simple, AST-shape-only check; recursing into inner selects is
+// future work if the false-positive rate becomes a problem.
+func selectHasWhere(sel *tree.Select) bool {
+	sc, ok := sel.Select.(*tree.SelectClause)
+	if !ok {
+		return false
+	}
+	return sc.Where != nil
 }
 
 // deleteNoWhereRule flags DELETE statements that have neither a WHERE
@@ -104,6 +135,111 @@ var dropTableRule = Rule{
 			Message:  fmt.Sprintf("DROP TABLE %s permanently removes the table and all its data", strings.Join(names, ", ")),
 			Position: &input.Position,
 			FixHint:  "Verify the table name and consider backing up data first",
+		}}
+	},
+}
+
+// dropDatabaseRule flags all DROP DATABASE statements. DROP DATABASE
+// is irreversible and cascades to every schema, table, and row the
+// database contains, so it is always treated as critical regardless of
+// IF EXISTS or DROP behavior modifiers.
+var dropDatabaseRule = Rule{
+	ReasonCode: "DROP_DATABASE",
+	Severity:   SeverityCritical,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		dd, ok := input.AST.(*tree.DropDatabase)
+		if !ok {
+			return nil
+		}
+		return []Finding{{
+			Message:  fmt.Sprintf("DROP DATABASE %s permanently removes the database and all its objects", dd.Name.String()),
+			Position: &input.Position,
+			FixHint:  "Verify the database name and consider backing up data first",
+		}}
+	},
+}
+
+// alterTableDropColumnRule flags every DROP COLUMN command inside an
+// ALTER TABLE statement. A single ALTER TABLE may carry multiple
+// commands (e.g. `ALTER TABLE t DROP COLUMN a, DROP COLUMN b`); each
+// drop produces its own finding so callers can act on them
+// independently.
+var alterTableDropColumnRule = Rule{
+	ReasonCode: "ALTER_TABLE_DROP_COLUMN",
+	Severity:   SeverityHigh,
+	Category:   "schema_safety",
+	Check: func(input CheckInput) []Finding {
+		at, ok := input.AST.(*tree.AlterTable)
+		if !ok {
+			return nil
+		}
+		var findings []Finding
+		table := at.Table.String()
+		for _, cmd := range at.Cmds {
+			drop, ok := cmd.(*tree.AlterTableDropColumn)
+			if !ok {
+				continue
+			}
+			findings = append(findings, Finding{
+				Message:  fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s permanently removes the column and its data", table, drop.Column.String()),
+				Position: &input.Position,
+				FixHint:  "Confirm no application reads or writes this column before dropping",
+			})
+		}
+		return findings
+	},
+}
+
+// selectForUpdateNoWhereRule flags `SELECT ... FOR UPDATE` queries that
+// have neither a WHERE clause nor a LIMIT. Without a predicate, the
+// statement takes a write lock on every row in the table, matching
+// CockroachDB's sql_safe_updates behavior.
+var selectForUpdateNoWhereRule = Rule{
+	ReasonCode: "SELECT_FOR_UPDATE_NO_WHERE",
+	Severity:   SeverityCritical,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		sel, ok := input.AST.(*tree.Select)
+		if !ok {
+			return nil
+		}
+		if !selectHasLockingStrength(sel, tree.ForUpdate) {
+			return nil
+		}
+		if sel.Limit != nil || selectHasWhere(sel) {
+			return nil
+		}
+		return []Finding{{
+			Message:  "SELECT ... FOR UPDATE without WHERE or LIMIT locks every row in the table",
+			Position: &input.Position,
+			FixHint:  "Add a WHERE clause or LIMIT to scope the lock",
+		}}
+	},
+}
+
+// selectForShareNoWhereRule flags `SELECT ... FOR SHARE` queries that
+// have neither a WHERE clause nor a LIMIT. Like FOR UPDATE, a missing
+// predicate causes the lock to span every row in the table.
+var selectForShareNoWhereRule = Rule{
+	ReasonCode: "SELECT_FOR_SHARE_NO_WHERE",
+	Severity:   SeverityHigh,
+	Category:   "data_safety",
+	Check: func(input CheckInput) []Finding {
+		sel, ok := input.AST.(*tree.Select)
+		if !ok {
+			return nil
+		}
+		if !selectHasLockingStrength(sel, tree.ForShare) {
+			return nil
+		}
+		if sel.Limit != nil || selectHasWhere(sel) {
+			return nil
+		}
+		return []Finding{{
+			Message:  "SELECT ... FOR SHARE without WHERE or LIMIT locks every row in the table",
+			Position: &input.Position,
+			FixHint:  "Add a WHERE clause or LIMIT to scope the lock",
 		}}
 	},
 }

--- a/internal/risk/rules_test.go
+++ b/internal/risk/rules_test.go
@@ -87,6 +87,81 @@ func TestAnalyze(t *testing.T) {
 			sql:                 "DELETE FROM users; SELECT * FROM t; UPDATE t SET x = 1",
 			expectedReasonCodes: []string{"DELETE_NO_WHERE", "SELECT_STAR", "UPDATE_NO_WHERE"},
 		},
+		{
+			name:                "DROP DATABASE",
+			sql:                 "DROP DATABASE d",
+			expectedReasonCodes: []string{"DROP_DATABASE"},
+		},
+		{
+			name:                "DROP DATABASE IF EXISTS CASCADE",
+			sql:                 "DROP DATABASE IF EXISTS d CASCADE",
+			expectedReasonCodes: []string{"DROP_DATABASE"},
+		},
+		{
+			name:                "ALTER TABLE DROP COLUMN",
+			sql:                 "ALTER TABLE t DROP COLUMN c",
+			expectedReasonCodes: []string{"ALTER_TABLE_DROP_COLUMN"},
+		},
+		{
+			name:                "ALTER TABLE DROP COLUMN multiple columns yields per-column findings",
+			sql:                 "ALTER TABLE t DROP COLUMN a, DROP COLUMN b",
+			expectedReasonCodes: []string{"ALTER_TABLE_DROP_COLUMN", "ALTER_TABLE_DROP_COLUMN"},
+		},
+		{
+			name:                "ALTER TABLE mixed commands flags only DROP COLUMN",
+			sql:                 "ALTER TABLE t ADD COLUMN x INT, DROP COLUMN y",
+			expectedReasonCodes: []string{"ALTER_TABLE_DROP_COLUMN"},
+		},
+		{
+			name:                "ALTER TABLE ADD COLUMN is safe",
+			sql:                 "ALTER TABLE t ADD COLUMN c INT",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT FOR UPDATE without WHERE or LIMIT",
+			sql:                 "SELECT id FROM t FOR UPDATE",
+			expectedReasonCodes: []string{"SELECT_FOR_UPDATE_NO_WHERE"},
+		},
+		{
+			name:                "SELECT FOR UPDATE with star fires both rules",
+			sql:                 "SELECT * FROM t FOR UPDATE",
+			expectedReasonCodes: []string{"SELECT_FOR_UPDATE_NO_WHERE", "SELECT_STAR"},
+		},
+		{
+			name:                "SELECT FOR UPDATE with WHERE is safe",
+			sql:                 "SELECT id FROM t WHERE id = 1 FOR UPDATE",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT FOR UPDATE with LIMIT is safe",
+			sql:                 "SELECT id FROM t LIMIT 10 FOR UPDATE",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT FOR SHARE without WHERE or LIMIT",
+			sql:                 "SELECT id FROM t FOR SHARE",
+			expectedReasonCodes: []string{"SELECT_FOR_SHARE_NO_WHERE"},
+		},
+		{
+			name:                "SELECT FOR SHARE with WHERE is safe",
+			sql:                 "SELECT id FROM t WHERE id = 1 FOR SHARE",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT FOR SHARE with LIMIT is safe",
+			sql:                 "SELECT id FROM t LIMIT 10 FOR SHARE",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "SELECT FOR UPDATE on union conservatively flagged",
+			sql:                 "(SELECT id FROM t WHERE id = 1) FOR UPDATE",
+			expectedReasonCodes: []string{"SELECT_FOR_UPDATE_NO_WHERE"},
+		},
+		{
+			name:                "multi-statement covers new rules in order",
+			sql:                 "DROP DATABASE d; ALTER TABLE t DROP COLUMN c; SELECT id FROM t FOR UPDATE",
+			expectedReasonCodes: []string{"DROP_DATABASE", "ALTER_TABLE_DROP_COLUMN", "SELECT_FOR_UPDATE_NO_WHERE"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -140,6 +215,26 @@ func TestFindingSeverity(t *testing.T) {
 			sql:              "SELECT * FROM t",
 			expectedSeverity: SeverityLow,
 		},
+		{
+			name:             "DROP_DATABASE is critical",
+			sql:              "DROP DATABASE d",
+			expectedSeverity: SeverityCritical,
+		},
+		{
+			name:             "ALTER_TABLE_DROP_COLUMN is high",
+			sql:              "ALTER TABLE t DROP COLUMN c",
+			expectedSeverity: SeverityHigh,
+		},
+		{
+			name:             "SELECT_FOR_UPDATE_NO_WHERE is critical",
+			sql:              "SELECT id FROM t FOR UPDATE",
+			expectedSeverity: SeverityCritical,
+		},
+		{
+			name:             "SELECT_FOR_SHARE_NO_WHERE is high",
+			sql:              "SELECT id FROM t FOR SHARE",
+			expectedSeverity: SeverityHigh,
+		},
 	}
 
 	for _, tc := range tests {
@@ -174,4 +269,19 @@ func TestDropTableMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	require.Contains(t, findings[0].Message, "users")
+}
+
+func TestDropDatabaseMessage(t *testing.T) {
+	findings, err := Analyze("DROP DATABASE inventory")
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, "inventory")
+}
+
+func TestAlterTableDropColumnMessage(t *testing.T) {
+	findings, err := Analyze("ALTER TABLE users DROP COLUMN email")
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, "users")
+	require.Contains(t, findings[0].Message, "email")
 }


### PR DESCRIPTION
## Summary

Extend the AST-only rule registry with four checks derived from CockroachDB's `sql_safe_updates` session variable that were not covered by the initial rule set in #24:

- `SELECT_FOR_UPDATE_NO_WHERE` (critical) — `SELECT ... FOR UPDATE` without WHERE or LIMIT locks every row in the table.
- `SELECT_FOR_SHARE_NO_WHERE` (high) — same shape for FOR SHARE.
- `ALTER_TABLE_DROP_COLUMN` (high) — any DROP COLUMN inside an ALTER TABLE; emits one finding per dropped column.
- `DROP_DATABASE` (critical) — any DROP DATABASE.

The two locking rules share small `selectHasLockingStrength` and `selectHasWhere` helpers. `ALTER_TABLE_DROP_COLUMN` introduces a new `schema_safety` category alongside the existing `data_safety` bucket.

`selectHasWhere` conservatively returns false for non-`SelectClause` shapes (UNION, ParenSelect, VALUES). This means e.g. `(SELECT id FROM t WHERE id=1) FOR UPDATE` is still flagged — a deliberate AST-shape-only trade-off, documented and locked in by a regression test.

Resolves: #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)