### PR TITLE
cmd: auto-discover crdb-sql.yaml in describe when --schema is omitted

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -9,12 +9,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/config"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 )
 
@@ -47,7 +49,13 @@ Then describe any table:
 
 Use --schema - to read DDL from stdin, allowing direct piping:
 
-  cockroach sql -e 'SHOW CREATE ALL TABLES' | crdb-sql describe users --schema -`,
+  cockroach sql -e 'SHOW CREATE ALL TABLES' | crdb-sql describe users --schema -
+
+If no --schema is supplied and a crdb-sql.yaml config is present in
+the working directory (or pointed at by --config), describe expands
+the config's schema globs across all sql pairs into one combined
+catalog and looks up the table there. Explicit --schema flags win
+outright (no merging with config-discovered files).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
@@ -55,9 +63,36 @@ Use --schema - to read DDL from stdin, allowing direct piping:
 				return r.RenderError(baseEnv, err)
 			}
 
+			tableName := args[0]
+
+			// Config fallback: when no explicit --schema is given but a
+			// crdb-sql.yaml has been auto-discovered (or pointed at by
+			// --config), expand every pair's schema globs into one
+			// catalog. Explicit --schema flags continue to win outright.
+			if len(schemaFiles) == 0 && state.cfg != nil {
+				paths, err := expandConfigSchemaPaths(state.cfg)
+				if err != nil {
+					return r.RenderError(baseEnv, err)
+				}
+				if len(paths) == 0 {
+					// Config was loaded but its globs matched no files.
+					// Distinguish this from the no-config case so users
+					// don't waste time wondering whether their config was
+					// even discovered.
+					return r.RenderError(baseEnv,
+						fmt.Errorf("crdb-sql.yaml at %s has no schema files matching its globs; check the schema patterns or pass --schema explicitly",
+							state.cfg.BaseDir))
+				}
+				cat, err := catalog.LoadFiles(paths)
+				if err != nil {
+					return renderSchemaLoadError(r, baseEnv, err)
+				}
+				return describeTableFromCatalog(r, baseEnv, cat, tableName)
+			}
+
 			if len(schemaFiles) == 0 {
 				return r.RenderError(baseEnv,
-					fmt.Errorf("at least one --schema file is required"))
+					fmt.Errorf("at least one --schema file is required (or a crdb-sql.yaml with matching schema globs)"))
 			}
 
 			sources, err := buildSchemaSources(schemaFiles, cmd.InOrStdin())
@@ -70,30 +105,7 @@ Use --schema - to read DDL from stdin, allowing direct piping:
 				return renderSchemaLoadError(r, baseEnv, err)
 			}
 
-			appendSchemaWarnings(&baseEnv, cat)
-
-			tableName := args[0]
-			tbl, ok := cat.Table(tableName)
-			if !ok {
-				available := cat.TableNames()
-				if len(available) == 0 {
-					return r.RenderError(baseEnv,
-						fmt.Errorf("table %q not found; schema files contain no tables", tableName))
-				}
-				return r.RenderError(baseEnv,
-					fmt.Errorf("table %q not found; available tables: %s",
-						tableName, strings.Join(available, ", ")))
-			}
-
-			data, err := json.Marshal(tbl)
-			if err != nil {
-				return r.RenderError(baseEnv, err)
-			}
-			baseEnv.Data = data
-
-			return r.Render(baseEnv, func(w io.Writer) error {
-				return renderTableText(w, tbl)
-			})
+			return describeTableFromCatalog(r, baseEnv, cat, tableName)
 		},
 	}
 
@@ -134,6 +146,65 @@ func buildSchemaSources(flags []string, stdin io.Reader) ([]catalog.SchemaSource
 		})
 	}
 	return sources, nil
+}
+
+// describeTableFromCatalog renders one table from cat through the
+// standard envelope. Schema-load warnings on cat are appended to the
+// envelope first so they ride along regardless of lookup outcome.
+// "Not found" errors include the available table list to nudge users
+// toward the right name (e.g. case or pluralization typos).
+func describeTableFromCatalog(
+	r output.Renderer, baseEnv output.Envelope, cat *catalog.Catalog, tableName string,
+) error {
+	appendSchemaWarnings(&baseEnv, cat)
+
+	tbl, ok := cat.Table(tableName)
+	if !ok {
+		available := cat.TableNames()
+		if len(available) == 0 {
+			return r.RenderError(baseEnv,
+				fmt.Errorf("table %q not found; schema files contain no tables", tableName))
+		}
+		return r.RenderError(baseEnv,
+			fmt.Errorf("table %q not found; available tables: %s",
+				tableName, strings.Join(available, ", ")))
+	}
+
+	data, err := json.Marshal(tbl)
+	if err != nil {
+		return r.RenderError(baseEnv, err)
+	}
+	baseEnv.Data = data
+
+	return r.Render(baseEnv, func(w io.Writer) error {
+		return renderTableText(w, tbl)
+	})
+}
+
+// expandConfigSchemaPaths flattens every SQLPair's schema globs into
+// one sorted, deduplicated path list. Each pair's ExpandSchema already
+// dedupes within itself; the outer map handles overlap across pairs
+// (e.g. two pairs both matching schema/shared/*.sql). The final
+// sort.Strings is needed because concatenation across pairs breaks
+// the per-pair ordering that ExpandSchema guarantees individually.
+func expandConfigSchemaPaths(cfg *config.File) ([]string, error) {
+	seen := make(map[string]struct{})
+	var paths []string
+	for _, pair := range cfg.SQL {
+		expanded, err := pair.ExpandSchema(cfg.BaseDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range expanded {
+			if _, dup := seen[p]; dup {
+				continue
+			}
+			seen[p] = struct{}{}
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
 }
 
 func renderTableText(w io.Writer, tbl catalog.Table) error {

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -144,6 +144,10 @@ func TestDescribeCmdJSONIndexes(t *testing.T) {
 }
 
 func TestDescribeCmdMissingSchemaFlag(t *testing.T) {
+	// Run from a directory with no crdb-sql.yaml so the config branch
+	// is inert and the explicit-schema requirement applies.
+	t.Chdir(t.TempDir())
+
 	root := newRootCmd()
 	var stdout bytes.Buffer
 	root.SetOut(&stdout)
@@ -157,6 +161,7 @@ func TestDescribeCmdMissingSchemaFlag(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.NotEmpty(t, env.Errors)
 	require.Contains(t, env.Errors[0].Message, "--schema")
+	require.Contains(t, env.Errors[0].Message, "crdb-sql.yaml")
 }
 
 func TestDescribeCmdTableNotFound(t *testing.T) {
@@ -365,6 +370,255 @@ func TestDescribeCmdParseError(t *testing.T) {
 	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
 	root.SetArgs([]string{"describe", "bad", "--schema", schema, "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "parse schema")
+}
+
+// setupDescribeConfigProject lays down a tiny project with one schema
+// file and a crdb-sql.yaml that picks it up by glob. Mirrors
+// setupValidateConfigProject. Queries are intentionally absent —
+// describe doesn't read them.
+func setupDescribeConfigProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT8 PRIMARY KEY, email VARCHAR(255) NOT NULL);\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+	return dir
+}
+
+func TestDescribeCmdConfigText(t *testing.T) {
+	dir := setupDescribeConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	got := stdout.String()
+	require.Contains(t, got, "Table: users")
+	require.Contains(t, got, "email")
+	require.Contains(t, got, "Primary Key: id")
+}
+
+func TestDescribeCmdConfigJSON(t *testing.T) {
+	dir := setupDescribeConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Empty(t, env.Errors)
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "users", tbl.Name)
+	require.Len(t, tbl.Columns, 2)
+	require.Equal(t, []string{"id"}, tbl.PrimaryKey)
+}
+
+func TestDescribeCmdConfigTableNotFound(t *testing.T) {
+	dir := setupDescribeConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "nope",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, `"nope" not found`)
+	require.Contains(t, env.Errors[0].Message, "users")
+}
+
+func TestDescribeCmdConfigEmptyExpansion(t *testing.T) {
+	// Config is loaded but its globs match nothing. The error must name
+	// the config (not the no-config message) so users can tell their
+	// config was discovered and the globs are the problem.
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "crdb-sql.yaml")
+	require.Contains(t, env.Errors[0].Message, "no schema files matching")
+	require.Contains(t, env.Errors[0].Message, dir)
+}
+
+func TestDescribeCmdExplicitSchemaWinsOverConfig(t *testing.T) {
+	// Config points at a schema with table "users"; --schema points
+	// at a different file with table "orders". The explicit flag must
+	// win outright (no merging), so describing "users" should fail
+	// with table-not-found.
+	dir := setupDescribeConfigProject(t)
+	override := writeSchemaFile(t, `CREATE TABLE orders (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+		"--schema", override,
+		"--output", "json",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, `"users" not found`)
+	require.Contains(t, env.Errors[0].Message, "orders")
+}
+
+// TestDescribeCmdConfigMultiPairDedup is the only test that exercises
+// the cross-pair deduplication in expandConfigSchemaPaths. Two pairs
+// share the same schema glob; without the outer dedup map, the shared
+// file would be loaded twice and catalog.LoadFiles would surface a
+// duplicate-table error.
+func TestDescribeCmdConfigMultiPairDedup(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT8 PRIMARY KEY);\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+  - schema: ["schema/users.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors, "duplicate-table errors indicate dedup failed")
+
+	var tbl catalog.Table
+	require.NoError(t, json.Unmarshal(env.Data, &tbl))
+	require.Equal(t, "users", tbl.Name)
+}
+
+// TestDescribeCmdConfigBadGlob covers the err-return inside
+// expandConfigSchemaPaths' loop. A malformed pattern (unmatched `[`)
+// makes doublestar.FilepathGlob return ErrBadPattern; the rendered
+// envelope must surface that as an error rather than silently
+// producing an empty path list.
+func TestDescribeCmdConfigBadGlob(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/["]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "users",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "expand glob")
+}
+
+// TestDescribeCmdConfigSchemaParseError covers the renderSchemaLoadError
+// path in the config branch: a glob-matched file with malformed DDL must
+// produce a parse-error envelope, not a "table not found".
+func TestDescribeCmdConfigSchemaParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/bad.sql", "CREAT TABLE oops (id INT8)")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"describe", "oops",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
 
 	err := root.Execute()
 	require.Error(t, err)


### PR DESCRIPTION
Mirror validate's config-driven path in describe. When no `--schema`
flag is given but `state.cfg` is non-nil (auto-discovered from CWD or
pointed at by `--config`), expand `cfg.SQL[*].Schema` globs across all
pairs into one deduplicated list and feed it to `catalog.LoadFiles`.
Explicit `--schema` flags continue to win outright with no merging.

Combining all pairs into a single catalog (rather than iterating
per-pair like validate) is appropriate here because describe produces
one output for one table: per-pair iteration would force an arbitrary
"which pair wins" rule, while one catalog lets duplicate-table
detection surface uniformly.

When the config is loaded but its globs match nothing, the rendered
error names the config's `BaseDir` and the "no schema files matching"
condition so users can tell their config was discovered (and the globs
are the problem) versus the no-config case.

Resolves: #91