### PR TITLE
diag: add Levenshtein "did you mean?" suggestions

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -354,9 +354,10 @@ func renderConfigText(w io.Writer, results []fileResult, errs []output.Error) er
 					fr.File, pos.Line, pos.Column, e.Message, e.Code); err != nil {
 					return err
 				}
-				continue
+			} else if _, err := fmt.Fprintf(w, "%s: %s [%s]\n", fr.File, e.Message, e.Code); err != nil {
+				return err
 			}
-			if _, err := fmt.Fprintf(w, "%s: %s [%s]\n", fr.File, e.Message, e.Code); err != nil {
+			if err := writeSuggestions(w, e.Suggestions); err != nil {
 				return err
 			}
 		}
@@ -392,10 +393,29 @@ func renderDiagErrors(r output.Renderer, env output.Envelope, errs []output.Erro
 					return werr
 				}
 			}
+			if werr := writeSuggestions(w, diagErr.Suggestions); werr != nil {
+				return werr
+			}
 		}
 		return nil
 	}); err != nil {
 		return err
 	}
 	return output.ErrRendered
+}
+
+// writeSuggestions prints structured "did you mean?" suggestions
+// underneath an error in text mode. Each suggestion gets one indented
+// line with the replacement and a percentage confidence — terse
+// enough to stay readable when many errors stack up, structured
+// enough that grep/awk can pick the lines out by the leading "  did
+// you mean: " prefix.
+func writeSuggestions(w io.Writer, suggs []output.Suggestion) error {
+	for _, s := range suggs {
+		if _, err := fmt.Fprintf(w, "  did you mean: %s (%d%% confidence)\n",
+			s.Replacement, int(s.Confidence*100+0.5)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -140,6 +140,67 @@ func TestValidateCmdJSONError(t *testing.T) {
 	require.Equal(t, 11, diagErr.Position.ByteOffset)
 }
 
+// TestValidateCmdSuggestionsJSON verifies that name-resolution errors
+// surface structured suggestions through the JSON envelope. Anchors
+// the end-to-end wiring of #15: semcheck attaches Suggestions, the
+// envelope serializes the field with the expected replacement and
+// byte range.
+func TestValidateCmdSuggestionsJSON(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeFile(t, dir, "schema.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY, name TEXT);\n")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--schema", schema,
+		"-e", "SELECT nme FROM users",
+	})
+
+	require.ErrorIs(t, root.Execute(), output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "42703", env.Errors[0].Code)
+	require.NotEmpty(t, env.Errors[0].Suggestions)
+	first := env.Errors[0].Suggestions[0]
+	require.Equal(t, "name", first.Replacement)
+	require.Equal(t, 7, first.Range.Start)
+	require.Equal(t, 10, first.Range.End)
+	require.Equal(t, "levenshtein_distance_1", first.Reason)
+}
+
+// TestValidateCmdSuggestionsText verifies that text-mode rendering
+// prints "did you mean: X" lines under errors. Locks in the renderer
+// tweak so a future refactor cannot silently drop the field.
+func TestValidateCmdSuggestionsText(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeFile(t, dir, "schema.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY, name TEXT);\n")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--schema", schema,
+		"-e", "SELECT nme FROM users",
+	})
+
+	require.ErrorIs(t, root.Execute(), output.ErrRendered)
+	// Lock both the replacement and the percentage format. A future
+	// refactor that drops the "(NN% confidence)" suffix or shifts
+	// rounding (e.g. removing the +0.5 bias) would silently change
+	// every text-mode user's output without this assertion.
+	require.Contains(t, stdout.String(), "did you mean: name (75% confidence)")
+}
+
 // TestValidateCmdExprFlag verifies the -e flag path.
 func TestValidateCmdExprFlag(t *testing.T) {
 	root := newRootCmd()

--- a/internal/diag/suggest.go
+++ b/internal/diag/suggest.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// maxSuggestions caps the number of structured fixes returned per
+// error. Three is enough to cover the common "1-2 close matches"
+// pattern without flooding the response with low-confidence noise.
+const maxSuggestions = 3
+
+// Suggest returns up to three "did you mean?" fix suggestions for
+// the misspelled token, ranked by Levenshtein edit distance against
+// candidates.
+//
+// Suggestions are filtered by a length-scaled threshold: short names
+// permit fewer edits (e.g. distance 2 between "id" and "od" is too
+// loose to be useful), longer names tolerate up to three. The full
+// rule lives in maxDistance.
+//
+// Returns nil when:
+//   - misspelled is empty;
+//   - pos is nil (no byte range can be computed, so the suggestion
+//     cannot be applied programmatically by the agent);
+//   - candidates is empty;
+//   - no candidate is within the length-scaled threshold.
+//
+// Per-candidate filtering: empty strings and case-insensitive exact
+// matches against misspelled are skipped (they don't represent a
+// useful fix). If every candidate is filtered, the function returns
+// nil along the "no candidate within threshold" path.
+//
+// The returned Range covers [pos.ByteOffset, pos.ByteOffset +
+// len(misspelled)) in the original SQL input. Confidence is in [0, 1]
+// and rounded to two decimals.
+//
+// candidates is read but not retained, and Suggestion.Replacement
+// borrows the underlying string from candidates (Go strings are
+// immutable, so this is safe for typical []string callers).
+func Suggest(misspelled string, candidates []string, pos *output.Position) []output.Suggestion {
+	if misspelled == "" || pos == nil || len(candidates) == 0 {
+		return nil
+	}
+
+	limit := maxDistance(len(misspelled))
+	type scored struct {
+		name     string
+		distance int
+	}
+	var hits []scored
+	for _, cand := range candidates {
+		if cand == "" || strings.EqualFold(cand, misspelled) {
+			continue
+		}
+		// Length pre-filter: a difference larger than the threshold
+		// means at least that many edits are required, so skip the
+		// O(n*m) DP.
+		if absDiff(len(cand), len(misspelled)) > limit {
+			continue
+		}
+		d := levenshtein(strings.ToLower(misspelled), strings.ToLower(cand))
+		if d > limit {
+			continue
+		}
+		hits = append(hits, scored{name: cand, distance: d})
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].distance != hits[j].distance {
+			return hits[i].distance < hits[j].distance
+		}
+		return hits[i].name < hits[j].name
+	})
+	if len(hits) > maxSuggestions {
+		hits = hits[:maxSuggestions]
+	}
+
+	rng := output.Range{
+		Start: pos.ByteOffset,
+		End:   pos.ByteOffset + len(misspelled),
+	}
+	out := make([]output.Suggestion, len(hits))
+	for i, h := range hits {
+		out[i] = output.Suggestion{
+			Replacement: h.name,
+			Range:       rng,
+			Confidence:  confidence(h.distance, max(len(misspelled), len(h.name))),
+			Reason:      fmt.Sprintf("levenshtein_distance_%d", h.distance),
+		}
+	}
+	return out
+}
+
+// maxDistance returns the largest edit distance accepted for a
+// misspelled token of the given length. The rule scales with name
+// length so short tokens don't get spurious "fixes":
+//
+//	len ≤ 3 → 1
+//	len ≤ 6 → 2
+//	len ≥ 7 → 3
+//
+// Three is the cap; beyond that the candidate is too dissimilar to
+// be a useful "did you mean?" hit and would dilute the signal.
+func maxDistance(nameLen int) int {
+	switch {
+	case nameLen <= 3:
+		return 1
+	case nameLen <= 6:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// confidence maps an edit distance to a [0, 1] score, rounded to two
+// decimals. The formula `1 - distance/maxLen` is a heuristic, not a
+// contract — agents that branch on confidence should treat the
+// numeric value as an ordering, not an absolute probability.
+func confidence(distance, maxLen int) float64 {
+	if maxLen == 0 {
+		return 0
+	}
+	c := 1.0 - float64(distance)/float64(maxLen)
+	return math.Round(c*100) / 100
+}
+
+// levenshtein returns the edit distance between a and b using a
+// two-row DP. Both inputs are walked as bytes; callers fold case
+// before invoking when ASCII case-insensitive comparison is desired.
+// Multi-byte UTF-8 sequences are compared byte-wise — adequate for
+// SQL identifiers, which are predominantly ASCII.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func absDiff(a, b int) int {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/diag/suggest_test.go
+++ b/internal/diag/suggest_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package diag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// pos is a tiny helper so test cases can declare positions inline
+// without repeating the struct literal.
+func pos(byteOffset int) *output.Position {
+	return &output.Position{Line: 1, Column: byteOffset + 1, ByteOffset: byteOffset}
+}
+
+func TestSuggest(t *testing.T) {
+	tests := []struct {
+		name             string
+		misspelled       string
+		candidates       []string
+		position         *output.Position
+		expectedCount    int
+		expectedFirst    string  // first replacement, when expectedCount > 0
+		expectedReason   string  // first reason, when expectedCount > 0
+		expectedConf     float64 // first confidence, when expectedCount > 0
+		expectedRangeEnd int     // first range.End, when expectedCount > 0
+	}{
+		{
+			name:             "distance 1 in middle bucket",
+			misspelled:       "nme",
+			candidates:       []string{"name", "id", "email"},
+			position:         pos(7),
+			expectedCount:    1,
+			expectedFirst:    "name",
+			expectedReason:   "levenshtein_distance_1",
+			expectedConf:     0.75, // 1 - 1/4
+			expectedRangeEnd: 10,
+		},
+		{
+			name:           "distance 1 in long bucket",
+			misspelled:     "username",
+			candidates:     []string{"user_name"},
+			position:       pos(0),
+			expectedCount:  1,
+			expectedFirst:  "user_name",
+			expectedReason: "levenshtein_distance_1",
+		},
+		{
+			name:           "distance 2 in middle bucket",
+			misspelled:     "emial",
+			candidates:     []string{"email"}, // transposition counts as 2 edits
+			position:       pos(0),
+			expectedCount:  1,
+			expectedFirst:  "email",
+			expectedReason: "levenshtein_distance_2",
+		},
+		{
+			name:          "short name rejects distance 2",
+			misspelled:    "xy",
+			candidates:    []string{"name", "id"},
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:           "distance 3 in long bucket",
+			misspelled:     "usrname",
+			candidates:     []string{"username"},
+			position:       pos(0),
+			expectedCount:  1,
+			expectedFirst:  "username",
+			expectedReason: "levenshtein_distance_1",
+		},
+		{
+			name:          "rejects distance 4 even in long bucket",
+			misspelled:    "completely",
+			candidates:    []string{"different"},
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:           "case-insensitive distance match",
+			misspelled:     "NAEM",
+			candidates:     []string{"name"},
+			position:       pos(0),
+			expectedCount:  1,
+			expectedFirst:  "name",
+			expectedReason: "levenshtein_distance_2",
+		},
+		{
+			name:          "case-insensitive exact match returns nil",
+			misspelled:    "NAME",
+			candidates:    []string{"name"},
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:          "exact match returns nil",
+			misspelled:    "name",
+			candidates:    []string{"name"},
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:          "nil position returns nil",
+			misspelled:    "nme",
+			candidates:    []string{"name"},
+			position:      nil,
+			expectedCount: 0,
+		},
+		{
+			name:          "empty misspelled returns nil",
+			misspelled:    "",
+			candidates:    []string{"name"},
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:          "empty candidates returns nil",
+			misspelled:    "nme",
+			candidates:    nil,
+			position:      pos(0),
+			expectedCount: 0,
+		},
+		{
+			name:           "ranking by distance then name",
+			misspelled:     "names",
+			candidates:     []string{"namxs", "name", "namy"},
+			position:       pos(0),
+			expectedCount:  3,
+			expectedFirst:  "name", // distance 1, alphabetically first vs "namxs"
+			expectedReason: "levenshtein_distance_1",
+		},
+		{
+			name:          "caps at three suggestions",
+			misspelled:    "name",
+			candidates:    []string{"nama", "namb", "namc", "namd", "name1"},
+			position:      pos(0),
+			expectedCount: 3,
+			expectedFirst: "nama",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Suggest(tc.misspelled, tc.candidates, tc.position)
+			require.Len(t, got, tc.expectedCount)
+			if tc.expectedCount == 0 {
+				return
+			}
+			require.Equal(t, tc.expectedFirst, got[0].Replacement)
+			if tc.expectedReason != "" && tc.expectedReason != "levenshtein_distance_0" {
+				require.Equal(t, tc.expectedReason, got[0].Reason)
+			}
+			if tc.expectedConf != 0 {
+				require.InDelta(t, tc.expectedConf, got[0].Confidence, 0.001)
+			}
+			if tc.expectedRangeEnd != 0 {
+				require.Equal(t, tc.expectedRangeEnd, got[0].Range.End)
+				require.Equal(t, tc.position.ByteOffset, got[0].Range.Start)
+			}
+		})
+	}
+}
+
+func TestSuggestRangeCoversMisspelled(t *testing.T) {
+	// Lock in the byte-range invariant: Range covers exactly
+	// [pos.ByteOffset, pos.ByteOffset + len(misspelled)) so an agent
+	// can apply the replacement by slicing the original SQL.
+	got := Suggest("nme", []string{"name"}, pos(7))
+	require.Len(t, got, 1)
+	require.Equal(t, output.Range{Start: 7, End: 10}, got[0].Range)
+}
+
+func TestMaxDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		nameLen  int
+		expected int
+	}{
+		{name: "single char", nameLen: 1, expected: 1},
+		{name: "boundary 3", nameLen: 3, expected: 1},
+		{name: "boundary 4", nameLen: 4, expected: 2},
+		{name: "boundary 6", nameLen: 6, expected: 2},
+		{name: "boundary 7", nameLen: 7, expected: 3},
+		{name: "long name", nameLen: 50, expected: 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, maxDistance(tc.nameLen))
+		})
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		expected int
+	}{
+		{name: "identical", a: "name", b: "name", expected: 0},
+		{name: "single substitution", a: "name", b: "namx", expected: 1},
+		{name: "single deletion", a: "name", b: "nam", expected: 1},
+		{name: "single insertion", a: "nme", b: "name", expected: 1},
+		{name: "two edits", a: "nme", b: "names", expected: 2},
+		{name: "empty a", a: "", b: "abc", expected: 3},
+		{name: "empty b", a: "abc", b: "", expected: 3},
+		{name: "both empty", a: "", b: "", expected: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, levenshtein(tc.a, tc.b))
+		})
+	}
+}

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -201,6 +201,52 @@ func TestIntegrationValidateSQL(t *testing.T) {
 		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{})
 		require.True(t, res.IsError, "missing required param must surface as tool error, got: %s", textOf(res))
 	})
+
+	// The next two cases cover the wiring added in #15: column errors
+	// reach the MCP envelope (closing a pre-existing gap where only
+	// CheckTableNames ran in this handler) and carry structured
+	// "did you mean?" suggestions.
+	t.Run("column typo surfaces suggestion", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{
+			"sql":     "SELECT nme FROM users",
+			"schemas": []any{map[string]any{"sql": usersSchema}},
+		})
+		env := decodeEnvelope(t, res)
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, "42703", env.Errors[0].Code)
+		require.NotEmpty(t, env.Errors[0].Suggestions)
+		require.Equal(t, "name", env.Errors[0].Suggestions[0].Replacement)
+	})
+
+	t.Run("table typo surfaces suggestion", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{
+			"sql":     "SELECT * FROM usrs",
+			"schemas": []any{map[string]any{"sql": usersSchema}},
+		})
+		env := decodeEnvelope(t, res)
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, "42P01", env.Errors[0].Code)
+		require.NotEmpty(t, env.Errors[0].Suggestions)
+		require.Equal(t, "users", env.Errors[0].Suggestions[0].Replacement)
+	})
+
+	// Regression guard: lock in that CheckColumnNames runs in the MCP
+	// handler at all, independent of whether a suggestion is produced.
+	// A future refactor that removes the CheckColumnNames call would
+	// make the suggestion-bearing tests above ambiguous (the column
+	// error might still leak through some other path), so a wholly
+	// unrelated column name — for which Suggest will return no
+	// candidates — locks the wiring on its own.
+	t.Run("unrelated column name still produces 42703", func(t *testing.T) {
+		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{
+			"sql":     "SELECT completely_unrelated_xyzzy FROM users",
+			"schemas": []any{map[string]any{"sql": usersSchema}},
+		})
+		env := decodeEnvelope(t, res)
+		require.Len(t, env.Errors, 1)
+		require.Equal(t, "42703", env.Errors[0].Code)
+		require.Empty(t, env.Errors[0].Suggestions, "no candidate is close enough to suggest")
+	})
 }
 
 // TestIntegrationFormatSQL covers pretty-printing on the happy path

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -104,7 +104,9 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 				return envelopeResult(env)
 			}
 			schemawarn.Append(&env, cat)
-			if nameErrs := semcheck.CheckTableNames(stmts, sql, cat); len(nameErrs) > 0 {
+			nameErrs := semcheck.CheckTableNames(stmts, sql, cat)
+			nameErrs = append(nameErrs, semcheck.CheckColumnNames(stmts, sql, cat)...)
+			if len(nameErrs) > 0 {
 				env.Errors = append(env.Errors, nameErrs...)
 				return envelopeResult(env)
 			}

--- a/internal/semcheck/names.go
+++ b/internal/semcheck/names.go
@@ -174,15 +174,18 @@ func (v *tableNameVisitor) checkTable(tn *tree.TableName) {
 	}
 	v.seen[key] = struct{}{}
 
+	pos := v.positionFor(name)
+	tables := v.availableTables()
 	*v.errs = append(*v.errs, output.Error{
 		Code:     unknownTableCode,
 		Severity: output.SeverityError,
 		Message:  fmt.Sprintf("relation %q does not exist", name),
-		Position: v.positionFor(name),
+		Position: pos,
 		Category: diag.CategoryUnknownTable,
 		Context: map[string]any{
-			"available_tables": v.availableTables(),
+			"available_tables": tables,
 		},
+		Suggestions: diag.Suggest(name, tables, pos),
 	})
 }
 
@@ -769,13 +772,14 @@ func (c *columnChecker) addTableExpr(sc *scope, te tree.TableExpr) {
 			for _, name := range cond.Cols {
 				colName := string(name)
 				if !columnExistsInScope(sc, colName) {
-					c.report(columnRef{name: colName}, output.Error{
+					cols := availableColumns(sc)
+					c.report(columnRef{name: colName}, cols, output.Error{
 						Code:     unknownColumnCode,
 						Severity: output.SeverityError,
 						Message:  fmt.Sprintf("column %q does not exist", colName),
 						Category: diag.CategoryUnknownColumn,
 						Context: map[string]any{
-							"available_columns": availableColumns(sc),
+							"available_columns": cols,
 						},
 					})
 				}
@@ -908,14 +912,17 @@ func (c *columnChecker) resolveRef(ref columnRef, sc *scope) {
 func (c *columnChecker) resolveQualified(ref columnRef, sc *scope) {
 	src, found := lookupSource(sc, ref.qualifier)
 	if !found {
-		c.report(ref, output.Error{
+		// The typo is the qualifier, not the column. Suggestions and
+		// the source-position lookup target the qualifier token.
+		aliases := availableAliases(sc)
+		c.reportFor(ref.qualifier, ref.qualifier, aliases, output.Error{
 			Code:     unknownColumnCode,
 			Severity: output.SeverityError,
 			Message:  fmt.Sprintf("missing FROM-clause entry for table %q", ref.qualifier),
 			Category: diag.CategoryUnknownColumn,
 			Context: map[string]any{
 				"missing_table":    ref.qualifier,
-				"available_tables": availableAliases(sc),
+				"available_tables": aliases,
 			},
 		})
 		return
@@ -926,7 +933,7 @@ func (c *columnChecker) resolveQualified(ref columnRef, sc *scope) {
 	if containsFold(src.columns, ref.name) {
 		return
 	}
-	c.report(ref, output.Error{
+	c.report(ref, src.columns, output.Error{
 		Code:     unknownColumnCode,
 		Severity: output.SeverityError,
 		Message:  fmt.Sprintf("column %q does not exist", ref.name),
@@ -953,7 +960,9 @@ func (c *columnChecker) resolveUnqualified(ref columnRef, sc *scope) {
 	case len(matches) == 1:
 		return
 	case len(matches) >= 2:
-		c.report(ref, output.Error{
+		// Spelling isn't the problem here — the ref matched two real
+		// sources. Suggestions would be misleading, so pass nil.
+		c.report(ref, nil, output.Error{
 			Code:     ambiguousColumnCode,
 			Severity: output.SeverityError,
 			Message:  fmt.Sprintf("column reference %q is ambiguous", ref.name),
@@ -969,32 +978,53 @@ func (c *columnChecker) resolveUnqualified(ref columnRef, sc *scope) {
 			// belong to it. Skip rather than false-positive.
 			return
 		}
-		c.report(ref, output.Error{
+		cols := availableColumns(sc)
+		c.report(ref, cols, output.Error{
 			Code:     unknownColumnCode,
 			Severity: output.SeverityError,
 			Message:  fmt.Sprintf("column %q does not exist", ref.name),
 			Category: diag.CategoryUnknownColumn,
 			Context: map[string]any{
-				"available_columns": availableColumns(sc),
+				"available_columns": cols,
 			},
 		})
 	}
 }
 
-// report deduplicates by lowercased "qualifier.name" and attaches the
-// position computed against the statement currently being checked.
-// The reported position is therefore the first non-duplicate
-// occurrence of the (qualifier, column) pair in input order — i.e. in
-// the first statement where the pair appears, not necessarily the
-// textually-first occurrence in the input. Position uses the same
-// word-boundary-aware substring search as the table walker.
-func (c *columnChecker) report(ref columnRef, e output.Error) {
-	key := strings.ToLower(ref.qualifier + "." + ref.name)
+// report is a thin wrapper around reportFor for the common case
+// where the misspelled token is the column name and dedup is by
+// "qualifier.name". Pass nil candidates to skip the suggestion
+// lookup (e.g. ambiguous-ref errors, where spelling is not the
+// issue).
+func (c *columnChecker) report(ref columnRef, candidates []string, e output.Error) {
+	c.reportFor(ref.qualifier+"."+ref.name, ref.name, candidates, e)
+}
+
+// reportFor records one error in the accumulator, deduplicating by a
+// lowercased dedupKey and attaching the position of misspelled in the
+// current statement plus any "did you mean?" suggestions derived from
+// candidates.
+//
+// The dedup key is opaque to reportFor: report passes "qualifier.name"
+// for column-not-found errors so two textually-distinct occurrences
+// of the same typo collapse to one envelope entry; resolveQualified
+// passes the bare qualifier when the qualifier itself is the typo so
+// "missing FROM-clause entry for table z" appears once even when
+// referenced multiple times.
+//
+// The reported position is the first non-duplicate occurrence in
+// input order — i.e. in the first statement where the dedup key
+// appears, not necessarily the textually-first occurrence across
+// statements. Position uses the same word-boundary-aware substring
+// search as the table walker.
+func (c *columnChecker) reportFor(dedupKey, misspelled string, candidates []string, e output.Error) {
+	key := strings.ToLower(dedupKey)
 	if _, dup := c.seen[key]; dup {
 		return
 	}
 	c.seen[key] = struct{}{}
-	e.Position = c.positionFor(ref.name)
+	e.Position = c.positionFor(misspelled)
+	e.Suggestions = diag.Suggest(misspelled, candidates, e.Position)
 	*c.errs = append(*c.errs, e)
 }
 

--- a/internal/semcheck/names_test.go
+++ b/internal/semcheck/names_test.go
@@ -641,3 +641,207 @@ func TestCheckColumnNamesEmptyStatements(t *testing.T) {
 	cat := usersAndOrdersCatalog(t)
 	require.Empty(t, CheckColumnNames(nil, "", cat))
 }
+
+// TestCheckTableNamesSuggestions covers the structured fix payload
+// added by issue #15 for unknown_table errors. Each case asserts the
+// first suggestion's replacement and (where relevant) that the byte
+// range covers the misspelled token in the input.
+func TestCheckTableNamesSuggestions(t *testing.T) {
+	cat := usersOnlyCatalog(t)
+	tests := []struct {
+		name                string
+		sql                 string
+		expectedFirst       string // first suggestion replacement; "" → expect none
+		expectedRangeStart  int
+		expectedRangeEnd    int
+		expectedSuggestions int
+	}{
+		{
+			name:                "close miss suggests users",
+			sql:                 "SELECT * FROM usrs",
+			expectedFirst:       "users",
+			expectedRangeStart:  14,
+			expectedRangeEnd:    18,
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "completely unrelated name yields no suggestion",
+			sql:                 "SELECT * FROM completely_different_thing",
+			expectedSuggestions: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			errs := CheckTableNames(stmts, tc.sql, cat)
+			require.Len(t, errs, 1)
+			require.Len(t, errs[0].Suggestions, tc.expectedSuggestions)
+			if tc.expectedSuggestions == 0 {
+				return
+			}
+			require.Equal(t, tc.expectedFirst, errs[0].Suggestions[0].Replacement)
+			require.Equal(t, tc.expectedRangeStart, errs[0].Suggestions[0].Range.Start)
+			require.Equal(t, tc.expectedRangeEnd, errs[0].Suggestions[0].Range.End)
+		})
+	}
+}
+
+// TestCheckColumnNamesSuggestions covers the structured fix payload
+// for unknown_column errors across the four call sites: qualified ref
+// against a known source, unqualified ref, USING-clause typo, and bad
+// qualifier (where the suggestion targets the qualifier itself).
+func TestCheckColumnNamesSuggestions(t *testing.T) {
+	cat := usersAndOrdersCatalog(t)
+	tests := []struct {
+		name                string
+		sql                 string
+		expectedFirst       string
+		expectedSuggestions int
+	}{
+		{
+			name:                "unqualified column typo suggests name",
+			sql:                 "SELECT nme FROM users",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "qualified column typo suggests name",
+			sql:                 "SELECT users.nme FROM users",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "USING clause typo suggests id",
+			sql:                 "SELECT * FROM users JOIN orders USING (idd)",
+			expectedFirst:       "id",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "bad qualifier suggests in-scope alias",
+			sql:                 "SELECT usrs.id FROM users",
+			expectedFirst:       "users",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "short typo below threshold yields no suggestion",
+			sql:                 "SELECT xy FROM users",
+			expectedSuggestions: 0,
+		},
+		{
+			name:                "ambiguous ref does not suggest",
+			sql:                 "SELECT id FROM users JOIN orders ON users.id = orders.user_id",
+			expectedSuggestions: 0,
+		},
+		{
+			name:                "INSERT target column typo suggests name",
+			sql:                 "INSERT INTO users (nme) VALUES ('x')",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "UPDATE SET LHS typo suggests name",
+			sql:                 "UPDATE users SET nme = 'x'",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "DELETE WHERE typo suggests name",
+			sql:                 "DELETE FROM users WHERE nme = 'x'",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "RETURNING typo suggests name",
+			sql:                 "INSERT INTO users (id) VALUES (1) RETURNING nme",
+			expectedFirst:       "name",
+			expectedSuggestions: 1,
+		},
+		{
+			name:                "ON CONFLICT target typo suggests id",
+			sql:                 "INSERT INTO users (id) VALUES (1) ON CONFLICT (idd) DO NOTHING",
+			expectedFirst:       "id",
+			expectedSuggestions: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			errs := CheckColumnNames(stmts, tc.sql, cat)
+			require.NotEmpty(t, errs)
+			require.Len(t, errs[0].Suggestions, tc.expectedSuggestions)
+			if tc.expectedSuggestions == 0 {
+				return
+			}
+			require.Equal(t, tc.expectedFirst, errs[0].Suggestions[0].Replacement)
+		})
+	}
+}
+
+// TestCheckColumnNamesSuggestionRange verifies that the suggestion's
+// byte range targets the correct occurrence of the misspelled token
+// across two important scenarios:
+//
+//   - When the typo appears multiple times in one statement, dedup
+//     records only one error and the range must point at the first
+//     occurrence (not span both, not point past them).
+//   - When the typo appears in the second of multiple statements,
+//     the range must be inside that statement's bytes, not the first
+//     statement's bytes.
+//
+// Both invariants are load-bearing: an agent applies the fix by
+// slicing sql[Range.Start:Range.End] and replacing it. A wrong offset
+// corrupts the SQL.
+func TestCheckColumnNamesSuggestionRange(t *testing.T) {
+	cat := usersAndOrdersCatalog(t)
+	tests := []struct {
+		name               string
+		sql                string
+		expectedRangeStart int
+		expectedRangeEnd   int
+		expectedToken      string
+	}{
+		{
+			name:               "multiple occurrences pin range to first",
+			sql:                "SELECT nme FROM users WHERE nme = 'x'",
+			expectedRangeStart: 7,
+			expectedRangeEnd:   10,
+			expectedToken:      "nme",
+		},
+		{
+			name:               "typo in second statement uses second-statement offset",
+			sql:                "SELECT id FROM users; SELECT nme FROM users",
+			expectedRangeStart: 29,
+			expectedRangeEnd:   32,
+			expectedToken:      "nme",
+		},
+		{
+			// The bad-qualifier site routes through reportFor with the
+			// qualifier as both dedup key and misspelled token. A
+			// regression that mistakenly passes ref.name would point
+			// the range at "id" (bytes 12-14) and an agent applying
+			// the suggestion would corrupt the SQL into "users.users".
+			name:               "bad qualifier targets qualifier bytes, not column bytes",
+			sql:                "SELECT usrs.id FROM users",
+			expectedRangeStart: 7,
+			expectedRangeEnd:   11,
+			expectedToken:      "usrs",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			errs := CheckColumnNames(stmts, tc.sql, cat)
+			require.Len(t, errs, 1)
+			require.NotEmpty(t, errs[0].Suggestions)
+			require.Equal(t, tc.expectedRangeStart, errs[0].Suggestions[0].Range.Start)
+			require.Equal(t, tc.expectedRangeEnd, errs[0].Suggestions[0].Range.End)
+			// Sanity: the byte slice the agent would replace equals
+			// the misspelled token verbatim.
+			require.Equal(t, tc.expectedToken,
+				tc.sql[errs[0].Suggestions[0].Range.Start:errs[0].Suggestions[0].Range.End])
+		})
+	}
+}


### PR DESCRIPTION
diag: add Levenshtein "did you mean?" suggestions

Add diag.Suggest, a Levenshtein-based suggester that turns the
unknown-name candidate lists already attached to validate's errors
into structured fix proposals on output.Error.Suggestions. Each
suggestion carries a replacement, the byte range to overwrite, a
confidence score, and a machine-readable reason
(levenshtein_distance_N), so an agent can apply the fix in one
round-trip rather than parsing English error text and guessing.

The threshold is length-scaled and capped at three edits, per #15:
names of three chars or fewer permit at most one edit, four through
six permit two, seven and longer permit three. A length pre-filter
short-circuits the DP for candidates whose lengths differ by more
than the threshold. Results are sorted (distance asc, name asc) and
capped at three suggestions to keep responses focused. Confidence is
1 - distance/maxLen, rounded to two decimals; the formula is
documented as a heuristic, not a contract, so a future tweak isn't
read as a regression.

Suggestions are attached at four sites in semcheck/names.go:

  - tableNameVisitor.checkTable for unknown_table errors;
  - columnChecker.resolveQualified for both the missing-FROM-clause
    branch (suggests an in-scope alias for the qualifier itself) and
    the column-not-in-source branch (suggests from src.columns);
  - columnChecker.resolveUnqualified for unmatched bare refs;
  - the USING-clause path in addTableExpr.

The ambiguous-reference branch deliberately passes nil candidates:
when a ref matches two real sources, spelling is not the issue and a
"did you mean?" line would mislead. The columnChecker.report helper
gains a candidates parameter and forwards to a new reportFor variant
that lets the bad-qualifier site key both the position lookup and
the suggestion on the qualifier token rather than the column name.

When pos is nil (parser-rendered identifier not present verbatim in
the source), Suggest returns nil — without a byte range an agent
cannot apply the fix programmatically, and a suggestion without a
range would be worse than none.

Ride-along fixes needed for the demo to work end-to-end:

  - internal/mcp/tools/validate.go's handler called only
    CheckTableNames, never CheckColumnNames, so today the MCP
    surface returns no column errors at all (let alone column
    suggestions). Wire CheckColumnNames in alongside CheckTableNames
    so the MCP envelope matches the CLI's behavior.
  - cmd/validate.go's text-mode renderers (renderDiagErrors and
    renderConfigText) printed line:col: message [code] and dropped
    Suggestions on the floor. Add a writeSuggestions helper that
    emits one indented "  did you mean: X (N% confidence)" line per
    suggestion in both single-input and config-driven paths, so
    text-mode consumers see the same information JSON consumers do.

Tests cover all surfaces: 13 cases in internal/diag/suggest_test.go
exercise the algorithm, length buckets, ranking, top-3 cap, case
folding, and edge returns; eight new cases in
internal/semcheck/names_test.go exercise each unknown-name site
(including the bad-qualifier and USING paths) plus
ambiguous-suppression and threshold-rejection; two cases in
cmd/validate_test.go lock in the JSON envelope round-trip and the
text-mode "did you mean: name" line; two cases in
internal/mcp/integration_tools_test.go assert column and table
suggestions reach the MCP envelope, also catching any future
regression of the CheckColumnNames wire-up.

Resolves: #15
Informs: #107

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>