### PR TITLE
version: add feature registry for CockroachDB syntax/features

### DIFF
--- a/internal/version/registry.go
+++ b/internal/version/registry.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package version provides a registry of CockroachDB SQL features and
+// the versions in which they were introduced (or removed).
+//
+// The registry is pure metadata. It does not inspect SQL or AST
+// nodes; that is the job of the AST inspector layered on top of it
+// (see issue #84). The contract between the two layers is the
+// feature tag — a stable, machine-readable string that identifies a
+// SQL feature independent of how the parser represents it.
+//
+// Tags are named for the user-facing feature ("regional_by_row"),
+// not for the AST node ("create_table_locality_regional_by_row"),
+// because a single feature may surface in multiple AST shapes
+// (e.g. CREATE TABLE ... LOCALITY and ALTER TABLE ... SET LOCALITY).
+// Naming by feature lets one registry entry cover every AST shape
+// and produces warning messages a user will recognize.
+//
+// Lifecycle: a Registry is constructed once via NewRegistry (or
+// DefaultRegistry for the seeded set) and is immutable afterward.
+// Concurrent readers are safe; there is no mutation API.
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Feature describes a single CockroachDB SQL feature and the
+// version range in which it is available.
+//
+// Introduced and Removed are MAJOR.MINOR strings (e.g. "24.1") in
+// the same canonical form produced by output.ValidateTargetVersion.
+// Patch components are not stored: feature gating is a
+// minor-release-grained concern, and recording patch noise would
+// invite false positives for users who specify "25.4.3".
+//
+//   - Introduced == "" means "supported in every known version"
+//     (i.e. predates the registry's earliest entry of interest).
+//   - Removed == "" means "still supported in current versions".
+//
+// DocURL is optional and intended for warning messages emitted by
+// the AST inspector in #84.
+type Feature struct {
+	Tag        string
+	Name       string
+	Introduced string
+	Removed    string
+	DocURL     string
+}
+
+// Status reports whether a feature is available in a given target
+// version. Returned by Registry.Supports.
+type Status int
+
+// Status values.
+const (
+	// StatusUnknown means the queried tag is not registered. Callers
+	// that treat unknown tags as "do not warn" should check for this
+	// value explicitly rather than relying on a boolean.
+	//
+	// StatusUnknown is intentionally the zero value, as a deliberate
+	// exception to the project convention of starting enums at one.
+	// The zero value is load-bearing here: a Status read from an
+	// uninitialized variable, or returned for an unrecognized tag,
+	// must be safe to interpret as "do not warn." Renumbering would
+	// silently turn unknown lookups into StatusSupported.
+	StatusUnknown Status = iota
+
+	// StatusSupported means the target version is at or after the
+	// feature's Introduced version, and before any Removed version.
+	StatusSupported
+
+	// StatusNotYetIntroduced means the target version predates the
+	// feature's Introduced version. The AST inspector turns this
+	// into a "feature requires vX.Y+" warning.
+	StatusNotYetIntroduced
+
+	// StatusRemoved means the target version is at or after the
+	// feature's Removed version.
+	StatusRemoved
+)
+
+// Feature tag constants. These are the stable identifiers the AST
+// inspector (#84) emits when it recognizes a feature in parsed SQL.
+// Adding a new tag means adding both a constant here and a matching
+// Feature{Tag: ...} entry in DefaultRegistry; a test enforces that
+// every exported constant is registered.
+const (
+	FeaturePLpgSQLFunctionBody = "plpgsql_function_body"
+	FeatureTrigramIndex        = "trigram_index"
+	FeatureRegionalByRow       = "regional_by_row"
+	FeatureAlterChangefeed     = "alter_changefeed"
+)
+
+// Registry holds an immutable set of Feature entries, indexed by
+// tag for O(1) lookup. Build with NewRegistry or DefaultRegistry.
+type Registry struct {
+	byTag map[string]Feature
+}
+
+// NewRegistry constructs a Registry from the given features.
+//
+// It panics on misconfiguration so that registry mistakes surface at
+// init time rather than as silent StatusUnknown results at query
+// time. Specifically, it panics if any feature has an empty Tag, an
+// empty Name, a duplicate Tag, an unparseable Introduced or Removed
+// version, a non-empty Removed without a non-empty Introduced (the
+// "removed but never introduced" shape is undefined), or a Removed
+// version that is not strictly greater than Introduced.
+func NewRegistry(features ...Feature) *Registry {
+	byTag := make(map[string]Feature, len(features))
+	for _, f := range features {
+		if f.Tag == "" {
+			panic("version: feature has empty Tag")
+		}
+		if f.Name == "" {
+			panic(fmt.Sprintf("version: feature %q has empty Name", f.Tag))
+		}
+		if _, dup := byTag[f.Tag]; dup {
+			panic(fmt.Sprintf("version: duplicate Tag %q", f.Tag))
+		}
+		if f.Introduced != "" {
+			if _, ok := parseMajorMinor(f.Introduced); !ok {
+				panic(fmt.Sprintf("version: feature %q has invalid Introduced %q", f.Tag, f.Introduced))
+			}
+		}
+		if f.Removed != "" {
+			if f.Introduced == "" {
+				panic(fmt.Sprintf("version: feature %q has Removed %q without Introduced", f.Tag, f.Removed))
+			}
+			if _, ok := parseMajorMinor(f.Removed); !ok {
+				panic(fmt.Sprintf("version: feature %q has invalid Removed %q", f.Tag, f.Removed))
+			}
+			if compareMajorMinor(f.Removed, f.Introduced) <= 0 {
+				panic(fmt.Sprintf("version: feature %q has Removed %q <= Introduced %q",
+					f.Tag, f.Removed, f.Introduced))
+			}
+		}
+		byTag[f.Tag] = f
+	}
+	return &Registry{byTag: byTag}
+}
+
+// DefaultRegistry returns the seeded set of CockroachDB feature
+// entries. The set is intentionally small; it will grow over time as
+// the AST inspector learns to recognize more features.
+func DefaultRegistry() *Registry {
+	return NewRegistry(
+		Feature{
+			Tag:        FeaturePLpgSQLFunctionBody,
+			Name:       "PL/pgSQL function bodies",
+			Introduced: "24.1",
+		},
+		Feature{
+			Tag:        FeatureTrigramIndex,
+			Name:       "trigram indexes",
+			Introduced: "23.1",
+		},
+		Feature{
+			Tag:        FeatureRegionalByRow,
+			Name:       "REGIONAL BY ROW tables",
+			Introduced: "21.1",
+		},
+		Feature{
+			Tag:        FeatureAlterChangefeed,
+			Name:       "ALTER CHANGEFEED",
+			Introduced: "22.1",
+		},
+	)
+}
+
+// Lookup returns the Feature registered under tag, if any. The bool
+// is false when the tag is not registered.
+func (r *Registry) Lookup(tag string) (Feature, bool) {
+	f, ok := r.byTag[tag]
+	return f, ok
+}
+
+// Supports reports whether the feature identified by tag is
+// available in target. target is expected to be in canonical form
+// (post-output.ValidateTargetVersion): MAJOR.MINOR or
+// MAJOR.MINOR.PATCH, no leading "v". Comparison ignores the patch
+// component — feature gating is a minor-release concern.
+//
+// The returned Feature is the registered entry (zero value when
+// status is StatusUnknown), so callers can build a warning message
+// without a separate Lookup call.
+//
+// If target itself is unparseable, Supports returns
+// (StatusUnknown, zero Feature). Callers should validate target
+// once at the boundary rather than relying on this fallback.
+func (r *Registry) Supports(target, tag string) (Status, Feature) {
+	f, ok := r.byTag[tag]
+	if !ok {
+		return StatusUnknown, Feature{}
+	}
+	if _, ok := parseMajorMinor(target); !ok {
+		return StatusUnknown, Feature{}
+	}
+	if f.Introduced != "" && compareMajorMinor(target, f.Introduced) < 0 {
+		return StatusNotYetIntroduced, f
+	}
+	if f.Removed != "" && compareMajorMinor(target, f.Removed) >= 0 {
+		return StatusRemoved, f
+	}
+	return StatusSupported, f
+}
+
+// parseMajorMinor extracts (major, minor) from a version string,
+// tolerating a leading "v" and any number of additional
+// dot-separated suffix components (patch, build metadata).
+// Returns (_, false) when the string does not start with two
+// dot-separated unsigned-numeric components. Mirrors the contract
+// of output.majorMinor but returns the parsed numbers so callers
+// can compare without a second string-split.
+func parseMajorMinor(v string) ([2]uint64, bool) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return [2]uint64{}, false
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return [2]uint64{}, false
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return [2]uint64{}, false
+	}
+	return [2]uint64{major, minor}, true
+}
+
+// compareMajorMinor returns -1, 0, or +1 when a is less than, equal
+// to, or greater than b at MAJOR.MINOR resolution. Panics if either
+// input is unparseable. The precondition is enforced rather than
+// tolerated because every in-package caller validates upstream
+// (NewRegistry validates Introduced/Removed, Supports validates
+// target), so reaching this function with bad input indicates a
+// programmer error that should fail loudly.
+func compareMajorMinor(a, b string) int {
+	av, ok := parseMajorMinor(a)
+	if !ok {
+		panic(fmt.Sprintf("version: compareMajorMinor: unparseable %q", a))
+	}
+	bv, ok := parseMajorMinor(b)
+	if !ok {
+		panic(fmt.Sprintf("version: compareMajorMinor: unparseable %q", b))
+	}
+	switch {
+	case av[0] != bv[0]:
+		if av[0] < bv[0] {
+			return -1
+		}
+		return 1
+	case av[1] != bv[1]:
+		if av[1] < bv[1] {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/internal/version/registry_test.go
+++ b/internal/version/registry_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSupports_BoundaryVersions exercises each seeded feature at the
+// minor release just before its introduction, at exact introduction,
+// and one minor after — the boundaries called out by the issue. A
+// bug in compareMajorMinor would show up here first.
+func TestSupports_BoundaryVersions(t *testing.T) {
+	reg := DefaultRegistry()
+
+	tests := []struct {
+		name           string
+		tag            string
+		target         string
+		expectedStatus Status
+	}{
+		{name: "plpgsql before", tag: FeaturePLpgSQLFunctionBody, target: "23.2", expectedStatus: StatusNotYetIntroduced},
+		{name: "plpgsql at", tag: FeaturePLpgSQLFunctionBody, target: "24.1", expectedStatus: StatusSupported},
+		{name: "plpgsql after", tag: FeaturePLpgSQLFunctionBody, target: "24.2", expectedStatus: StatusSupported},
+		{name: "plpgsql with patch", tag: FeaturePLpgSQLFunctionBody, target: "24.1.3", expectedStatus: StatusSupported},
+		{name: "plpgsql with v prefix", tag: FeaturePLpgSQLFunctionBody, target: "v24.1", expectedStatus: StatusSupported},
+
+		{name: "trigram before", tag: FeatureTrigramIndex, target: "22.2", expectedStatus: StatusNotYetIntroduced},
+		{name: "trigram at", tag: FeatureTrigramIndex, target: "23.1", expectedStatus: StatusSupported},
+		{name: "trigram after", tag: FeatureTrigramIndex, target: "23.2", expectedStatus: StatusSupported},
+
+		{name: "rbr before", tag: FeatureRegionalByRow, target: "20.2", expectedStatus: StatusNotYetIntroduced},
+		{name: "rbr at", tag: FeatureRegionalByRow, target: "21.1", expectedStatus: StatusSupported},
+		{name: "rbr after", tag: FeatureRegionalByRow, target: "21.2", expectedStatus: StatusSupported},
+
+		{name: "alter changefeed before", tag: FeatureAlterChangefeed, target: "21.2", expectedStatus: StatusNotYetIntroduced},
+		{name: "alter changefeed at", tag: FeatureAlterChangefeed, target: "22.1", expectedStatus: StatusSupported},
+		{name: "alter changefeed after", tag: FeatureAlterChangefeed, target: "22.2", expectedStatus: StatusSupported},
+
+		{name: "cross-major: target predates oldest seed", tag: FeaturePLpgSQLFunctionBody, target: "19.1", expectedStatus: StatusNotYetIntroduced},
+		{name: "cross-major: target newer than newest seed", tag: FeaturePLpgSQLFunctionBody, target: "26.2", expectedStatus: StatusSupported},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotFeature := reg.Supports(tc.target, tc.tag)
+			require.Equal(t, tc.expectedStatus, gotStatus)
+			require.Equal(t, tc.tag, gotFeature.Tag,
+				"Supports must return the matched feature so callers can build a warning without a second lookup")
+		})
+	}
+}
+
+func TestSupports_UnknownTag(t *testing.T) {
+	reg := DefaultRegistry()
+	status, feat := reg.Supports("25.4", "no_such_feature")
+	require.Equal(t, StatusUnknown, status)
+	require.Equal(t, Feature{}, feat)
+}
+
+func TestSupports_UnparseableTarget(t *testing.T) {
+	reg := DefaultRegistry()
+	status, _ := reg.Supports("not-a-version", FeaturePLpgSQLFunctionBody)
+	require.Equal(t, StatusUnknown, status)
+}
+
+// TestSupports_MajorMinorPatchEquivalence pins the contract that
+// "25.4" and "25.4.0" compare equal. A regression here would mean
+// users who type a patch component get different warnings than
+// users who type only MAJOR.MINOR.
+func TestSupports_MajorMinorPatchEquivalence(t *testing.T) {
+	reg := DefaultRegistry()
+	a, _ := reg.Supports("24.1", FeaturePLpgSQLFunctionBody)
+	b, _ := reg.Supports("24.1.0", FeaturePLpgSQLFunctionBody)
+	c, _ := reg.Supports("24.1.99", FeaturePLpgSQLFunctionBody)
+	require.Equal(t, a, b)
+	require.Equal(t, b, c)
+}
+
+// TestStatusUnknown_IsZeroValue pins the load-bearing contract
+// that Status's zero value is StatusUnknown. The registry treats
+// "unknown" as the safe default; renumbering would silently turn
+// uninitialized statuses into StatusSupported.
+func TestStatusUnknown_IsZeroValue(t *testing.T) {
+	var s Status
+	require.Equal(t, StatusUnknown, s)
+}
+
+func TestLookup_Found(t *testing.T) {
+	reg := DefaultRegistry()
+	f, ok := reg.Lookup(FeaturePLpgSQLFunctionBody)
+	require.True(t, ok)
+	require.Equal(t, "24.1", f.Introduced)
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	reg := DefaultRegistry()
+	_, ok := reg.Lookup("no_such_feature")
+	require.False(t, ok)
+}
+
+// TestExportedConstantsAreRegistered enforces that every Feature*
+// constant resolves to a registered feature in DefaultRegistry.
+// Drift here is the one cost of maintaining both a constant list
+// and a seed list; the test catches it rather than trusting
+// reviewers.
+func TestExportedConstantsAreRegistered(t *testing.T) {
+	reg := DefaultRegistry()
+	for _, tag := range []string{
+		FeaturePLpgSQLFunctionBody,
+		FeatureTrigramIndex,
+		FeatureRegionalByRow,
+		FeatureAlterChangefeed,
+	} {
+		_, ok := reg.Lookup(tag)
+		require.Truef(t, ok, "constant %q is not registered in DefaultRegistry", tag)
+	}
+}
+
+// TestNewRegistry_PanicsOnMisconfiguration uses PanicsWithValue-style
+// matching (substring on the panic message) so that each case
+// asserts not just "panics" but "panics for the documented reason."
+// Without this, a refactor that triggered a different panic could
+// pass the test for the wrong cause.
+func TestNewRegistry_PanicsOnMisconfiguration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		features               []Feature
+		expectedPanicSubstring string
+	}{
+		{
+			name:                   "empty tag",
+			features:               []Feature{{Tag: "", Name: "x", Introduced: "24.1"}},
+			expectedPanicSubstring: "empty Tag",
+		},
+		{
+			name:                   "empty name",
+			features:               []Feature{{Tag: "x", Name: "", Introduced: "24.1"}},
+			expectedPanicSubstring: "empty Name",
+		},
+		{
+			name: "duplicate tag",
+			features: []Feature{
+				{Tag: "x", Name: "x", Introduced: "24.1"},
+				{Tag: "x", Name: "x", Introduced: "25.1"},
+			},
+			expectedPanicSubstring: "duplicate Tag",
+		},
+		{
+			name:                   "invalid introduced",
+			features:               []Feature{{Tag: "x", Name: "x", Introduced: "not-a-version"}},
+			expectedPanicSubstring: "invalid Introduced",
+		},
+		{
+			name:                   "invalid removed",
+			features:               []Feature{{Tag: "x", Name: "x", Introduced: "24.1", Removed: "garbage"}},
+			expectedPanicSubstring: "invalid Removed",
+		},
+		{
+			name:                   "removed without introduced",
+			features:               []Feature{{Tag: "x", Name: "x", Removed: "24.1"}},
+			expectedPanicSubstring: "without Introduced",
+		},
+		{
+			name:                   "removed equals introduced",
+			features:               []Feature{{Tag: "x", Name: "x", Introduced: "24.1", Removed: "24.1"}},
+			expectedPanicSubstring: "<= Introduced",
+		},
+		{
+			name:                   "removed before introduced",
+			features:               []Feature{{Tag: "x", Name: "x", Introduced: "25.1", Removed: "24.1"}},
+			expectedPanicSubstring: "<= Introduced",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				require.NotNil(t, r, "NewRegistry must panic")
+				msg, ok := r.(string)
+				require.Truef(t, ok, "panic value must be a string, got %T", r)
+				require.Containsf(t, msg, tc.expectedPanicSubstring,
+					"panic message %q must contain %q", msg, tc.expectedPanicSubstring)
+			}()
+			NewRegistry(tc.features...)
+		})
+	}
+}
+
+// TestRemovedStatus exercises the StatusRemoved branch using a
+// hand-built registry, since no seeded feature has been removed.
+// Without this test the StatusRemoved path would be dead code.
+func TestRemovedStatus(t *testing.T) {
+	reg := NewRegistry(Feature{
+		Tag:        "deprecated_thing",
+		Name:       "deprecated thing",
+		Introduced: "20.1",
+		Removed:    "24.1",
+	})
+
+	tests := []struct {
+		name           string
+		target         string
+		expectedStatus Status
+	}{
+		{name: "before introduced", target: "19.2", expectedStatus: StatusNotYetIntroduced},
+		{name: "at introduced", target: "20.1", expectedStatus: StatusSupported},
+		{name: "between introduced and removed", target: "23.2", expectedStatus: StatusSupported},
+		{name: "at removed", target: "24.1", expectedStatus: StatusRemoved},
+		{name: "after removed", target: "25.4", expectedStatus: StatusRemoved},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := reg.Supports(tc.target, "deprecated_thing")
+			require.Equal(t, tc.expectedStatus, got)
+		})
+	}
+}
+
+// TestEmptyIntroduced covers the documented contract that an empty
+// Introduced string means "supported in every known version".
+func TestEmptyIntroduced(t *testing.T) {
+	reg := NewRegistry(Feature{Tag: "ancient", Name: "ancient feature"})
+	got, _ := reg.Supports("1.0", "ancient")
+	require.Equal(t, StatusSupported, got)
+}


### PR DESCRIPTION
Introduces `internal/version`, a registry mapping CockroachDB SQL
features to the versions in which they were introduced (or removed).
The registry is pure metadata: it does not inspect SQL or AST nodes.
That layering belongs to the AST inspector tracked by #84, which will
import this package, walk parsed statements, and call `Supports` to
turn `StatusNotYetIntroduced` results into version-mismatch warnings.

Tags are named for the user-facing feature (`regional_by_row`), not
for the AST node, so a single registry entry can cover every parser
shape that surfaces the same feature (`CREATE TABLE ... LOCALITY` and
`ALTER TABLE ... SET LOCALITY` both map to one tag and one warning).

Seeded with the four features called out in the issue: PL/pgSQL
function bodies (v24.1), trigram indexes (v23.1), `REGIONAL BY ROW`
(v21.1), and `ALTER CHANGEFEED` (v22.1). Each tag is also exported as
a `Feature*` constant so the inspector in #84 gets compile-time
checking and IDE discoverability instead of relying on stringly
typed lookups; a test enforces that every constant resolves to a
registered entry.

Comparison is at MAJOR.MINOR resolution, matching the convention
already established by `output.VersionMismatchWarning`. Patch
components are accepted in the input but ignored, so users who
specify `24.1`, `24.1.0`, or `24.1.99` see identical results.

`NewRegistry` panics on misconfiguration (empty tag, empty name,
duplicate tag, unparseable version, `Removed` without `Introduced`,
`Removed <= Introduced`) so registry mistakes surface at init rather
than as silent `StatusUnknown` results at query time. Issue #109
tracks expanding the seed list with broader release-note coverage.

Resolves: #83
Informs: #81