### PR TITLE
explain-ddl: add crdb-sql explain-ddl and explain_schema_change MCP tool

### DIFF
--- a/cmd/explain_ddl.go
+++ b/cmd/explain_ddl.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newExplainDDLCmd builds the `crdb-sql explain-ddl` subcommand. It
+// runs `EXPLAIN (DDL, SHAPE) <stmt>` against the cluster identified by
+// --dsn (or the CRDB_DSN env var) and renders the resulting declarative
+// schema-changer plan.
+//
+// Input modes mirror explain: -e for inline SQL, a positional file
+// argument, or stdin. Output modes mirror explain too: text (the raw
+// SHAPE output, exactly as `cockroach sql` would render it) and json
+// (structured envelope with statement, operations, and raw_text).
+//
+// Like explain, this is a Tier 3 (connected) command. EXPLAIN (DDL,
+// SHAPE) does not execute the wrapped DDL — it only asks the
+// declarative schema changer to compile a plan — but the read-only
+// allowlist (issue #21) will still wrap this path so non-DDL statements
+// are rejected before reaching the cluster.
+func newExplainDDLCmd(state *rootState) *cobra.Command {
+	var expr string
+
+	cmd := &cobra.Command{
+		Use:   "explain-ddl [file]",
+		Short: "Run EXPLAIN (DDL, SHAPE) against the cluster and return the schema-change plan as structured JSON",
+		Long: `Connect to a CockroachDB cluster and run EXPLAIN (DDL, SHAPE)
+against the supplied DDL statement. The wrapped statement is not executed
+— the declarative schema changer only compiles a plan. Input is read
+from the -e flag (inline SQL), a positional file argument, or stdin. The
+connection string is read from --dsn or CRDB_DSN (flag wins).`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			sql = strings.TrimSpace(sql)
+
+			if state.dsn == "" {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
+			}
+
+			mgr := conn.NewManager(state.dsn)
+			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
+
+			result, err := mgr.ExplainDDL(cmd.Context(), sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
+			}
+
+			baseEnv.ConnectionStatus = output.ConnectionConnected
+
+			data, err := json.Marshal(result)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				_, werr := io.WriteString(w, result.RawText)
+				return werr
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline DDL to explain")
+
+	return cmd
+}

--- a/cmd/explain_ddl_test.go
+++ b/cmd/explain_ddl_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// runExplainDDL executes `crdb-sql explain-ddl` with the supplied args
+// and stdin, returning the captured stdout buffer and the Execute error.
+// Mirror of runExplain so the table tests below stay terse.
+func runExplainDDL(t *testing.T, stdin string, args ...string) (*bytes.Buffer, error) {
+	t.Helper()
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(append([]string{"explain-ddl"}, args...))
+	return &stdout, root.Execute()
+}
+
+// TestExplainDDLCmdNoDSN verifies that explain-ddl without a DSN fails
+// before any cluster contact, returning a structured error that names
+// both the flag and the env var.
+func TestExplainDDLCmdNoDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	_, err := runExplainDDL(t, "", "-e", "ALTER TABLE t ADD COLUMN x INT")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no connection string")
+}
+
+// TestExplainDDLCmdNoDSNJSON verifies the JSON envelope shape when no
+// DSN is configured: tier=connected, status=disconnected, an error
+// entry pointing the user at --dsn / CRDB_DSN, and no Data payload.
+func TestExplainDDLCmdNoDSNJSON(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplainDDL(t, "", "--output", "json", "-e", "ALTER TABLE t ADD COLUMN x INT")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "--dsn")
+	require.Contains(t, env.Errors[0].Message, "CRDB_DSN")
+	require.Empty(t, env.Data)
+}
+
+// TestExplainDDLCmdNoInput verifies that an invocation with no -e, no
+// file, and no piped stdin reports an empty-input error rather than
+// attempting an EXPLAIN of the empty string.
+func TestExplainDDLCmdNoInput(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runExplainDDL(t, "", "--output", "json")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "no SQL input")
+}
+
+// TestExplainDDLCmdReachesConnectAttempt verifies that with a SQL input
+// and an unreachable DSN, explain-ddl gets past input parsing and DSN
+// validation and fails at the connect step. The same "connect to
+// CockroachDB" wording as ping/explain locks in that the conn.Manager
+// path is shared.
+func TestExplainDDLCmdReachesConnectAttempt(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplainDDL(t, "", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1",
+		"-e", "ALTER TABLE t ADD COLUMN x INT")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.NotContains(t, env.Errors[0].Message, "no connection string")
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+}
+
+// TestExplainDDLCmdReadsFromFileArg verifies that a positional file
+// argument is plumbed through sqlinput.ReadSQL and reaches the connect
+// step (rather than failing at input resolution).
+func TestExplainDDLCmdReadsFromFileArg(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	dir := t.TempDir()
+	sqlFile := filepath.Join(dir, "ddl.sql")
+	require.NoError(t, os.WriteFile(sqlFile, []byte("ALTER TABLE t ADD COLUMN x INT"), 0644))
+
+	stdout, err := runExplainDDL(t, "", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1",
+		sqlFile)
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+		"file arg must reach the connect step, not fail at input parsing")
+}
+
+// TestExplainDDLCmdReadsFromStdin verifies that piped SQL on stdin
+// reaches the connect step.
+func TestExplainDDLCmdReadsFromStdin(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	stdout, err := runExplainDDL(t, "ALTER TABLE t ADD COLUMN x INT\n", "--output", "json",
+		"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+		"stdin input must reach the connect step, not fail at input parsing")
+}
+
+// TestExplainDDLCmdRejectsExtraArgs verifies that more than one
+// positional argument is rejected (the optional positional is the SQL
+// file).
+func TestExplainDDLCmdRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"explain-ddl", "file1.sql", "file2.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,6 +149,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newRiskCmd(state))
 	root.AddCommand(newSummarizeCmd(state))
 	root.AddCommand(newExplainCmd(state))
+	root.AddCommand(newExplainDDLCmd(state))
 	root.AddCommand(newMCPCmd(state))
 	return root
 }

--- a/internal/conn/explain_ddl_parse.go
+++ b/internal/conn/explain_ddl_parse.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DDLOperation is one operation in a CockroachDB declarative schema
+// changer plan, as rendered by `EXPLAIN (DDL, SHAPE)`. Op is the
+// operation description with the leading tree connector stripped (e.g.
+// "execute 4 system table mutations transactions", "backfill using
+// primary index users_pkey- in relation users"). Targets holds the
+// indented sub-lines that follow the operation, describing the index or
+// constraint the operation acts on (e.g. "into users_pkey+ (id; name)",
+// "from users@[5] into users_pkey+"). Most operations have no targets;
+// the slice is nil in that case.
+//
+// CRDB conventions in these strings: a trailing `-` on an index name
+// (e.g. `users_pkey-`) marks the version being torn down; a trailing
+// `+` marks the version being built up. `t@[N]` references a table's
+// internal index by ID. These are passed through verbatim because they
+// are part of CRDB's diagnostic vocabulary.
+//
+// SHAPE output presents operations as a flat sequence under the
+// statement root rather than as named lifecycle phases (statement /
+// pre-commit / post-commit). The phase boundary is implicit in the
+// ordering of `execute N system table mutations transactions` markers.
+type DDLOperation struct {
+	Op      string   `json:"op"`
+	Targets []string `json:"targets,omitempty"`
+}
+
+// DDLExplainResult is the structured form of a `EXPLAIN (DDL, SHAPE)`
+// result.
+//
+// Statement is the SQL statement that the schema changer would execute,
+// extracted from the leading "Schema change plan for <stmt>;" header.
+// Operations is the parsed flat list of operations in execution order.
+// RawText is the original multi-line `info` string the cluster
+// returned, retained verbatim so the CLI text mode can render output
+// exactly as `cockroach sql` would and so agents can re-parse if they
+// need detail the structured form drops (e.g. tree connector positions).
+//
+// Like ExplainResult, DDLExplainResult is only constructed on the
+// success path; any failure (query, scan, parse) returns the zero value
+// plus an error.
+type DDLExplainResult struct {
+	Statement  string         `json:"statement"`
+	Operations []DDLOperation `json:"operations"`
+	RawText    string         `json:"raw_text"`
+}
+
+// ddlPlanHeaderPrefix is the literal prefix CRDB emits on the first
+// line of EXPLAIN (DDL, SHAPE) output. We require it to match (rather
+// than fuzzy-detecting an SQL fragment) so a future CRDB format change
+// surfaces here as a clear parser error instead of a silently-empty
+// Statement field.
+const ddlPlanHeaderPrefix = "Schema change plan for "
+
+// parseExplainDDLShape converts the multi-line `info` string of a CRDB
+// `EXPLAIN (DDL, SHAPE)` result into structured form.
+//
+// Inputs:
+//   - text: the contents of the single `info` column of the SHAPE
+//     result. EXPLAIN (DDL, SHAPE) returns one row whose value is a
+//     newline-separated rendering of the schema-change plan.
+//
+// Outputs:
+//   - statement: the SQL statement the schema changer would execute,
+//     stripped of the "Schema change plan for " prefix and trailing
+//     semicolon. Sensitive literal values remain wrapped in CRDB's
+//     `‹...›` redaction markers; callers that need a clean SQL string
+//     should strip them downstream.
+//   - operations: the flat operation sequence in execution order.
+//   - err: non-nil only when the input does not match the SHAPE format
+//     (empty input, missing header, unrecognized tree-connector
+//     prefixes, target lines before any operation). Unrecognized lines
+//     fail loudly so a CRDB upgrade that introduces new SHAPE syntax —
+//     including deeper nesting than depth 2 — surfaces here rather
+//     than producing a quietly-incomplete plan.
+//
+// Format reference (from samples captured against cockroach demo):
+//
+//	Schema change plan for ALTER TABLE t ADD COLUMN x INT;
+//	 ├── execute 2 system table mutations transactions
+//	 ├── backfill using primary index t_pkey- in relation t
+//	 │    └── into t_pkey+ (id; x+)
+//	 └── execute 4 system table mutations transactions
+//
+// Operations are at depth 1 (one space, then `├──` or `└──`). Targets
+// are at depth 2 (one space, then `│`-or-space + spaces + `└──`/`├──`).
+func parseExplainDDLShape(text string) (string, []DDLOperation, error) {
+	if text == "" {
+		return "", nil, fmt.Errorf("parse SHAPE output: empty input")
+	}
+
+	// CRDB appends a trailing newline; strip it so the trailing empty
+	// element doesn't show up as a malformed line below.
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+
+	header := lines[0]
+	if !strings.HasPrefix(header, ddlPlanHeaderPrefix) {
+		return "", nil, fmt.Errorf("parse SHAPE output: first line missing %q prefix: %q", ddlPlanHeaderPrefix, header)
+	}
+	statement := strings.TrimSuffix(strings.TrimPrefix(header, ddlPlanHeaderPrefix), ";")
+
+	var operations []DDLOperation
+	for i, raw := range lines[1:] {
+		line := strings.TrimRight(raw, " \t")
+		if line == "" {
+			continue
+		}
+
+		depth, content, err := classifyShapeLine(line)
+		if err != nil {
+			// +2 so the index in the error matches the line number in
+			// the raw text (1-based, with the header counted).
+			return "", nil, fmt.Errorf("parse SHAPE output: line %d: %w (raw: %q)", i+2, err, raw)
+		}
+
+		switch depth {
+		case shapeDepthOperation:
+			operations = append(operations, DDLOperation{Op: content})
+		case shapeDepthTarget:
+			if len(operations) == 0 {
+				return "", nil, fmt.Errorf("parse SHAPE output: line %d: target before any operation (raw: %q)", i+2, raw)
+			}
+			last := &operations[len(operations)-1]
+			last.Targets = append(last.Targets, content)
+		}
+	}
+
+	return statement, operations, nil
+}
+
+// shapeDepth identifies the structural role of a SHAPE line. Two levels
+// have been observed in real cluster output: an "operation" directly
+// under the plan root, and an optional "target" sub-line under an
+// operation. classifyShapeLine returns one of these or an error if the
+// line's connector pattern doesn't match either.
+type shapeDepth int
+
+const (
+	shapeDepthOperation shapeDepth = iota + 1
+	shapeDepthTarget
+)
+
+// classifyShapeLine inspects a single non-empty SHAPE line and returns
+// its depth and the content text after the tree connector. The two
+// recognized shapes are:
+//
+//	" ├── <op>"     or  " └── <op>"           → operation (depth 1)
+//	" │    └── <t>" or  "      └── <t>"       → target (depth 2)
+//	" │    ├── <t>" or  "      ├── <t>"       → target (depth 2)
+//
+// Any other prefix is a format we have not seen — return an error so
+// CRDB-side changes are not silently misclassified. The exact leading
+// whitespace counts come from the captured fixtures: depth 1 is one
+// space then a connector; depth 2 is one space, then `│` or space, then
+// four spaces, then a connector.
+func classifyShapeLine(line string) (shapeDepth, string, error) {
+	if op, ok := stripConnector(line, " "); ok {
+		return shapeDepthOperation, op, nil
+	}
+	for _, prefix := range []string{" │    ", "      "} {
+		if t, ok := stripConnector(line, prefix); ok {
+			return shapeDepthTarget, t, nil
+		}
+	}
+	return 0, "", fmt.Errorf("unrecognized tree-connector prefix")
+}
+
+// stripConnector returns (content, true) if line begins with prefix
+// followed by a `├── ` or `└── ` connector and has non-empty content
+// after it. Returns ("", false) otherwise. Centralizing the connector
+// match keeps classifyShapeLine readable when we add more depths later.
+func stripConnector(line, prefix string) (string, bool) {
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	rest := line[len(prefix):]
+	for _, connector := range []string{"├── ", "└── "} {
+		if strings.HasPrefix(rest, connector) {
+			content := strings.TrimSpace(rest[len(connector):])
+			if content == "" {
+				return "", false
+			}
+			return content, true
+		}
+	}
+	return "", false
+}

--- a/internal/conn/explain_ddl_parse_test.go
+++ b/internal/conn/explain_ddl_parse_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Fixtures live in testdata/explain_ddl/*.txt and were captured from a
+// `cockroach demo --no-example-database` cluster running EXPLAIN (DDL,
+// SHAPE) against representative DDLs. They are the source of truth for
+// the parser's acceptance contract: regenerate with the probe documented
+// in the PR if a future CRDB version changes the SHAPE output format.
+
+func TestParseExplainDDLShapeFixtures(t *testing.T) {
+	tests := []struct {
+		name               string
+		fixture            string
+		expectedStatement  string
+		expectedOperations []DDLOperation
+	}{
+		{
+			name:              "add column without backfill",
+			fixture:           "add_column.txt",
+			expectedStatement: "ALTER TABLE defaultdb.public.users ADD COLUMN age INT8",
+			expectedOperations: []DDLOperation{
+				{Op: "execute 4 system table mutations transactions"},
+			},
+		},
+		{
+			name:              "add column with not null default triggers backfill",
+			fixture:           "add_column_not_null_default.txt",
+			expectedStatement: "ALTER TABLE defaultdb.public.users ADD COLUMN status STRING NOT NULL DEFAULT ‹'active'›",
+			expectedOperations: []DDLOperation{
+				{Op: "execute 2 system table mutations transactions"},
+				{
+					Op:      "backfill using primary index users_pkey- in relation users",
+					Targets: []string{"into users_pkey+ (id; name, status+)"},
+				},
+				{Op: "execute 2 system table mutations transactions"},
+				{
+					Op:      "merge temporary indexes into backfilled indexes in relation users",
+					Targets: []string{"from users@[5] into users_pkey+"},
+				},
+				{Op: "execute 1 system table mutations transaction"},
+				{Op: "validate UNIQUE constraint backed by index users_pkey+ in relation users"},
+				{Op: "validate NOT NULL constraint on column status+ in index users_pkey+ in relation users"},
+				{Op: "execute 4 system table mutations transactions"},
+			},
+		},
+		{
+			name:              "create index",
+			fixture:           "create_index.txt",
+			expectedStatement: "CREATE INDEX ON defaultdb.public.users (id, name)",
+			expectedOperations: []DDLOperation{
+				{Op: "execute 2 system table mutations transactions"},
+				{
+					Op:      "backfill using primary index users_pkey in relation users",
+					Targets: []string{"into users_id_name_idx+ (id, name)"},
+				},
+				{Op: "execute 2 system table mutations transactions"},
+				{
+					Op:      "merge temporary indexes into backfilled indexes in relation users",
+					Targets: []string{"from users@[5] into users_id_name_idx+"},
+				},
+				{Op: "execute 1 system table mutations transaction"},
+				{Op: "validate UNIQUE constraint backed by index users_id_name_idx+ in relation users"},
+				{Op: "execute 2 system table mutations transactions"},
+			},
+		},
+		{
+			name:              "drop index cascade",
+			fixture:           "drop_index_cascade.txt",
+			expectedStatement: "DROP INDEX defaultdb.public.users@idx_users_name CASCADE",
+			expectedOperations: []DDLOperation{
+				{Op: "execute 4 system table mutations transactions"},
+			},
+		},
+		{
+			name:              "alter primary key noop",
+			fixture:           "alter_primary_key.txt",
+			expectedStatement: "ALTER TABLE defaultdb.public.users ALTER PRIMARY KEY USING COLUMNS (id)",
+			expectedOperations: []DDLOperation{
+				{Op: "execute 1 system table mutations transaction"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata", "explain_ddl", tc.fixture))
+			require.NoError(t, err, "read fixture")
+
+			statement, operations, err := parseExplainDDLShape(string(data))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatement, statement)
+			require.Equal(t, tc.expectedOperations, operations)
+		})
+	}
+}
+
+func TestParseExplainDDLShapeErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{
+			name:        "empty input",
+			input:       "",
+			expectedErr: "empty input",
+		},
+		{
+			name:        "missing header prefix",
+			input:       "Some other plan;\n └── execute 1 system table mutations transaction\n",
+			expectedErr: `first line missing "Schema change plan for " prefix`,
+		},
+		{
+			name:        "unrecognized connector prefix",
+			input:       "Schema change plan for FOO;\n\t-> not a tree connector\n",
+			expectedErr: "unrecognized tree-connector prefix",
+		},
+		{
+			name: "operation connector with empty content",
+			// stripConnector returns ok=false on empty content, so the
+			// line falls through to "unrecognized" rather than producing
+			// an empty Op. This pins that behavior so an emit of
+			// `" └── \n"` from a future CRDB version is rejected loudly,
+			// not stored as a blank operation.
+			input:       "Schema change plan for FOO;\n └── \n",
+			expectedErr: "unrecognized tree-connector prefix",
+		},
+		{
+			name:        "target line before any operation",
+			input:       "Schema change plan for FOO;\n │    └── orphan target\n",
+			expectedErr: "target before any operation",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseExplainDDLShape(tc.input)
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// TestParseExplainDDLShapeStatementTrimming pins how the header line is
+// canonicalized. The fixtures all happen to end with exactly one
+// trailing semicolon; these cases lock in the behavior at the
+// boundaries of that assumption so a future CRDB version that drops or
+// doubles the semicolon does not silently shift the Statement field.
+func TestParseExplainDDLShapeStatementTrimming(t *testing.T) {
+	tests := []struct {
+		name              string
+		header            string
+		expectedStatement string
+	}{
+		{
+			name:              "single trailing semicolon stripped",
+			header:            "Schema change plan for ALTER TABLE t ADD COLUMN x INT;",
+			expectedStatement: "ALTER TABLE t ADD COLUMN x INT",
+		},
+		{
+			name:              "no trailing semicolon preserved as-is",
+			header:            "Schema change plan for ALTER TABLE t ADD COLUMN x INT",
+			expectedStatement: "ALTER TABLE t ADD COLUMN x INT",
+		},
+		{
+			name: "double trailing semicolon strips only one",
+			// TrimSuffix is one-shot by design — assert that so a
+			// future regression to a strip-all-trailing-semicolons
+			// implementation is caught here.
+			header:            "Schema change plan for ALTER TABLE t ADD COLUMN x INT;;",
+			expectedStatement: "ALTER TABLE t ADD COLUMN x INT;",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.header + "\n └── execute 1 system table mutations transaction\n"
+			statement, _, err := parseExplainDDLShape(input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatement, statement)
+		})
+	}
+}
+
+// TestDDLExplainResultJSONShape locks the JSON contract for
+// DDLExplainResult. CLI envelopes and MCP tool results both ship this
+// struct as `data`; renaming or dropping the JSON tags would silently
+// break agent clients that read fields by name. An assertion on a
+// fully-populated value catches both rename and omitempty regressions.
+func TestDDLExplainResultJSONShape(t *testing.T) {
+	result := DDLExplainResult{
+		Statement: "ALTER TABLE t ADD COLUMN x INT",
+		Operations: []DDLOperation{
+			{Op: "execute 4 system table mutations transactions"},
+			{
+				Op:      "backfill using primary index t_pkey- in relation t",
+				Targets: []string{"into t_pkey+ (id; x+)"},
+			},
+		},
+		RawText: "raw plan text",
+	}
+
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	expected := `{
+		"statement": "ALTER TABLE t ADD COLUMN x INT",
+		"operations": [
+			{"op": "execute 4 system table mutations transactions"},
+			{
+				"op": "backfill using primary index t_pkey- in relation t",
+				"targets": ["into t_pkey+ (id; x+)"]
+			}
+		],
+		"raw_text": "raw plan text"
+	}`
+	require.JSONEq(t, expected, string(data))
+}

--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -156,6 +156,73 @@ func (m *Manager) runExplain(ctx context.Context, sql string) (ExplainResult, er
 	return ExplainResult{Header: header, Plan: plan, RawRows: raw}, nil
 }
 
+// ExplainDDL runs `EXPLAIN (DDL, SHAPE) <sql>` against the cluster and
+// returns the parsed schema-change plan alongside the raw text the
+// cluster returned.
+//
+// EXPLAIN (DDL, SHAPE) does not execute the wrapped DDL — it only asks
+// the declarative schema changer to compile a plan — so no read-only
+// safety wrapper is applied here; the dedicated allowlist (issue #21)
+// will layer on top by intercepting the SQL before it reaches this
+// method, leaving runExplainDDL as the single chokepoint to wrap.
+//
+// On any query/scan/parse failure after a successful connect, the
+// underlying connection is closed and the Manager reverts to its
+// pre-connect state, mirroring Explain's recovery contract.
+func (m *Manager) ExplainDDL(ctx context.Context, sql string) (DDLExplainResult, error) {
+	if err := m.connect(ctx); err != nil {
+		return DDLExplainResult{}, err
+	}
+
+	result, err := m.runExplainDDL(ctx, sql)
+	if err != nil {
+		m.conn.Close(ctx) //nolint:errcheck // best-effort cleanup
+		m.conn = nil
+		return DDLExplainResult{}, err
+	}
+	return result, nil
+}
+
+// runExplainDDL is the inner half of ExplainDDL that owns the
+// query/scan/parse pipeline. SHAPE output is contractually a single row
+// whose `info` column is the entire multi-line plan; we iterate with
+// Query (rather than QueryRow) so we can fail loudly on a future CRDB
+// version that splits the output across rows, matching the parser's
+// "be strict so format changes surface here" discipline. Splitting this
+// out lets ExplainDDL centralize the connection-recovery sequence so
+// the failure modes (Query, Scan, rows.Err, multi-row, parse) cannot
+// drift apart.
+func (m *Manager) runExplainDDL(ctx context.Context, sql string) (DDLExplainResult, error) {
+	rows, err := m.conn.Query(ctx, "EXPLAIN (DDL, SHAPE) "+sql)
+	if err != nil {
+		return DDLExplainResult{}, fmt.Errorf("run EXPLAIN (DDL, SHAPE): %w", err)
+	}
+	defer rows.Close()
+
+	var raw []string
+	for rows.Next() {
+		var info string
+		if err := rows.Scan(&info); err != nil {
+			return DDLExplainResult{}, fmt.Errorf("scan EXPLAIN (DDL, SHAPE) row: %w", err)
+		}
+		raw = append(raw, info)
+	}
+	if err := rows.Err(); err != nil {
+		return DDLExplainResult{}, fmt.Errorf("read EXPLAIN (DDL, SHAPE) rows: %w", err)
+	}
+	if len(raw) != 1 {
+		return DDLExplainResult{}, fmt.Errorf(
+			"EXPLAIN (DDL, SHAPE) returned %d rows, expected exactly 1 (CRDB output format may have changed)", len(raw))
+	}
+
+	text := raw[0]
+	statement, operations, err := parseExplainDDLShape(text)
+	if err != nil {
+		return DDLExplainResult{}, fmt.Errorf("parse EXPLAIN (DDL, SHAPE) output: %w", err)
+	}
+	return DDLExplainResult{Statement: statement, Operations: operations, RawText: text}, nil
+}
+
 // Close closes the underlying connection if one was established.
 // It is safe to call on a Manager that never connected.
 func (m *Manager) Close(ctx context.Context) error {

--- a/internal/conn/manager_integration_test.go
+++ b/internal/conn/manager_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
@@ -126,6 +127,90 @@ func TestIntegrationManagerCloseAfterPing(t *testing.T) {
 	require.NoError(t, mgr.Close(ctx))
 	require.NoError(t, mgr.Close(ctx),
 		"Close should be a no-op on a Manager whose connection was already released")
+}
+
+// TestIntegrationManagerExplainDDL covers the happy path for
+// ExplainDDL against a real cluster. Assertions are deliberately
+// tolerant of CRDB version drift: we check that a known statement
+// canonicalizes into the Statement field, that at least one operation
+// is parsed (even the cheapest schema change emits an "execute N system
+// table mutations transactions" line), and that RawText is non-empty.
+// We do not pin the operation count or text because the declarative
+// schema changer's plan composition can shift between minor versions.
+func TestIntegrationManagerExplainDDL(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a fresh table so the ALTER ... ADD COLUMN target exists
+	// in the catalog when the schema changer plans it. We use a
+	// one-off pgx connection (mustExec) because Manager intentionally
+	// exposes only EXPLAIN-flavored read paths.
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE IF NOT EXISTS explain_ddl_users (id INT PRIMARY KEY, name STRING)")
+
+	result, err := mgr.ExplainDDL(ctx,
+		"ALTER TABLE explain_ddl_users ADD COLUMN age INT")
+	require.NoError(t, err)
+	require.Contains(t, result.Statement, "ALTER TABLE",
+		"statement should canonicalize the ALTER")
+	require.Contains(t, result.Statement, "ADD COLUMN age",
+		"statement should preserve the ADD COLUMN clause")
+	require.NotEmpty(t, result.Operations,
+		"every schema change has at least one operation")
+	require.NotEmpty(t, result.RawText,
+		"raw text should be retained for fidelity")
+}
+
+// TestIntegrationManagerExplainDDLRecoversAfterError pins the
+// connection-recovery contract documented on ExplainDDL: an error
+// after a successful connect closes the cached connection and nils it
+// so the next call re-dials transparently. A regression that left the
+// dead connection in place would silently leak it and reuse it on the
+// next call.
+func TestIntegrationManagerExplainDDLRecoversAfterError(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE IF NOT EXISTS explain_ddl_recovery (id INT PRIMARY KEY)")
+
+	// First call against a non-existent table forces a cluster-side
+	// error after the lazy connect has succeeded — the recovery code
+	// path we want to exercise.
+	_, err := mgr.ExplainDDL(ctx,
+		"ALTER TABLE explain_ddl_does_not_exist ADD COLUMN x INT")
+	require.Error(t, err, "ALTER on missing table should surface a cluster error")
+
+	// Second call must succeed against a real table — proving the
+	// Manager re-dialed and is not stuck on the closed connection.
+	result, err := mgr.ExplainDDL(ctx,
+		"ALTER TABLE explain_ddl_recovery ADD COLUMN x INT")
+	require.NoError(t, err, "ExplainDDL after a prior failure must reconnect")
+	require.NotEmpty(t, result.Operations,
+		"recovered call should return a real plan, not zero value")
+}
+
+// mustExec opens a one-off pgx connection and runs sql, failing the
+// test on any error. Used to perform DDL setup outside the Manager:
+// Manager intentionally exposes no general Exec, so tests that need a
+// one-shot escape hatch for setup go through here rather than around
+// it. Kept private to this test file because no other test needs
+// arbitrary execution.
+func mustExec(t *testing.T, ctx context.Context, dsn, sql string) {
+	t.Helper()
+	c, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err, "open setup connection")
+	defer c.Close(ctx) //nolint:errcheck // best-effort cleanup
+	_, err = c.Exec(ctx, sql)
+	require.NoError(t, err, "exec setup SQL")
 }
 
 // TestIntegrationManagerPingFailures table-drives the

--- a/internal/conn/testdata/explain_ddl/add_column.txt
+++ b/internal/conn/testdata/explain_ddl/add_column.txt
@@ -1,0 +1,3 @@
+Schema change plan for ALTER TABLE defaultdb.public.users ADD COLUMN age INT8;
+ └── execute 4 system table mutations transactions
+

--- a/internal/conn/testdata/explain_ddl/add_column_not_null_default.txt
+++ b/internal/conn/testdata/explain_ddl/add_column_not_null_default.txt
@@ -1,0 +1,12 @@
+Schema change plan for ALTER TABLE defaultdb.public.users ADD COLUMN status STRING NOT NULL DEFAULT ‹'active'›;
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index users_pkey- in relation users
+ │    └── into users_pkey+ (id; name, status+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation users
+ │    └── from users@[5] into users_pkey+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index users_pkey+ in relation users
+ ├── validate NOT NULL constraint on column status+ in index users_pkey+ in relation users
+ └── execute 4 system table mutations transactions
+

--- a/internal/conn/testdata/explain_ddl/alter_primary_key.txt
+++ b/internal/conn/testdata/explain_ddl/alter_primary_key.txt
@@ -1,0 +1,3 @@
+Schema change plan for ALTER TABLE defaultdb.public.users ALTER PRIMARY KEY USING COLUMNS (id);
+ └── execute 1 system table mutations transaction
+

--- a/internal/conn/testdata/explain_ddl/create_index.txt
+++ b/internal/conn/testdata/explain_ddl/create_index.txt
@@ -1,0 +1,11 @@
+Schema change plan for CREATE INDEX ON defaultdb.public.users (id, name);
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index users_pkey in relation users
+ │    └── into users_id_name_idx+ (id, name)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation users
+ │    └── from users@[5] into users_id_name_idx+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index users_id_name_idx+ in relation users
+ └── execute 2 system table mutations transactions
+

--- a/internal/conn/testdata/explain_ddl/drop_index_cascade.txt
+++ b/internal/conn/testdata/explain_ddl/drop_index_cascade.txt
@@ -1,0 +1,3 @@
+Schema change plan for DROP INDEX defaultdb.public.users@idx_users_name CASCADE;
+ └── execute 4 system table mutations transactions
+

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -39,6 +39,7 @@ var expectedTools = []string{
 	tools.FormatSQLToolName,
 	tools.DetectRiskyQueryToolName,
 	tools.ExplainSQLToolName,
+	tools.ExplainSchemaChangeToolName,
 	tools.ListTablesToolName,
 	tools.DescribeTableToolName,
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -74,6 +74,7 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.ExplainSchemaChangeTool(), tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))
 	s.AddTool(tools.DescribeTableTool(), tools.DescribeTableHandler(parserVersion))
 	return s

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -85,6 +85,7 @@ func TestNewServerRegistersTools(t *testing.T) {
 		tools.FormatSQLToolName,
 		tools.DetectRiskyQueryToolName,
 		tools.ExplainSQLToolName,
+		tools.ExplainSchemaChangeToolName,
 		tools.ListTablesToolName,
 		tools.DescribeTableToolName,
 	} {

--- a/internal/mcp/tools/explain_schema_change.go
+++ b/internal/mcp/tools/explain_schema_change.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// ExplainSchemaChangeTool returns the MCP tool definition for
+// explain_schema_change. This is the discoverable name for CRDB's
+// `EXPLAIN (DDL, SHAPE)` capability — the underlying SQL syntax is
+// buried in the manual, so the tool name lets agents reach for it by
+// what it does (preview a schema-change plan) rather than by knowing
+// the exact incantation.
+//
+// Like explain_sql, the `dsn` parameter is required because MCP
+// sessions are stateless: the server holds no per-client connection,
+// and credentials are never logged or echoed back.
+func ExplainSchemaChangeTool() mcp.Tool {
+	return mcp.NewTool(
+		ExplainSchemaChangeToolName,
+		mcp.WithDescription(`Run EXPLAIN (DDL, SHAPE) against a CockroachDB cluster and return the declarative schema-changer plan as structured JSON. The wrapped DDL is not executed — the schema changer only compiles a plan. Returns the operations list (with backfill / merge / validate steps), the canonicalized statement, and the raw text the cluster returned.`),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("DDL statement to plan (e.g. ALTER TABLE ... ADD COLUMN ...)")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+	)
+}
+
+// ExplainSchemaChangeHandler returns the handler for the
+// explain_schema_change tool. The envelope's ConnectionStatus starts
+// disconnected and flips to connected only after a successful run, so
+// partial-failure envelopes report the actual reached state.
+// Cluster-side errors (timeouts, syntax in the wrapped DDL, perm
+// denied) populate env.Errors via diag.FromClusterError to carry
+// SQLSTATE; tool-level errors (missing parameters) are returned as
+// mcp.NewToolResultError per the discipline documented in tools.go.
+//
+// defaultTargetVersion is the server-level default; per-call
+// target_version arguments override it.
+func ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractRequiredString(req, "sql")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		dsn, toolErr := extractRequiredString(req, "dsn")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := connectedEnvelope(parserVersion, target)
+
+		mgr := conn.NewManager(dsn)
+		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
+
+		result, err := mgr.ExplainDDL(ctx, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
+			return envelopeResult(env)
+		}
+
+		env.ConnectionStatus = output.ConnectionConnected
+		data, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -32,13 +32,14 @@ import (
 
 // Registered MCP tool names.
 const (
-	ParseSQLToolName         = "parse_sql"
-	ValidateSQLToolName      = "validate_sql"
-	FormatSQLToolName        = "format_sql"
-	DetectRiskyQueryToolName = "detect_risky_query"
-	ExplainSQLToolName       = "explain_sql"
-	ListTablesToolName       = "list_tables"
-	DescribeTableToolName    = "describe_table"
+	ParseSQLToolName            = "parse_sql"
+	ValidateSQLToolName         = "validate_sql"
+	FormatSQLToolName           = "format_sql"
+	DetectRiskyQueryToolName    = "detect_risky_query"
+	ExplainSQLToolName          = "explain_sql"
+	ExplainSchemaChangeToolName = "explain_schema_change"
+	ListTablesToolName          = "list_tables"
+	DescribeTableToolName       = "describe_table"
 )
 
 // TargetVersionParamName is the optional MCP tool parameter name that

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -122,6 +122,88 @@ func TestExplainSQLHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
 	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
 }
 
+// TestExplainSchemaChangeHandlerParameterValidation covers the
+// tool-level error path for explain_schema_change. Cluster round-trips
+// are not exercised here; an end-to-end smoke is documented in the
+// issue verification plan.
+func TestExplainSchemaChangeHandlerParameterValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing both params", args: map[string]any{}},
+		{name: "missing dsn", args: map[string]any{"sql": "ALTER TABLE t ADD COLUMN x INT"}},
+		{name: "missing sql", args: map[string]any{"dsn": "postgres://h:26257/db"}},
+		{name: "empty sql", args: map[string]any{"sql": "", "dsn": "postgres://h:26257/db"}},
+		{name: "empty dsn", args: map[string]any{"sql": "ALTER TABLE t ADD COLUMN x INT", "dsn": ""}},
+		{name: "wrong type sql", args: map[string]any{"sql": 1, "dsn": "postgres://h:26257/db"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExplainSchemaChangeHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.True(t, res.IsError, "expected tool-level error")
+		})
+	}
+}
+
+// TestExplainSchemaChangeHandlerRejectsMalformedTargetVersion confirms
+// per-call target_version validation runs before the cluster dial,
+// matching the explain_sql behavior.
+func TestExplainSchemaChangeHandlerRejectsMalformedTargetVersion(t *testing.T) {
+	handler := ExplainSchemaChangeHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "ALTER TABLE t ADD COLUMN x INT",
+		"dsn":            "postgres://nope:1/db?connect_timeout=1",
+		"target_version": "garbage",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "malformed target_version must surface as a tool error")
+}
+
+// TestExplainSchemaChangeToolAdvertisesTargetVersionParam pins that
+// the MCP schema for explain_schema_change lists target_version among
+// its parameters so clients can discover the override surface from
+// tool metadata.
+func TestExplainSchemaChangeToolAdvertisesTargetVersionParam(t *testing.T) {
+	tool := ExplainSchemaChangeTool()
+	props := tool.InputSchema.Properties
+	require.Contains(t, props, TargetVersionParamName,
+		"explain_schema_change schema must advertise the target_version property")
+}
+
+// TestExplainSchemaChangeHandlerConnectionFailureSurfacesEnvelopeError
+// verifies that when the cluster is unreachable, the handler returns a
+// successful MCP tool result whose envelope carries the error — not a
+// tool-level error. Same discipline as explain_sql.
+func TestExplainSchemaChangeHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
+	handler := ExplainSchemaChangeHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql": "ALTER TABLE t ADD COLUMN x INT",
+		// Unreachable host — connection will fail before any query.
+		"dsn": "postgres://nope:1/db?connect_timeout=1",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+		"failed connect must leave status disconnected")
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+}
+
 func TestExtractSQL(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Surface CRDB's `EXPLAIN (DDL, SHAPE)` as a discoverable Tier-3
capability so agents can predict the impact of a DDL before running
it. Mirrors the existing `explain` / `explain_sql` shape introduced
for plain EXPLAIN.

The SHAPE output is a single multi-line `info` row laying out the
declarative schema-changer plan as a flat list of operations
("execute N system table mutations transactions", "backfill",
"merge", "validate") under a "Schema change plan for <stmt>;"
header, with optional indented target sub-lines under operations
that touch indexes. The parser captures this into:

  - Statement: the canonicalized DDL (prefix and trailing `;` stripped)
  - Operations: ordered []DDLOperation (Op + optional Targets)
  - RawText: the verbatim multi-line text, retained for fidelity

The parser was designed against five real samples captured from
`cockroach demo` (ADD COLUMN, ADD COLUMN with NOT NULL DEFAULT,
CREATE INDEX, DROP INDEX CASCADE, ALTER PRIMARY KEY) and committed
as testdata fixtures so a future CRDB SHAPE format change surfaces
as a fixture-driven test failure rather than a silently-incomplete
plan. Unrecognized tree-connector prefixes fail loudly for the
same reason.

Compact-mode (Unicode tree) parsing remains deferred per the
hackathon plan §Risks; the read-only allowlist (#21) will wrap
Manager.ExplainDDL as the single chokepoint when implemented.

Resolves: #20