### PR TITLE
cmd: auto-discover crdb-sql.yaml in list-tables when --schema is omitted

### DIFF
--- a/cmd/list_tables.go
+++ b/cmd/list_tables.go
@@ -46,7 +46,13 @@ obtain one from a running CockroachDB cluster with:
 
 Then list the tables:
 
-  crdb-sql list-tables --schema schema.sql`,
+  crdb-sql list-tables --schema schema.sql
+
+If no --schema is supplied and a crdb-sql.yaml config is present in
+the working directory (or pointed at by --config), list-tables expands
+the config's schema globs across all sql pairs into one combined
+catalog and lists tables from there. Explicit --schema flags win
+outright (no merging with config-discovered files).`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierSchemaFile, cmd)
@@ -54,9 +60,34 @@ Then list the tables:
 				return r.RenderError(baseEnv, err)
 			}
 
+			// Config fallback: when no explicit --schema is given but a
+			// crdb-sql.yaml has been auto-discovered (or pointed at by
+			// --config), expand every pair's schema globs into one
+			// catalog. Explicit --schema flags continue to win outright.
+			if len(schemaFiles) == 0 && state.cfg != nil {
+				paths, err := expandConfigSchemaPaths(state.cfg)
+				if err != nil {
+					return r.RenderError(baseEnv, err)
+				}
+				if len(paths) == 0 {
+					// Config was loaded but its globs matched no files.
+					// Distinguish this from the no-config case so users
+					// don't waste time wondering whether their config was
+					// even discovered.
+					return r.RenderError(baseEnv,
+						fmt.Errorf("crdb-sql.yaml at %s has no schema files matching its globs; check the schema patterns or pass --schema explicitly",
+							state.cfg.BaseDir))
+				}
+				cat, err := catalog.LoadFiles(paths)
+				if err != nil {
+					return renderSchemaLoadError(r, baseEnv, err)
+				}
+				return renderListTables(r, baseEnv, cat)
+			}
+
 			if len(schemaFiles) == 0 {
 				return r.RenderError(baseEnv,
-					fmt.Errorf("at least one --schema file is required"))
+					fmt.Errorf("at least one --schema file is required (or a crdb-sql.yaml with matching schema globs)"))
 			}
 
 			cat, err := catalog.LoadFiles(schemaFiles)
@@ -64,27 +95,7 @@ Then list the tables:
 				return renderSchemaLoadError(r, baseEnv, err)
 			}
 
-			appendSchemaWarnings(&baseEnv, cat)
-
-			tables := cat.TableNames()
-			if tables == nil {
-				tables = []string{}
-			}
-
-			data, err := json.Marshal(listTablesResult{Tables: tables})
-			if err != nil {
-				return r.RenderError(baseEnv, err)
-			}
-			baseEnv.Data = data
-
-			return r.Render(baseEnv, func(w io.Writer) error {
-				for _, name := range tables {
-					if _, err := fmt.Fprintln(w, name); err != nil {
-						return err
-					}
-				}
-				return nil
-			})
+			return renderListTables(r, baseEnv, cat)
 		},
 	}
 
@@ -92,4 +103,33 @@ Then list the tables:
 		"schema SQL file(s) to load (repeatable)")
 
 	return cmd
+}
+
+// renderListTables emits the table-name list for cat through the
+// standard envelope. Schema-load warnings on cat are appended first so
+// they ride along regardless of how many tables were found. Both the
+// explicit --schema and config-fallback branches funnel through here
+// so the two paths render identically.
+func renderListTables(r output.Renderer, baseEnv output.Envelope, cat *catalog.Catalog) error {
+	appendSchemaWarnings(&baseEnv, cat)
+
+	tables := cat.TableNames()
+	if tables == nil {
+		tables = []string{}
+	}
+
+	data, err := json.Marshal(listTablesResult{Tables: tables})
+	if err != nil {
+		return r.RenderError(baseEnv, err)
+	}
+	baseEnv.Data = data
+
+	return r.Render(baseEnv, func(w io.Writer) error {
+		for _, name := range tables {
+			if _, err := fmt.Fprintln(w, name); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/cmd/list_tables_test.go
+++ b/cmd/list_tables_test.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,6 +75,9 @@ func TestListTablesCmdMissingSchemaFlag(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.NotEmpty(t, env.Errors)
 	require.Contains(t, env.Errors[0].Message, "--schema")
+	// The message also nudges users toward the config-driven path so
+	// they discover the alternative without consulting docs.
+	require.Contains(t, env.Errors[0].Message, "crdb-sql.yaml")
 }
 
 func TestListTablesCmdEmptySchema(t *testing.T) {
@@ -154,6 +158,275 @@ func TestListTablesCmdParseError(t *testing.T) {
 	root.SetOut(&stdout)
 	root.SetErr(&bytes.Buffer{})
 	root.SetArgs([]string{"list-tables", "--schema", schema, "--output", "json"})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "parse schema")
+}
+
+// setupListTablesConfigProject lays down a tiny project with two
+// schema files and a crdb-sql.yaml that picks them up by glob.
+// Mirrors setupDescribeConfigProject. Queries are intentionally
+// absent — list-tables doesn't read them.
+func setupListTablesConfigProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT8 PRIMARY KEY);\n")
+	writeFile(t, dir, "schema/orders.sql",
+		"CREATE TABLE orders (id INT8 PRIMARY KEY);\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+	return dir
+}
+
+func TestListTablesCmdConfigText(t *testing.T) {
+	dir := setupListTablesConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	// expandConfigSchemaPaths sorts paths, so orders.sql is processed
+	// before users.sql; TableNames preserves encounter order.
+	require.Equal(t, "orders\nusers\n", stdout.String())
+}
+
+func TestListTablesCmdConfigJSON(t *testing.T) {
+	dir := setupListTablesConfigProject(t)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.TierSchemaFile, env.Tier)
+	require.Empty(t, env.Errors)
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"orders", "users"}, result.Tables)
+}
+
+// TestListTablesCmdConfigEmptyExpansion covers the case where a
+// crdb-sql.yaml is discovered but its globs match no files. The error
+// must name the config (not the no-config message) so users can tell
+// their config was loaded and the globs are the problem.
+func TestListTablesCmdConfigEmptyExpansion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "crdb-sql.yaml")
+	require.Contains(t, env.Errors[0].Message, "no schema files matching")
+	require.Contains(t, env.Errors[0].Message, dir)
+}
+
+// TestListTablesCmdExplicitSchemaWinsOverConfig confirms there is no
+// merging: when --schema is passed alongside --config, only the
+// flag-supplied file is loaded. Config has users+orders; --schema
+// points at a file with only "products".
+func TestListTablesCmdExplicitSchemaWinsOverConfig(t *testing.T) {
+	dir := setupListTablesConfigProject(t)
+	override := writeSchemaFile(t, `CREATE TABLE products (id INT8 PRIMARY KEY)`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+		"--schema", override,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors)
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"products"}, result.Tables)
+}
+
+// TestListTablesCmdConfigMultiPairDedup exercises the cross-pair
+// deduplication in expandConfigSchemaPaths. Two pairs share the same
+// schema glob; without the outer dedup map, the shared file would be
+// loaded twice and catalog.LoadFiles would surface a duplicate-table
+// error.
+func TestListTablesCmdConfigMultiPairDedup(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT8 PRIMARY KEY);\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+  - schema: ["schema/users.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.Errors, "duplicate-table errors indicate dedup failed")
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"users"}, result.Tables)
+}
+
+// TestListTablesCmdConfigBadGlob covers the err-return inside
+// expandConfigSchemaPaths' loop. A malformed pattern (unmatched `[`)
+// makes doublestar.FilepathGlob return ErrBadPattern; the rendered
+// envelope must surface that as an error rather than silently
+// producing an empty path list.
+func TestListTablesCmdConfigBadGlob(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/["]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.NotEmpty(t, env.Errors)
+	require.Contains(t, env.Errors[0].Message, "expand glob")
+}
+
+// TestListTablesCmdConfigWarningsPropagated guards the
+// appendSchemaWarnings call inside renderListTables on the
+// config-fallback branch. TestListTablesCmdWarningsPropagated already
+// covers the explicit --schema branch; this one covers the config
+// branch independently so a future refactor that splits the warning
+// hookup loses coverage on at most one path, not both.
+func TestListTablesCmdConfigWarningsPropagated(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/mixed.sql", `
+		SELECT 1;
+		CREATE TABLE t (id INT8 PRIMARY KEY);
+	`)
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+	require.Contains(t, env.Errors[0].Message, "skipped 1 non-CREATE TABLE")
+
+	var result listTablesResult
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.Equal(t, []string{"t"}, result.Tables)
+}
+
+// TestListTablesCmdConfigSchemaParseError covers the
+// renderSchemaLoadError path in the config branch: a glob-matched file
+// with malformed DDL must produce a parse-error envelope.
+func TestListTablesCmdConfigSchemaParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/bad.sql", "CREAT TABLE oops (id INT8)")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: []
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"list-tables",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
 
 	err := root.Execute()
 	require.Error(t, err)


### PR DESCRIPTION
## Summary

Mirror describe's config-driven path in list-tables. When no `--schema`
flag is given but `state.cfg` is non-nil (auto-discovered from CWD or
pointed at by `--config`), expand `cfg.SQL[*].Schema` globs across all
pairs into one deduplicated list and feed it to `catalog.LoadFiles`.
Explicit `--schema` flags continue to win outright with no merging.

Reuses the existing `expandConfigSchemaPaths` helper from `describe.go`
since the semantics match: list-tables produces one output covering the
full schema set, so a single combined catalog is the right shape
(per-pair iteration would force an arbitrary "which pair wins" rule for
table-name overlap, while one catalog lets duplicate-table detection
surface uniformly).

Both branches now funnel through a new `renderListTables` helper so the
explicit-flag and config-fallback paths emit identical envelopes.

The "at least one --schema file is required" error now also mentions
`crdb-sql.yaml` so users hitting a config-file dead end (config exists
but its globs match nothing) get a useful pointer.

Resolves: #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)