### PR TITLE
mcp: expose summarize_sql as MCP tool

### DIFF
--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -38,6 +38,7 @@ var expectedTools = []string{
 	tools.ValidateSQLToolName,
 	tools.FormatSQLToolName,
 	tools.DetectRiskyQueryToolName,
+	tools.SummarizeSQLToolName,
 	tools.ExplainSQLToolName,
 	tools.ExplainSchemaChangeToolName,
 	tools.ListTablesToolName,
@@ -313,6 +314,29 @@ func TestIntegrationDetectRiskyQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIntegrationSummarizeSQL asserts the tool returns one Summary per
+// statement with the expected operation and table set. Specific field
+// shapes (predicates, joins, affected_columns) are pinned in the
+// summarize package's own tests; this test exists to catch wiring
+// breakage between server registration, handler dispatch, and JSON
+// round-trip across the stdio boundary.
+func TestIntegrationSummarizeSQL(t *testing.T) {
+	c := newMCPClient(t)
+
+	res := callTool(t, c, tools.SummarizeSQLToolName, map[string]any{
+		"sql": "DELETE FROM orders WHERE status='x'",
+	})
+	env := decodeEnvelope(t, res)
+	assertTier1Envelope(t, env)
+	require.Empty(t, env.Errors)
+
+	var summaries []map[string]any
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 1)
+	require.Equal(t, "DELETE", summaries[0]["operation"])
+	require.Equal(t, []any{"orders"}, summaries[0]["tables"])
 }
 
 // TestIntegrationListTables covers list_tables on both the happy path

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,11 +5,12 @@
 
 // Package mcp builds the crdb-sql Model Context Protocol server.
 //
-// The server registers a health-check tool (ping), four Tier 1 SQL
-// tools (parse_sql, validate_sql, format_sql, detect_risky_query),
-// two Tier 2 catalog tools (list_tables, describe_table) that operate
-// on inline CREATE TABLE schemas, and the Tier 3 explain_sql tool that
-// runs EXPLAIN against a live cluster. validate_sql is dual-tier: it
+// The server registers a health-check tool (ping), five Tier 1 SQL
+// tools (parse_sql, validate_sql, format_sql, detect_risky_query,
+// summarize_sql), two Tier 2 catalog tools (list_tables,
+// describe_table) that operate on inline CREATE TABLE schemas, and
+// two Tier 3 connected tools (explain_sql, explain_schema_change)
+// that run against a live cluster. validate_sql is dual-tier: it
 // runs Tier 1 by default and lifts to Tier 2 (name resolution) when
 // the caller supplies inline schemas. Keeping construction pure (no
 // transport, no I/O) lets the cmd layer pick a transport — currently
@@ -73,6 +74,7 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.SummarizeSQLTool(), tools.SummarizeSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSchemaChangeTool(), tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))

--- a/internal/mcp/tools/summarize.go
+++ b/internal/mcp/tools/summarize.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/summarize"
+)
+
+// SummarizeSQLTool returns the MCP tool definition for summarize_sql.
+func SummarizeSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		SummarizeSQLToolName,
+		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected columns, and risk level."),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to summarize")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+	)
+}
+
+// SummarizeSQLHandler returns the handler for the summarize_sql tool.
+// It delegates to summarize.Summarize and wraps the result in the
+// standard output.Envelope used by all tools in this package.
+// defaultTargetVersion is the server-level default; per-call
+// target_version arguments override it.
+func SummarizeSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
+	return func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractSQL(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := baseEnvelope(parserVersion, target)
+
+		summaries, err := summarize.Summarize(sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+
+		data, err := json.Marshal(summaries)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode summaries: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -5,9 +5,11 @@
 
 // Package tools provides MCP tool handler constructors for the SQL
 // tools. The Tier 1 (zero-config) tools are parse_sql, validate_sql,
-// format_sql, and detect_risky_query; explain_sql is the only Tier 3
-// (connected) tool, requiring a per-call DSN since the MCP server holds
-// no per-session connection state.
+// format_sql, detect_risky_query, and summarize_sql; the Tier 2
+// (schema_file) tools are list_tables and describe_table; the Tier 3
+// (connected) tools are explain_sql and explain_schema_change, which
+// require a per-call DSN since the MCP server holds no per-session
+// connection state.
 //
 // Each handler returns the same output.Envelope JSON shape that the CLI
 // emits under --output=json, so MCP clients get structured errors,
@@ -36,6 +38,7 @@ const (
 	ValidateSQLToolName         = "validate_sql"
 	FormatSQLToolName           = "format_sql"
 	DetectRiskyQueryToolName    = "detect_risky_query"
+	SummarizeSQLToolName        = "summarize_sql"
 	ExplainSQLToolName          = "explain_sql"
 	ExplainSchemaChangeToolName = "explain_schema_change"
 	ListTablesToolName          = "list_tables"
@@ -77,8 +80,8 @@ func extractRequiredString(req mcp.CallToolRequest, name string) (string, *mcp.C
 }
 
 // extractSQL is a thin convenience wrapper around extractRequiredString
-// for the common "sql" parameter, kept so the four SQL-only handlers
-// (parse, validate, format, risk) stay terse.
+// for the common "sql" parameter, kept so the SQL-input handlers stay
+// terse.
 func extractSQL(req mcp.CallToolRequest) (string, *mcp.CallToolResult) {
 	return extractRequiredString(req, "sql")
 }

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/summarize"
 	"github.com/spilchen/sql-ai-tools/internal/validateresult"
 )
 
@@ -687,6 +688,98 @@ func TestDetectRiskyQueryHandler(t *testing.T) {
 				require.Equal(t, tc.expectedReasonCode, findings[0].ReasonCode)
 				require.Equal(t, risk.SeverityCritical, findings[0].Severity)
 				require.NotEmpty(t, findings[0].FixHint)
+			}
+		})
+	}
+}
+
+func TestSummarizeSQLHandler(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 map[string]any
+		expectedToolErr      bool
+		expectedEnvErrs      bool
+		expectedCode         string
+		expectedSummaryCount int
+		expectedOperation    summarize.Operation
+		expectedTables       []string
+		expectedPredicates   []string
+	}{
+		{
+			name:                 "DELETE with WHERE",
+			args:                 map[string]any{"sql": "DELETE FROM orders WHERE status='x'"},
+			expectedSummaryCount: 1,
+			expectedOperation:    summarize.OpDelete,
+			expectedTables:       []string{"orders"},
+			expectedPredicates:   []string{"status = 'x'"},
+		},
+		{
+			name:                 "multiple statements",
+			args:                 map[string]any{"sql": "SELECT 1; UPDATE t SET x=1 WHERE id=1"},
+			expectedSummaryCount: 2,
+		},
+		{
+			name:            "parse error returns structured SQLSTATE error",
+			args:            map[string]any{"sql": "SELECTT 1"},
+			expectedEnvErrs: true,
+			expectedCode:    "42601",
+		},
+		{
+			name:            "empty sql",
+			args:            map[string]any{"sql": ""},
+			expectedToolErr: true,
+		},
+		{
+			name:            "missing sql param",
+			args:            map[string]any{},
+			expectedToolErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := SummarizeSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			if tc.expectedToolErr {
+				require.True(t, res.IsError, "expected tool-level error")
+				return
+			}
+
+			env := requireEnvelope(t, res)
+			require.Equal(t, testParserVersion, env.ParserVersion)
+			require.Equal(t, output.TierZeroConfig, env.Tier)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+
+			if tc.expectedEnvErrs {
+				require.NotEmpty(t, env.Errors)
+				require.Nil(t, env.Data)
+				if tc.expectedCode != "" {
+					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
+				}
+				return
+			}
+
+			require.Empty(t, env.Errors)
+			require.NotNil(t, env.Data)
+
+			var summaries []summarize.Summary
+			require.NoError(t, json.Unmarshal(env.Data, &summaries))
+			require.Len(t, summaries, tc.expectedSummaryCount)
+
+			if tc.expectedOperation != "" {
+				require.Equal(t, tc.expectedOperation, summaries[0].Operation)
+			}
+			if tc.expectedTables != nil {
+				require.Equal(t, tc.expectedTables, summaries[0].Tables)
+			}
+			if tc.expectedPredicates != nil {
+				require.Equal(t, tc.expectedPredicates, summaries[0].Predicates)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Wire the AST-only summarize logic from `internal/summarize` into the MCP server so agents can call `summarize_sql` directly without shelling out to the CLI subcommand. The handler mirrors `detect_risky_query`: it extracts `sql`, resolves an optional per-call `target_version`, and returns the Tier 0 envelope with `[]summarize.Summary` marshaled into `Data`. Parse errors flow through `diag.FromParseError` so clients see the same SQLSTATE-coded structured error as every other tool.

Resolves: #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)