### PR TITLE
version: emit feature warnings from parse and validate

### DIFF
--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -11,11 +11,13 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // newParseCmd builds the `crdb-sql parse` subcommand. It reads SQL from
@@ -52,10 +54,13 @@ normalized form with literal constants replaced by placeholders.`,
 
 			sql = strings.TrimSpace(sql)
 
-			stmts, err := sqlparse.Classify(sql)
-			if err != nil {
-				return renderParseError(r, baseEnv, err, sql)
+			parsed, parseErr := parser.Parse(sql)
+			if parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
 			}
+			stmts := sqlparse.ClassifyParsed(parsed)
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(parsed, state.targetVersion, nil)...)
 
 			data, err := json.Marshal(stmts)
 			if err != nil {

--- a/cmd/parse_test.go
+++ b/cmd/parse_test.go
@@ -185,3 +185,94 @@ func TestParseCmdConflictingInput(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot use -e flag and file argument together")
 }
+
+// TestParseCmdVersionWarning_PLpgSQL exercises the new feature-warning
+// path: when --target-version predates a feature's Introduced version,
+// the envelope carries a feature_not_yet_introduced WARNING, but the
+// parse still succeeds (data payload is populated, no ErrRendered).
+func TestParseCmdVersionWarning_PLpgSQL(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"parse",
+		"--target-version", "23.2",
+		"-e", `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "23.2", env.TargetVersion)
+
+	// Find the feature warning. The envelope may also carry a
+	// target_version_mismatch warning (parser is on v0.26 in this
+	// build) so we filter rather than index.
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected a feature_not_yet_introduced warning in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, got.Severity)
+	require.Equal(t, "plpgsql_function_body", got.Context["feature_tag"])
+	require.Equal(t, "24.1", got.Context["introduced"])
+	require.Equal(t, "23.2", got.Context["target"])
+	require.NotEmpty(t, env.Data, "parse must still succeed and emit a data payload")
+}
+
+// TestParseCmdVersionWarning_NoneAtNewerTarget pins the negative case:
+// when target is at or after the feature's Introduced version, no
+// feature warning is emitted.
+func TestParseCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"parse",
+		"--target-version", "24.1",
+		"-e", `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestParseCmdVersionWarning_NoFlagSkips covers the documented short-
+// circuit: omitting --target-version skips the inspector entirely.
+// Without this, a regression that promoted "" to "warn anyway" would
+// only surface in MCP tests.
+func TestParseCmdVersionWarning_NoFlagSkips(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"parse",
+		"-e", `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.TargetVersion)
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"no --target-version must skip feature warnings, got %+v", e)
+	}
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/semcheck"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 	"github.com/spilchen/sql-ai-tools/internal/validateresult"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // newValidateCmd builds the `crdb-sql validate` subcommand. It reads
@@ -101,6 +102,9 @@ matched by the config and reports per-file results in one envelope.`,
 				return renderDiagErrors(r, baseEnv, typeErrs)
 			}
 
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(stmts, state.targetVersion, nil)...)
+
 			checks := validateresult.Checks{
 				Syntax:    validateresult.CheckOK,
 				TypeCheck: validateresult.CheckOK,
@@ -154,8 +158,11 @@ matched by the config and reports per-file results in one envelope.`,
 }
 
 // fileResult is one entry in the JSON payload for the config-driven
-// validate path. Each query file gets exactly one entry; ErrorCount
-// is the number of structured Errors attributable to that file.
+// validate path. Each query file gets exactly one entry. ErrorCount
+// counts ERROR-severity diagnostics only; advisory WARNING entries
+// (today: version-aware feature warnings) are excluded so the field
+// stays consistent with Valid — a file with valid=true cannot have
+// error_count>0.
 type fileResult struct {
 	File       string `json:"file"`
 	Valid      bool   `json:"valid"`
@@ -209,11 +216,11 @@ func runValidateConfig(state *rootState, cmd *cobra.Command) error {
 		}
 
 		for _, qp := range queryPaths {
-			fileErrs, ok := validateQueryFile(qp, cat)
+			fileErrs, ok := validateQueryFile(qp, cat, state.targetVersion)
 			results = append(results, fileResult{
 				File:       qp,
 				Valid:      ok,
-				ErrorCount: len(fileErrs),
+				ErrorCount: countErrors(fileErrs),
 			})
 			baseEnv.Errors = append(baseEnv.Errors, fileErrs...)
 			if !ok {
@@ -248,11 +255,19 @@ func runValidateConfig(state *rootState, cmd *cobra.Command) error {
 
 // validateQueryFile reads one query file and runs the same parse +
 // type-check pipeline used in the single-input path. When cat is
-// non-nil, table-name resolution also runs against it. Each returned
-// output.Error is tagged with the file path in Context["file"] so
-// agents can attribute diagnostics across many files in one envelope.
-// Returns ok=true when no errors were found.
-func validateQueryFile(path string, cat *catalog.Catalog) (errs []output.Error, ok bool) {
+// non-nil, table-name resolution also runs against it. When
+// targetVersion is non-empty, version-aware feature warnings are
+// appended too. Each returned output.Error is tagged with the file
+// path in Context["file"] so agents can attribute diagnostics across
+// many files in one envelope.
+//
+// ok is true when no ERROR-severity diagnostics were found. Advisory
+// WARNING-severity entries (today: version-aware feature warnings)
+// are surfaced in errs but do not flip ok — the per-file Valid
+// status mirrors the single-input path, where warnings are advisory.
+func validateQueryFile(
+	path string, cat *catalog.Catalog, targetVersion string,
+) (errs []output.Error, ok bool) {
 	data, readErr := os.ReadFile(path)
 	if readErr != nil {
 		return []output.Error{{
@@ -277,22 +292,49 @@ func validateQueryFile(path string, cat *catalog.Catalog) (errs []output.Error, 
 		return []output.Error{tagFile(e, path)}, false
 	}
 
-	var fileErrs []output.Error
-	for _, e := range semcheck.CheckExprTypes(stmts, sql) {
+	var (
+		fileErrs   []output.Error
+		hardErrors bool
+	)
+	addHard := func(e output.Error) {
 		fileErrs = append(fileErrs, tagFile(e, path))
+		hardErrors = true
+	}
+	addAdvisory := func(e output.Error) {
+		fileErrs = append(fileErrs, tagFile(e, path))
+	}
+	for _, e := range semcheck.CheckExprTypes(stmts, sql) {
+		addHard(e)
 	}
 	if cat != nil {
 		for _, e := range semcheck.CheckTableNames(stmts, sql, cat) {
-			fileErrs = append(fileErrs, tagFile(e, path))
+			addHard(e)
 		}
 		for _, e := range semcheck.CheckColumnNames(stmts, sql, cat) {
-			fileErrs = append(fileErrs, tagFile(e, path))
+			addHard(e)
 		}
+	}
+	for _, e := range version.Inspect(stmts, targetVersion, nil) {
+		addAdvisory(e)
 	}
 	if len(fileErrs) == 0 {
 		return nil, true
 	}
-	return fileErrs, false
+	return fileErrs, !hardErrors
+}
+
+// countErrors returns the number of ERROR-severity entries in errs,
+// excluding advisory warnings. Used to keep fileResult.ErrorCount
+// consistent with fileResult.Valid: an advisory-only file should
+// report error_count=0 alongside valid=true.
+func countErrors(errs []output.Error) int {
+	n := 0
+	for _, e := range errs {
+		if e.Severity == output.SeverityError {
+			n++
+		}
+	}
+	return n
 }
 
 // tagFile attaches the source file path to an error's Context so

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -858,3 +858,237 @@ func TestValidateCmdSchemaTextSuccess(t *testing.T) {
 	require.NoError(t, root.Execute())
 	require.Equal(t, "Valid.\n", stdout.String())
 }
+
+// TestValidateCmdVersionWarning_PLpgSQL is the issue #84 demo case:
+// validate --target-version 23.2 on a PL/pgSQL routine returns
+// valid: true alongside a feature_not_yet_introduced WARNING. The
+// verdict is unchanged; the warning is advisory.
+func TestValidateCmdVersionWarning_PLpgSQL(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--target-version", "23.2",
+		"-e", `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected feature_not_yet_introduced in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, got.Severity)
+	require.Equal(t, "plpgsql_function_body", got.Context["feature_tag"])
+	require.Contains(t, got.Message, "PL/pgSQL")
+	require.Contains(t, got.Message, "24.1")
+	require.Contains(t, got.Message, "23.2")
+
+	var result struct {
+		Valid bool `json:"valid"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.True(t, result.Valid, "verdict must remain valid: warnings are advisory")
+}
+
+// TestValidateCmdVersionWarning_NoneAtNewerTarget pins that no
+// feature warning fires when the target meets the introduced version.
+func TestValidateCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--target-version", "24.1",
+		"-e", `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestValidateCmdConfigVersionWarning exercises the config-driven path
+// with a query that uses a feature unavailable at the target version.
+// The per-file Valid status must remain true (warnings are advisory),
+// the envelope must carry a feature_not_yet_introduced WARNING tagged
+// with the originating file, and overall execution must succeed (no
+// ErrRendered). This is the only test that exercises validateQueryFile's
+// new addAdvisory path end-to-end.
+func TestValidateCmdConfigVersionWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	queryPath := writeFile(t, dir, "queries/fn.sql",
+		`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;`+"\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--target-version", "23.2",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute(),
+		"version warnings are advisory; the run must not exit non-zero")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var featWarn *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			featWarn = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, featWarn, "expected feature warning in %+v", env.Errors)
+	require.Equal(t, queryPath, featWarn.Context["file"],
+		"advisory warning must carry the originating file path")
+
+	var payload struct {
+		Files []struct {
+			File       string `json:"file"`
+			Valid      bool   `json:"valid"`
+			ErrorCount int    `json:"error_count"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 1)
+	require.True(t, payload.Files[0].Valid,
+		"advisory warning must not flip per-file Valid")
+}
+
+// TestValidateCmdConfigMixedErrorAndWarning pins the validateQueryFile
+// contract for files that have BOTH a hard ERROR (table that doesn't
+// resolve against the schema) and an advisory WARNING (PL/pgSQL at a
+// pre-Introduced target). The hard error must flip Valid to false;
+// the warning must still appear in the envelope; ErrorCount must
+// count only the hard error so the field stays consistent with Valid.
+func TestValidateCmdConfigMixedErrorAndWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	queryPath := writeFile(t, dir, "queries/q.sql",
+		`SELECT * FROM nonexistent;`+"\n"+
+			`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;`+"\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--target-version", "23.2",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered, "hard error must exit non-zero")
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	hardErr, advisoryWarn := false, false
+	for _, e := range env.Errors {
+		if e.Code == "42P01" {
+			hardErr = true
+		}
+		if e.Code == output.CodeFeatureNotYetIntroduced {
+			advisoryWarn = true
+		}
+	}
+	require.True(t, hardErr, "missing hard 42P01 error: %+v", env.Errors)
+	require.True(t, advisoryWarn, "missing advisory feature warning: %+v", env.Errors)
+
+	var payload struct {
+		Files []struct {
+			File       string `json:"file"`
+			Valid      bool   `json:"valid"`
+			ErrorCount int    `json:"error_count"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 1)
+	require.False(t, payload.Files[0].Valid, "hard error must flip Valid")
+	require.Equal(t, queryPath, payload.Files[0].File)
+	require.Equal(t, 1, payload.Files[0].ErrorCount,
+		"ErrorCount must count only the hard error, not the advisory warning")
+}
+
+// TestValidateCmdConfigVersionWarningErrorCount pins that an advisory-
+// only file reports error_count=0 alongside valid=true. This is the
+// regression guard for the iteration-2 fix that excluded WARNINGs
+// from ErrorCount.
+func TestValidateCmdConfigVersionWarningErrorCount(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	writeFile(t, dir, "queries/fn.sql",
+		`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;`+"\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--target-version", "23.2",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	var payload struct {
+		Files []struct {
+			Valid      bool `json:"valid"`
+			ErrorCount int  `json:"error_count"`
+		} `json:"files"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Len(t, payload.Files, 1)
+	require.True(t, payload.Files[0].Valid)
+	require.Equal(t, 0, payload.Files[0].ErrorCount,
+		"advisory-only file must report error_count=0")
+}

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -10,12 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/diag"
-	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // ParseSQLTool returns the MCP tool definition for parse_sql.
@@ -47,11 +48,13 @@ func ParseSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHand
 
 		env := baseEnvelope(parserVersion, target)
 
-		stmts, err := sqlparse.Classify(sql)
+		parsed, err := parser.Parse(sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
 			return envelopeResult(env)
 		}
+		stmts := sqlparse.ClassifyParsed(parsed)
+		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
 
 		data, err := json.Marshal(stmts)
 		if err != nil {

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -998,3 +998,140 @@ func TestParseSQLHandlerTargetVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestParseSQLHandler_VersionWarning exercises the inspector wired
+// into the MCP parse_sql tool: a per-call target_version that
+// predates the seeded plpgsql_function_body Introduced version
+// produces a feature_not_yet_introduced WARNING in the envelope
+// while the data payload (classified statements) still populates.
+//
+// Mirrors TestParseCmdVersionWarning_PLpgSQL on the CLI surface so a
+// regression in either path is caught locally.
+func TestParseSQLHandler_VersionWarning(t *testing.T) {
+	const plpgsqlSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+	tests := []struct {
+		name           string
+		targetVersion  string
+		expectFeatWarn bool
+	}{
+		{name: "before introduced", targetVersion: "23.2", expectFeatWarn: true},
+		{name: "at introduced", targetVersion: "24.1", expectFeatWarn: false},
+		{name: "no target version skips", targetVersion: "", expectFeatWarn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ParseSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			args := map[string]any{"sql": plpgsqlSQL}
+			if tc.targetVersion != "" {
+				args["target_version"] = tc.targetVersion
+			}
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.NotEmpty(t, env.Data, "data payload must populate even with warnings")
+
+			featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+			if !tc.expectFeatWarn {
+				require.Nilf(t, featWarn, "unexpected feature warning: %+v", featWarn)
+				return
+			}
+			require.NotNilf(t, featWarn, "expected feature_not_yet_introduced in %+v", env.Errors)
+			require.Equal(t, output.SeverityWarning, featWarn.Severity)
+			require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
+		})
+	}
+}
+
+// TestValidateSQLHandler_VersionWarning is the MCP-side mirror of the
+// issue #84 demo: per-call target_version=23.2 with PL/pgSQL emits
+// the feature warning while keeping valid: true. Coverage at this
+// layer ensures CLI and MCP stay in sync as the inspector grows.
+func TestValidateSQLHandler_VersionWarning(t *testing.T) {
+	const plpgsqlSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+	handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            plpgsqlSQL,
+		"target_version": "23.2",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+	require.NotNilf(t, featWarn, "expected feature warning in %+v", env.Errors)
+	require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+
+	var result validateresult.Result
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.True(t, result.Valid, "warnings are advisory; verdict must remain valid")
+}
+
+// findEnvErrorByCode returns the first envelope Error whose Code
+// matches code, or nil. Tests use it instead of indexing into the
+// Errors slice so that an unrelated warning (e.g.
+// target_version_mismatch from the parser-version skew) sitting at
+// position 0 doesn't shift the assertion target.
+func findEnvErrorByCode(errs []output.Error, code string) *output.Error {
+	for i := range errs {
+		if errs[i].Code == code {
+			return &errs[i]
+		}
+	}
+	return nil
+}
+
+// TestParseSQLHandler_ParseErrorPreservesPriorWarnings pins that the
+// parse handler appends (rather than overwrites) on parse failure: a
+// pre-stamped target_version_mismatch warning from baseEnvelope must
+// survive into the response. Without this, agents lose the version-
+// skew signal exactly when their SQL is malformed.
+func TestParseSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := ParseSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	// target_version with a different MAJOR.MINOR than testParserVersion
+	// (v0.26.2) triggers VersionMismatchWarning; SELECTT 1 then forces
+	// a parse error.
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}
+
+// TestValidateSQLHandler_ParseErrorPreservesPriorWarnings is the
+// validate-side mirror — the same append-not-overwrite contract on
+// the validate handler's parse-error branch.
+func TestValidateSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
 	"github.com/spilchen/sql-ai-tools/internal/semcheck"
 	"github.com/spilchen/sql-ai-tools/internal/validateresult"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // ValidateSQLTool returns the MCP tool definition for validate_sql.
@@ -76,14 +77,16 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 
 		stmts, parseErr := parser.Parse(sql)
 		if parseErr != nil {
-			env.Errors = []output.Error{diag.FromParseError(parseErr, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(parseErr, sql))
 			return envelopeResult(env)
 		}
 
 		if typeErrs := semcheck.CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
-			env.Errors = typeErrs
+			env.Errors = append(env.Errors, typeErrs...)
 			return envelopeResult(env)
 		}
+
+		env.Errors = append(env.Errors, version.Inspect(stmts, target, nil)...)
 
 		checks := validateresult.Checks{
 			Syntax:    validateresult.CheckOK,

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -102,6 +102,15 @@ const (
 	// version differs from the bundled parser version at the
 	// MAJOR.MINOR level.
 	CodeTargetVersionMismatch = "target_version_mismatch"
+
+	// CodeFeatureNotYetIntroduced is emitted when the AST inspector
+	// recognizes a CockroachDB SQL feature whose Introduced version
+	// (per the version registry) is newer than the user's declared
+	// target version. The accompanying Error.Context carries the
+	// feature_tag, feature_name, introduced, and target keys so
+	// agents can branch programmatically without parsing the
+	// human-readable Message.
+	CodeFeatureNotYetIntroduced = "feature_not_yet_introduced"
 )
 
 // Severity is the severity level of a structured Error. Values use the

--- a/internal/sqlparse/classify.go
+++ b/internal/sqlparse/classify.go
@@ -14,6 +14,7 @@ package sqlparse
 
 import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -56,12 +57,25 @@ type ClassifiedStatement struct {
 // mode).
 //
 // An empty input returns an empty slice with no error.
+//
+// Callers that need both the classified output and the underlying AST
+// (to layer additional analysis like version.Inspect on top) should
+// call parser.Parse themselves and use ClassifyParsed instead, to
+// avoid double-parsing.
 func Classify(sql string) ([]ClassifiedStatement, error) {
 	stmts, err := parser.Parse(sql)
 	if err != nil {
 		return nil, err
 	}
+	return ClassifyParsed(stmts), nil
+}
 
+// ClassifyParsed turns an already-parsed statement set into per-
+// statement classifications. It is the second half of Classify, exposed
+// so callers that already invoked parser.Parse (e.g. to also run
+// type-checking or AST inspection) can reuse the parsed output rather
+// than reparsing the SQL string.
+func ClassifyParsed(stmts statements.Statements) []ClassifiedStatement {
 	result := make([]ClassifiedStatement, len(stmts))
 	for i, stmt := range stmts {
 		result[i] = ClassifiedStatement{
@@ -71,7 +85,7 @@ func Classify(sql string) ([]ClassifiedStatement, error) {
 			Normalized:    tree.FormatStatementHideConstants(stmt.AST),
 		}
 	}
-	return result, nil
+	return result
 }
 
 // mapStatementType converts a tree.StatementType enum value to its

--- a/internal/version/check.go
+++ b/internal/version/check.go
@@ -1,0 +1,235 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package version
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// defaultRegistry is the package-level Registry singleton consumed by
+// Inspect when its reg argument is nil. Built once at init time so
+// per-request callers do not pay the cost of constructing (and
+// validating) the seeded set on every parse/validate invocation. Must
+// stay equivalent to DefaultRegistry().
+var defaultRegistry = DefaultRegistry()
+
+// Inspect walks each top-level statement in stmts, detects any
+// CockroachDB SQL features it recognizes, and returns one
+// output.Error (Severity=WARNING, Code=CodeFeatureNotYetIntroduced)
+// per detected feature whose Introduced version (per reg) is newer
+// than target. Warnings are advisory: the parse / validate verdict
+// is unchanged.
+//
+// target must be in canonical form (post-output.ValidateTargetVersion):
+// MAJOR.MINOR or MAJOR.MINOR.PATCH, no leading "v". An empty target
+// returns nil so callers can invoke Inspect unconditionally without
+// guarding on whether --target-version was supplied.
+//
+// reg may be nil, in which case the package-level defaultRegistry
+// (seeded from DefaultRegistry) is used. Tests pass an explicit
+// registry to exercise hand-rolled features.
+//
+// Each returned Error carries Context entries — feature_tag,
+// feature_name, introduced, target — so agents can branch
+// programmatically without parsing the human-readable Message.
+//
+// Precondition: target has already been validated by the caller (the
+// CLI does this in cmd/root via output.ValidateTargetVersion; the MCP
+// surface does it in resolveTargetVersion). An unparseable target
+// silently returns no warnings, mirroring Registry.Supports.
+func Inspect(stmts statements.Statements, target string, reg *Registry) []output.Error {
+	if target == "" || len(stmts) == 0 {
+		return nil
+	}
+	if reg == nil {
+		reg = defaultRegistry
+	}
+
+	var warnings []output.Error
+	for _, stmt := range stmts {
+		// Per-statement dedupe: a CREATE TABLE ... LOCALITY REGIONAL
+		// BY ROW with a trigram index would otherwise emit two
+		// warnings for the same locality if the visitor surfaced it
+		// twice. The seen set scopes to one statement so a multi-
+		// statement input still warns once per statement.
+		seen := make(map[string]struct{})
+		for _, tag := range detectFeatures(stmt.AST) {
+			if _, dup := seen[tag]; dup {
+				continue
+			}
+			seen[tag] = struct{}{}
+			status, feat := reg.Supports(target, tag)
+			if status != StatusNotYetIntroduced {
+				continue
+			}
+			warnings = append(warnings, buildWarning(feat, target))
+		}
+	}
+	return warnings
+}
+
+// detectFeatures returns the set of registry tags whose feature is
+// referenced by stmt. The detector deliberately uses a top-level
+// type switch rather than a tree.WalkStmt visitor: each seeded
+// feature lives in a specific statement shape (CreateRoutine,
+// CreateTable, AlterTable, AlterTableLocality, CreateIndex,
+// AlterChangefeed), and a deep walk would surface no additional
+// cases while complicating IndexElem traversal (IndexElem is not
+// visited by tree.WalkStmt's Expr/Statement/TableExpr method set).
+//
+// The current implementation cannot return a duplicate tag for one
+// statement, but Inspect dedupes anyway so future detectors that
+// surface the same tag from multiple subtrees stay safe.
+func detectFeatures(stmt tree.Statement) []string {
+	var tags []string
+	switch s := stmt.(type) {
+	case *tree.CreateRoutine:
+		if hasPLpgSQLBody(s) {
+			tags = append(tags, FeaturePLpgSQLFunctionBody)
+		}
+	case *tree.CreateTable:
+		if isRegionalByRow(s.Locality) {
+			tags = append(tags, FeatureRegionalByRow)
+		}
+		if defsHaveTrigramIndex(s.Defs) {
+			tags = append(tags, FeatureTrigramIndex)
+		}
+	case *tree.AlterTableLocality:
+		// The parser surfaces ALTER TABLE ... SET LOCALITY ... as a
+		// distinct top-level statement, not an AlterTable with a
+		// locality command, so this case stands alone rather than
+		// nesting inside *tree.AlterTable.
+		if isRegionalByRow(s.Locality) {
+			tags = append(tags, FeatureRegionalByRow)
+		}
+	case *tree.AlterTable:
+		// ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (col gin_trgm_ops)
+		// is the realistic shape that lets a user retrofit a trigram
+		// index without a full CREATE INDEX. The constraint def reuses
+		// IndexElemList, so the same opclass check applies. We walk
+		// every cmd rather than short-circuit so the dedupe contract
+		// in Inspect handles multi-cmd statements (e.g. two ADD
+		// CONSTRAINT clauses in one ALTER TABLE) uniformly with the
+		// other detector arms.
+		for _, cmd := range s.Cmds {
+			add, ok := cmd.(*tree.AlterTableAddConstraint)
+			if !ok {
+				continue
+			}
+			uc, ok := add.ConstraintDef.(*tree.UniqueConstraintTableDef)
+			if !ok {
+				continue
+			}
+			if elemsHaveTrigramOpClass(uc.Columns) {
+				tags = append(tags, FeatureTrigramIndex)
+			}
+		}
+	case *tree.CreateIndex:
+		if elemsHaveTrigramOpClass(s.Columns) {
+			tags = append(tags, FeatureTrigramIndex)
+		}
+	case *tree.AlterChangefeed:
+		tags = append(tags, FeatureAlterChangefeed)
+	}
+	return tags
+}
+
+// hasPLpgSQLBody reports whether the routine declares LANGUAGE
+// plpgsql. The check mirrors upstream cockroachdb-parser's own
+// detection in create_routine.go: scan the RoutineOption list for a
+// RoutineLanguage value of RoutineLangPLpgSQL. The parser normalizes
+// "PLpgSQL", "plpgsql", "PLPGSQL" to the same RoutineLangPLpgSQL
+// value, so a case-fold compare is unnecessary.
+func hasPLpgSQLBody(s *tree.CreateRoutine) bool {
+	for _, opt := range s.Options {
+		if lang, ok := opt.(tree.RoutineLanguage); ok && lang == tree.RoutineLangPLpgSQL {
+			return true
+		}
+	}
+	return false
+}
+
+// isRegionalByRow reports whether loc declares REGIONAL BY ROW
+// placement. nil is treated as "no locality declared," not as a
+// match — REGIONAL BY ROW must be explicit in the SQL to be flagged.
+func isRegionalByRow(loc *tree.Locality) bool {
+	return loc != nil && loc.LocalityLevel == tree.LocalityLevelRow
+}
+
+// defsHaveTrigramIndex scans the table definitions for an inline
+// INDEX clause that uses a trigram opclass on any of its columns.
+// Inline indexes parse into *tree.IndexTableDef (and
+// *tree.UniqueConstraintTableDef.IndexTableDef for unique forms);
+// both share the same IndexElemList shape so the inner check is
+// reused.
+func defsHaveTrigramIndex(defs tree.TableDefs) bool {
+	for _, def := range defs {
+		switch d := def.(type) {
+		case *tree.IndexTableDef:
+			if elemsHaveTrigramOpClass(d.Columns) {
+				return true
+			}
+		case *tree.UniqueConstraintTableDef:
+			if elemsHaveTrigramOpClass(d.Columns) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// elemsHaveTrigramOpClass reports whether any element in elems uses
+// a trigram operator class (gin_trgm_ops or gist_trgm_ops). The
+// match is case-insensitive because tree.Name preserves the user's
+// casing — a future regression that downcased OpClass at parse time
+// would otherwise silently break detection here.
+func elemsHaveTrigramOpClass(elems tree.IndexElemList) bool {
+	for _, e := range elems {
+		oc := strings.ToLower(string(e.OpClass))
+		if oc == "gin_trgm_ops" || oc == "gist_trgm_ops" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildWarning constructs the user-facing Error for a detected feature
+// whose Introduced version is newer than target. The Message follows
+// the demo wording in issue #84; the Context map carries the same
+// data in machine-readable form so agents do not need to re-parse the
+// string. DocURL is included only when non-empty so the JSON payload
+// stays tight for the common (no-docs-link) case.
+func buildWarning(feat Feature, target string) output.Error {
+	ctx := map[string]any{
+		"feature_tag":  feat.Tag,
+		"feature_name": feat.Name,
+		"introduced":   feat.Introduced,
+		"target":       target,
+	}
+	if feat.DocURL != "" {
+		ctx["doc_url"] = feat.DocURL
+	}
+	return output.Error{
+		Code:     output.CodeFeatureNotYetIntroduced,
+		Severity: output.SeverityWarning,
+		// Phrased "X required for Y" rather than "Y requires X" so the
+		// sentence reads naturally for both singular feature names
+		// ("ALTER CHANGEFEED") and plural ones ("PL/pgSQL function
+		// bodies") — the latter would force a "bodies requires"
+		// disagreement under the inverse phrasing.
+		Message: fmt.Sprintf(
+			"CockroachDB v%s+ required for %s; target version is %s",
+			feat.Introduced, feat.Name, target,
+		),
+		Context: ctx,
+	}
+}

--- a/internal/version/check_test.go
+++ b/internal/version/check_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// TestInspect_FeatureBoundaries pins one (feature, target) per
+// detector at "before introduced" (warns) and "at introduced" (no
+// warning). The feature-name and code shape are checked once via
+// findWarningByTag below; this table keeps the per-feature surface
+// small and readable.
+func TestInspect_FeatureBoundaries(t *testing.T) {
+	plpgsqlSQL := `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+	rbrCreateSQL := `CREATE TABLE t (id INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`
+	rbrAlterSQL := `ALTER TABLE t SET LOCALITY REGIONAL BY ROW`
+	trigramCreateIndexSQL := `CREATE INDEX i ON t USING GIN (col gin_trgm_ops)`
+	trigramInlineIndexSQL := `CREATE TABLE t (col TEXT, INVERTED INDEX (col gin_trgm_ops))`
+	alterChangefeedSQL := `ALTER CHANGEFEED 12345 SET resolved = '5s'`
+
+	tests := []struct {
+		name        string
+		sql         string
+		target      string
+		expectedTag string // empty means: no warning expected
+	}{
+		{name: "plpgsql before introduced", sql: plpgsqlSQL, target: "23.2", expectedTag: FeaturePLpgSQLFunctionBody},
+		{name: "plpgsql at introduced", sql: plpgsqlSQL, target: "24.1", expectedTag: ""},
+		{name: "plpgsql after introduced", sql: plpgsqlSQL, target: "25.4", expectedTag: ""},
+
+		{name: "regional by row create before", sql: rbrCreateSQL, target: "20.2", expectedTag: FeatureRegionalByRow},
+		{name: "regional by row create at", sql: rbrCreateSQL, target: "21.1", expectedTag: ""},
+		{name: "regional by row alter before", sql: rbrAlterSQL, target: "20.2", expectedTag: FeatureRegionalByRow},
+		{name: "regional by row alter at", sql: rbrAlterSQL, target: "21.1", expectedTag: ""},
+
+		{name: "trigram create index before", sql: trigramCreateIndexSQL, target: "22.2", expectedTag: FeatureTrigramIndex},
+		{name: "trigram create index at", sql: trigramCreateIndexSQL, target: "23.1", expectedTag: ""},
+		{name: "trigram inline index before", sql: trigramInlineIndexSQL, target: "22.2", expectedTag: FeatureTrigramIndex},
+		{name: "trigram inline index at", sql: trigramInlineIndexSQL, target: "23.1", expectedTag: ""},
+
+		{name: "alter changefeed before", sql: alterChangefeedSQL, target: "21.2", expectedTag: FeatureAlterChangefeed},
+		{name: "alter changefeed at", sql: alterChangefeedSQL, target: "22.1", expectedTag: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			warnings := Inspect(stmts, tc.target, nil)
+
+			if tc.expectedTag == "" {
+				require.Empty(t, warnings, "expected no warnings, got %+v", warnings)
+				return
+			}
+
+			w := findWarningByTag(warnings, tc.expectedTag)
+			require.NotNilf(t, w, "expected warning with feature_tag=%q in %+v", tc.expectedTag, warnings)
+			require.Equal(t, output.CodeFeatureNotYetIntroduced, w.Code)
+			require.Equal(t, output.SeverityWarning, w.Severity)
+			require.Equal(t, tc.target, w.Context["target"])
+			require.NotEmpty(t, w.Context["feature_name"])
+			require.NotEmpty(t, w.Context["introduced"])
+			require.Contains(t, w.Message, w.Context["feature_name"].(string))
+		})
+	}
+}
+
+// TestInspect_EmptyTargetSkips pins the documented short-circuit:
+// callers can invoke Inspect unconditionally; an empty target means
+// "no --target-version was supplied" and produces no warnings.
+func TestInspect_EmptyTargetSkips(t *testing.T) {
+	stmts, err := parser.Parse(`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`)
+	require.NoError(t, err)
+	require.Empty(t, Inspect(stmts, "", nil))
+}
+
+// TestInspect_EmptyStmtsSkips pins the empty-stmts short-circuit so
+// callers can pass a nil/empty slice (e.g. the empty-input MCP path)
+// without producing spurious warnings.
+func TestInspect_EmptyStmtsSkips(t *testing.T) {
+	require.Empty(t, Inspect(nil, "23.2", nil))
+}
+
+// TestInspect_UnknownFeatureNoWarning makes sure that a statement type
+// the inspector doesn't recognize (here: a plain SELECT) produces no
+// warnings even at an ancient target version. Without this, a future
+// refactor that accidentally promoted "no detector" to "warn anyway"
+// would slip through.
+func TestInspect_UnknownFeatureNoWarning(t *testing.T) {
+	stmts, err := parser.Parse(`SELECT 1`)
+	require.NoError(t, err)
+	require.Empty(t, Inspect(stmts, "1.0", nil))
+}
+
+// TestInspect_PLpgSQLDetectorNegativeCases pins that the routine
+// detector fires only on LANGUAGE plpgsql. A regression that dropped
+// the language check (or inverted it) would warn on every CREATE
+// FUNCTION and the existing positive cases would still pass.
+func TestInspect_PLpgSQLDetectorNegativeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "LANGUAGE SQL must not warn", sql: `CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS 'SELECT 1'`},
+		{name: "no LANGUAGE clause must not warn", sql: `CREATE FUNCTION f() RETURNS INT AS 'SELECT 1' LANGUAGE SQL`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Empty(t, Inspect(stmts, "1.0", nil))
+		})
+	}
+}
+
+// TestInspect_TrigramOpClassVariants exercises the gist_trgm_ops
+// branch and the case-fold path of elemsHaveTrigramOpClass — both
+// of which are unreached by the boundary table above (which only
+// uses lowercase gin_trgm_ops).
+func TestInspect_TrigramOpClassVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "gist_trgm_ops on CREATE INDEX", sql: `CREATE INDEX i ON t USING GIST (col gist_trgm_ops)`},
+		{name: "uppercase GIN_TRGM_OPS", sql: `CREATE INDEX i ON t USING GIN (col GIN_TRGM_OPS)`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			warnings := Inspect(stmts, "22.2", nil)
+			require.Len(t, warnings, 1)
+			require.Equal(t, FeatureTrigramIndex, warnings[0].Context["feature_tag"])
+		})
+	}
+}
+
+// TestInspect_TrigramViaAlterTableAddConstraint covers the realistic
+// retrofit pattern: ALTER TABLE ... ADD CONSTRAINT u UNIQUE (col
+// gin_trgm_ops). Without the *tree.AlterTable arm in detectFeatures
+// this case silently bypasses the warning.
+func TestInspect_TrigramViaAlterTableAddConstraint(t *testing.T) {
+	stmts, err := parser.Parse(`ALTER TABLE t ADD CONSTRAINT u UNIQUE (col gin_trgm_ops)`)
+	require.NoError(t, err)
+	warnings := Inspect(stmts, "22.2", nil)
+	require.Len(t, warnings, 1)
+	require.Equal(t, FeatureTrigramIndex, warnings[0].Context["feature_tag"])
+}
+
+// TestInspect_AlterTableNegativeCases exercises every short-circuit
+// branch in the *tree.AlterTable arm: a non-AddConstraint cmd, an
+// AddConstraint with a non-Unique constraint def, and a UNIQUE
+// constraint without a trigram opclass. All three must produce no
+// warning. Without these, a refactor that flipped any inner type
+// assertion would still pass the positive
+// TestInspect_TrigramViaAlterTableAddConstraint above.
+func TestInspect_AlterTableNegativeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "ADD COLUMN: non-AddConstraint cmd", sql: `ALTER TABLE t ADD COLUMN x INT`},
+		{name: "ADD CONSTRAINT CHECK: non-Unique constraint", sql: `ALTER TABLE t ADD CONSTRAINT c CHECK (x > 0)`},
+		{name: "ADD CONSTRAINT UNIQUE without opclass", sql: `ALTER TABLE t ADD CONSTRAINT u UNIQUE (col)`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Empty(t, Inspect(stmts, "22.2", nil))
+		})
+	}
+}
+
+// TestInspect_AlterTableMultiCmdDedupes pins that two trigram-bearing
+// ADD CONSTRAINT clauses in one ALTER TABLE produce exactly one
+// warning. The arm walks every cmd (no short-circuit), and the
+// per-statement dedupe in Inspect collapses repeats of the same tag.
+// Without this test, dropping the dedupe would silently double-warn.
+func TestInspect_AlterTableMultiCmdDedupes(t *testing.T) {
+	stmts, err := parser.Parse(
+		`ALTER TABLE t ADD CONSTRAINT u1 UNIQUE (a gin_trgm_ops), ADD CONSTRAINT u2 UNIQUE (b gin_trgm_ops)`)
+	require.NoError(t, err)
+	warnings := Inspect(stmts, "22.2", nil)
+	require.Len(t, warnings, 1)
+	require.Equal(t, FeatureTrigramIndex, warnings[0].Context["feature_tag"])
+}
+
+// TestInspect_RemovedFeatureNoWarning is the dead-code guard for the
+// "status != StatusNotYetIntroduced" branch in Inspect. No seeded
+// feature has Removed set today, so without an explicit registry a
+// refactor that flipped the comparison to "== StatusSupported" would
+// start spamming warnings for removed features and no test would
+// catch it.
+func TestInspect_RemovedFeatureNoWarning(t *testing.T) {
+	custom := NewRegistry(Feature{
+		Tag:        FeaturePLpgSQLFunctionBody,
+		Name:       "deprecated plpgsql",
+		Introduced: "20.1",
+		Removed:    "24.1",
+	})
+	stmts, err := parser.Parse(`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`)
+	require.NoError(t, err)
+	require.Empty(t, Inspect(stmts, "25.4", custom),
+		"target past Removed must not produce a NotYetIntroduced warning")
+}
+
+// TestInspect_MultiStatementWarnsPerStatement covers the contract that
+// each statement is inspected independently: a script mixing one
+// flagged feature and one supported statement produces exactly one
+// warning, attributed by tag (we don't carry per-statement positions
+// in the warning today, but the count must match).
+func TestInspect_MultiStatementWarnsPerStatement(t *testing.T) {
+	sql := `SELECT 1;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;
+CREATE TABLE t (id INT PRIMARY KEY) LOCALITY REGIONAL BY ROW`
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	warnings := Inspect(stmts, "20.2", nil)
+	require.Len(t, warnings, 2)
+
+	require.NotNil(t, findWarningByTag(warnings, FeaturePLpgSQLFunctionBody))
+	require.NotNil(t, findWarningByTag(warnings, FeatureRegionalByRow))
+}
+
+// TestInspect_DedupesWithinStatement asserts the per-statement seen
+// set: a single CREATE TABLE that surfaces the same tag through two
+// detection paths (e.g. inline INDEX trigram check seen twice if the
+// def list is malformed) emits exactly one warning per tag.
+func TestInspect_DedupesWithinStatement(t *testing.T) {
+	// A CREATE TABLE with two trigram inline indexes on different
+	// columns must still warn only once for the trigram tag.
+	sql := `CREATE TABLE t (
+		a TEXT,
+		b TEXT,
+		INVERTED INDEX (a gin_trgm_ops),
+		INVERTED INDEX (b gin_trgm_ops)
+	)`
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	warnings := Inspect(stmts, "22.2", nil)
+	require.Len(t, warnings, 1)
+	require.Equal(t, FeatureTrigramIndex, warnings[0].Context["feature_tag"])
+}
+
+// TestInspect_ExplicitRegistry pins that a caller-supplied registry
+// overrides the package singleton — required for tests of as-yet-
+// unseeded features and for hypothetical downstream callers who want
+// to gate on a custom feature set.
+func TestInspect_ExplicitRegistry(t *testing.T) {
+	custom := NewRegistry(Feature{
+		Tag:        FeaturePLpgSQLFunctionBody,
+		Name:       "custom plpgsql label",
+		Introduced: "99.9",
+	})
+	stmts, err := parser.Parse(`CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`)
+	require.NoError(t, err)
+
+	warnings := Inspect(stmts, "25.4", custom)
+	require.Len(t, warnings, 1)
+	require.Equal(t, "custom plpgsql label", warnings[0].Context["feature_name"])
+}
+
+// TestInspect_DefaultRegistrySingletonMatchesDefault pins the
+// load-bearing contract that the package-level defaultRegistry is the
+// same content as DefaultRegistry(). A refactor that drifted them
+// apart would silently change which warnings the production CLI and
+// MCP surfaces emit, with no test coverage at the call sites.
+func TestInspect_DefaultRegistrySingletonMatchesDefault(t *testing.T) {
+	require.Equal(t, DefaultRegistry().byTag, defaultRegistry.byTag)
+}
+
+// findWarningByTag returns the first warning whose Context.feature_tag
+// matches tag, or nil. Tests use it instead of indexing into the
+// slice so a future detector that adds a second warning per statement
+// (e.g. a side-effect tag) doesn't break unrelated assertions.
+func findWarningByTag(warnings []output.Error, tag string) *output.Error {
+	for i := range warnings {
+		if got, _ := warnings[i].Context["feature_tag"].(string); got == tag {
+			return &warnings[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Wire the feature registry added in #83 into the `parse` and `validate` surfaces (CLI and MCP). When `--target-version` (or the per-call `target_version` MCP argument) predates a feature's `Introduced` version, the envelope now carries a `feature_not_yet_introduced` WARNING entry so agents can surface compatibility gaps without re-deriving them from raw parser output.

The warning is advisory only: validate's `"valid"` verdict is unchanged and parse still emits its data payload. Each warning's `Context` carries `feature_tag`, `feature_name`, `introduced`, and `target` so agents can branch programmatically without parsing the human-readable Message.

## Design

Detection lives in a new `internal/version/check.go` via a top-level type-switch over parsed statements rather than a deep `tree.WalkStmt` visitor, because each seeded feature lives in a specific statement shape (`CreateRoutine`, `CreateTable`, `AlterTable`, `AlterTableLocality`, `CreateIndex`, `AlterChangefeed`) and `IndexElem` op-class checks aren't reachable from the standard visitor's `Expr`/`Statement`/`TableExpr` method set.

The four call sites (`cmd/parse.go`, `cmd/validate.go`, `internal/mcp/tools/{parse,validate}.go`) now share one parse-then-inspect pipeline. To avoid double-parsing, `sqlparse.Classify` is split into `Classify` (parses and classifies in one call, kept for existing callers) and `ClassifyParsed` (takes pre-parsed stmts so callers can layer additional analysis on the same AST).

The config-driven validate path (`validateQueryFile`) gains the same warnings; advisory entries flow into the per-file errors list but do not flip the file's `Valid` status, and `fileResult.ErrorCount` counts only ERROR-severity entries so it stays consistent with `Valid` (an advisory-only file reports `valid=true, error_count=0`).

## Demo

```
$ crdb-sql validate --target-version 23.2 \
    -e "CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS \$\$ BEGIN RETURN 1; END \$\$" \
    --output json | jq '.errors[] | select(.code == "feature_not_yet_introduced")'
{
  "code": "feature_not_yet_introduced",
  "severity": "WARNING",
  "message": "CockroachDB v24.1+ required for PL/pgSQL function bodies; target version is 23.2",
  "context": {
    "feature_name": "PL/pgSQL function bodies",
    "feature_tag": "plpgsql_function_body",
    "introduced": "24.1",
    "target": "23.2"
  }
}
```

Resolves: #84