### PR TITLE
semcheck: accumulate diagnostics across all phases in validate

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -95,40 +95,51 @@ matched by the config and reports per-file results in one envelope.`,
 
 			stmts, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				// A parse failure prevents every later phase from
+				// running, so we report Syntax as the failed phase
+				// and the rest as Skipped. Consumers can branch on
+				// the Checks payload without inspecting error codes.
+				parseChecks := validateresult.Checks{
+					Syntax:         validateresult.CheckFailed,
+					TypeCheck:      validateresult.CheckSkipped,
+					NameResolution: validateresult.CheckSkipped,
+				}
+				return renderValidateFailure(r, baseEnv,
+					[]output.Error{diag.FromParseError(parseErr, sql)}, parseChecks)
 			}
 
-			if typeErrs := semcheck.CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
-				return renderDiagErrors(r, baseEnv, typeErrs)
-			}
-
+			// Version-aware feature warnings are advisory: they
+			// describe target-version compatibility independently
+			// of whether semantic checks pass. Emit them
+			// unconditionally so a user fixing a type error still
+			// sees the upcoming-feature warnings in the same run.
 			baseEnv.Errors = append(baseEnv.Errors,
 				version.Inspect(stmts, state.targetVersion, nil)...)
 
-			checks := validateresult.Checks{
-				Syntax:    validateresult.CheckOK,
-				TypeCheck: validateresult.CheckOK,
-			}
+			checks := validateresult.Checks{Syntax: validateresult.CheckOK}
 
+			var cat *catalog.Catalog
 			if len(schemaFiles) == 0 {
-				checks.NameResolution = validateresult.CheckSkipped
 				baseEnv.Errors = append(baseEnv.Errors, validateresult.CapabilityRequiredError(
 					validateresult.CapabilityNameResolution,
 					"name resolution skipped: --schema not provided",
 					"pass --schema FILE to enable table name resolution",
 				))
 			} else {
-				cat, err := catalog.LoadFiles(schemaFiles)
+				var err error
+				cat, err = catalog.LoadFiles(schemaFiles)
 				if err != nil {
 					return renderSchemaLoadError(r, baseEnv, err)
 				}
 				appendSchemaWarnings(&baseEnv, cat)
-				nameErrs := semcheck.CheckTableNames(stmts, sql, cat)
-				nameErrs = append(nameErrs, semcheck.CheckColumnNames(stmts, sql, cat)...)
-				if len(nameErrs) > 0 {
-					return renderDiagErrors(r, baseEnv, nameErrs)
-				}
-				checks.NameResolution = validateresult.CheckOK
+			}
+
+			semRes, semErrs := semcheck.Run(stmts, sql, cat)
+			checks.TypeCheck = semRes.TypeCheck
+			checks.NameResolution = semRes.NameResolution
+
+			if len(semErrs) > 0 {
+				return renderValidateFailure(r, baseEnv, semErrs, checks)
 			}
 
 			data, err := json.Marshal(validateresult.Result{Valid: true, Checks: checks})
@@ -292,35 +303,25 @@ func validateQueryFile(
 		return []output.Error{tagFile(e, path)}, false
 	}
 
-	var (
-		fileErrs   []output.Error
-		hardErrors bool
-	)
-	addHard := func(e output.Error) {
-		fileErrs = append(fileErrs, tagFile(e, path))
-		hardErrors = true
-	}
-	addAdvisory := func(e output.Error) {
-		fileErrs = append(fileErrs, tagFile(e, path))
-	}
-	for _, e := range semcheck.CheckExprTypes(stmts, sql) {
-		addHard(e)
-	}
-	if cat != nil {
-		for _, e := range semcheck.CheckTableNames(stmts, sql, cat) {
-			addHard(e)
-		}
-		for _, e := range semcheck.CheckColumnNames(stmts, sql, cat) {
-			addHard(e)
-		}
-	}
-	for _, e := range version.Inspect(stmts, targetVersion, nil) {
-		addAdvisory(e)
-	}
-	if len(fileErrs) == 0 {
+	// semcheck.Run returns only hard ERROR-severity diagnostics
+	// (type-check, table-name, column-name); the runner already
+	// accumulates across phases without early returns. Version
+	// warnings are appended afterwards as advisories — they do not
+	// flip the per-file Valid flag, mirroring the single-input
+	// path's treatment of warnings.
+	_, semErrs := semcheck.Run(stmts, sql, cat)
+	versionWarns := version.Inspect(stmts, targetVersion, nil)
+	if len(semErrs) == 0 && len(versionWarns) == 0 {
 		return nil, true
 	}
-	return fileErrs, !hardErrors
+	fileErrs := make([]output.Error, 0, len(semErrs)+len(versionWarns))
+	for _, e := range semErrs {
+		fileErrs = append(fileErrs, tagFile(e, path))
+	}
+	for _, e := range versionWarns {
+		fileErrs = append(fileErrs, tagFile(e, path))
+	}
+	return fileErrs, len(semErrs) == 0
 }
 
 // countErrors returns the number of ERROR-severity entries in errs,
@@ -424,26 +425,63 @@ func renderDiagErrors(r output.Renderer, env output.Envelope, errs []output.Erro
 	env.Data = nil
 
 	if err := r.Render(env, func(w io.Writer) error {
-		for _, diagErr := range errs {
-			pos := diagErr.Position
-			if pos != nil {
-				if _, werr := fmt.Fprintf(w, "%d:%d: %s [%s]\n", pos.Line, pos.Column, diagErr.Message, diagErr.Code); werr != nil {
-					return werr
-				}
-			} else {
-				if _, werr := fmt.Fprintf(w, "%s [%s]\n", diagErr.Message, diagErr.Code); werr != nil {
-					return werr
-				}
-			}
-			if werr := writeSuggestions(w, diagErr.Suggestions); werr != nil {
-				return werr
-			}
-		}
-		return nil
+		return writeDiagErrors(w, errs)
 	}); err != nil {
 		return err
 	}
 	return output.ErrRendered
+}
+
+// renderValidateFailure renders a validate run that produced one or
+// more errors. checks records the per-phase outcome and is marshalled
+// into env.Data as a Result{Valid:false} payload so JSON consumers
+// always learn which phases ran (and which were skipped because an
+// upstream phase failed). errs is appended to env.Errors and printed
+// in text mode through the writeDiagErrors helper shared with
+// renderDiagErrors.
+func renderValidateFailure(
+	r output.Renderer, env output.Envelope, errs []output.Error, checks validateresult.Checks,
+) error {
+	// Append diagnostics to the envelope before marshaling so that
+	// even an (essentially impossible) Marshal failure of the tiny
+	// Result struct still surfaces every error the caller wanted to
+	// report. RenderError preserves env.Errors when promoting to the
+	// generic internal_error path.
+	env.Errors = append(env.Errors, errs...)
+
+	data, err := json.Marshal(validateresult.Result{Valid: false, Checks: checks})
+	if err != nil {
+		return r.RenderError(env, err)
+	}
+	env.Data = data
+
+	if err := r.Render(env, func(w io.Writer) error {
+		return writeDiagErrors(w, errs)
+	}); err != nil {
+		return err
+	}
+	return output.ErrRendered
+}
+
+// writeDiagErrors prints one line per diagnostic error in text mode,
+// followed by any "did you mean" suggestion lines. Shared by the two
+// validate failure-rendering paths so a future formatting tweak (e.g.
+// adding the SQLSTATE class name) only needs to change one place.
+func writeDiagErrors(w io.Writer, errs []output.Error) error {
+	for _, diagErr := range errs {
+		pos := diagErr.Position
+		if pos != nil {
+			if _, werr := fmt.Fprintf(w, "%d:%d: %s [%s]\n", pos.Line, pos.Column, diagErr.Message, diagErr.Code); werr != nil {
+				return werr
+			}
+		} else if _, werr := fmt.Fprintf(w, "%s [%s]\n", diagErr.Message, diagErr.Code); werr != nil {
+			return werr
+		}
+		if werr := writeSuggestions(w, diagErr.Suggestions); werr != nil {
+			return werr
+		}
+	}
+	return nil
 }
 
 // writeSuggestions prints structured "did you mean?" suggestions

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -112,7 +112,9 @@ func TestValidateCmdTextError(t *testing.T) {
 }
 
 // TestValidateCmdJSONError verifies that invalid SQL in JSON mode
-// produces an envelope with structured errors and nil data.
+// produces an envelope with structured errors plus a Result payload
+// recording which phases ran (parse failed, type/name skipped because
+// there is no AST to feed them).
 func TestValidateCmdJSONError(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
@@ -127,7 +129,6 @@ func TestValidateCmdJSONError(t *testing.T) {
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Len(t, env.Errors, 1)
-	require.Nil(t, env.Data)
 
 	diagErr := env.Errors[0]
 	require.Equal(t, "42601", diagErr.Code)
@@ -138,6 +139,20 @@ func TestValidateCmdJSONError(t *testing.T) {
 	require.Equal(t, 1, diagErr.Position.Line)
 	require.Equal(t, 12, diagErr.Position.Column)
 	require.Equal(t, 11, diagErr.Position.ByteOffset)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			Syntax         string `json:"syntax"`
+			TypeCheck      string `json:"type_check"`
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.False(t, payload.Valid)
+	require.Equal(t, "failed", payload.Checks.Syntax)
+	require.Equal(t, "skipped", payload.Checks.TypeCheck)
+	require.Equal(t, "skipped", payload.Checks.NameResolution)
 }
 
 // TestValidateCmdSuggestionsJSON verifies that name-resolution errors
@@ -284,7 +299,11 @@ func TestValidateCmdTypeErrorText(t *testing.T) {
 }
 
 // TestValidateCmdTypeErrorJSON verifies that a type mismatch in JSON
-// mode produces an envelope with a structured error and nil data.
+// mode produces an envelope with a structured error plus the Result
+// payload recording which phases ran. Without --schema, the run also
+// includes a capability_required warning since name resolution was
+// skipped — kept consistent with the success path so consumers see
+// the same warning regardless of whether other phases passed.
 func TestValidateCmdTypeErrorJSON(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
@@ -297,15 +316,102 @@ func TestValidateCmdTypeErrorJSON(t *testing.T) {
 
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
-	require.Len(t, env.Errors, 1)
-	require.Nil(t, env.Data)
+	require.Len(t, env.Errors, 2)
 
-	diagErr := env.Errors[0]
-	require.NotEmpty(t, diagErr.Code)
-	require.Equal(t, output.SeverityError, diagErr.Severity)
-	require.Contains(t, diagErr.Message, "unsupported binary operator")
-	require.NotNil(t, diagErr.Position)
-	require.Equal(t, 1, diagErr.Position.Line)
+	require.Equal(t, "capability_required", env.Errors[0].Code)
+	require.Equal(t, output.SeverityWarning, env.Errors[0].Severity)
+
+	typeErr := env.Errors[1]
+	require.NotEmpty(t, typeErr.Code)
+	require.Equal(t, output.SeverityError, typeErr.Severity)
+	require.Contains(t, typeErr.Message, "unsupported binary operator")
+	require.NotNil(t, typeErr.Position)
+	require.Equal(t, 1, typeErr.Position.Line)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			Syntax         string `json:"syntax"`
+			TypeCheck      string `json:"type_check"`
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.False(t, payload.Valid)
+	require.Equal(t, "ok", payload.Checks.Syntax)
+	require.Equal(t, "failed", payload.Checks.TypeCheck)
+	require.Equal(t, "skipped", payload.Checks.NameResolution)
+}
+
+// TestValidateCmdMultiStatementErrorAccumulation is the end-to-end
+// demo from issue #16: a two-statement input with two distinct typos
+// must surface both diagnostics in a single envelope rather than
+// stopping at the first one.
+func TestValidateCmdMultiStatementErrorAccumulation(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeFile(t, dir, "schema.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY, name TEXT);\n")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate", "--output", "json", "--schema", schema,
+		"-e", "SELECT * FROM usrs; SELECT nme FROM users",
+	})
+
+	require.ErrorIs(t, root.Execute(), output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 2)
+
+	require.Equal(t, "42P01", env.Errors[0].Code)
+	require.Equal(t, "unknown_table", env.Errors[0].Category)
+	require.Contains(t, env.Errors[0].Message, "usrs")
+
+	require.Equal(t, "42703", env.Errors[1].Code)
+	require.Equal(t, "unknown_column", env.Errors[1].Category)
+	require.Contains(t, env.Errors[1].Message, "nme")
+}
+
+// TestValidateCmdCrossPhaseErrorAccumulation verifies that an error
+// in an earlier phase (type check) does not suppress diagnostics from
+// a later phase (name resolution). Before issue #16 the early-return
+// pipeline hid the second error.
+func TestValidateCmdCrossPhaseErrorAccumulation(t *testing.T) {
+	dir := t.TempDir()
+	schema := writeFile(t, dir, "schema.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate", "--output", "json", "--schema", schema,
+		"-e", "SELECT 1 + 'x'; SELECT * FROM usrs",
+	})
+
+	require.ErrorIs(t, root.Execute(), output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 2)
+	require.Contains(t, env.Errors[0].Message, "unsupported binary operator")
+	require.Equal(t, "42P01", env.Errors[1].Code)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			TypeCheck      string `json:"type_check"`
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.Equal(t, "failed", payload.Checks.TypeCheck)
+	require.Equal(t, "failed", payload.Checks.NameResolution)
 }
 
 // TestValidateCmdColumnRefNoTypeError verifies that SQL with column
@@ -466,6 +572,57 @@ sql:
 	}
 	require.Contains(t, []string{payload.Files[0].File, payload.Files[1].File}, good1)
 	require.Contains(t, []string{payload.Files[0].File, payload.Files[1].File}, good2)
+}
+
+// TestValidateCmdConfigCrossPhaseAccumulation verifies that the
+// config-driven multi-file path also accumulates diagnostics across
+// phases — a type error in one query file does not suppress a
+// name-resolution error in a different file. Pins the runner wiring
+// in validateQueryFile so a future refactor cannot reintroduce the
+// pre-#16 early-return behavior on the multi-file path.
+func TestValidateCmdConfigCrossPhaseAccumulation(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "schema/users.sql",
+		"CREATE TABLE users (id INT PRIMARY KEY);\n")
+	typeBad := writeFile(t, dir, "queries/q_type.sql", "SELECT 1 + 'x';\n")
+	nameBad := writeFile(t, dir, "queries/q_name.sql", "SELECT * FROM usrs;\n")
+	writeFile(t, dir, "crdb-sql.yaml", `version: 1
+sql:
+  - schema: ["schema/*.sql"]
+    queries: ["queries/*.sql"]
+`)
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"validate",
+		"--output", "json",
+		"--config", filepath.Join(dir, "crdb-sql.yaml"),
+	})
+
+	require.ErrorIs(t, root.Execute(), output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	// Both files must contribute their per-phase diagnostic; tagFile
+	// stamps Context["file"] so we can attribute each error.
+	var typeErrCount, nameErrCount int
+	for _, e := range env.Errors {
+		path, _ := e.Context["file"].(string)
+		switch path {
+		case typeBad:
+			typeErrCount++
+			require.Contains(t, e.Message, "unsupported binary operator")
+		case nameBad:
+			nameErrCount++
+			require.Equal(t, "42P01", e.Code)
+		}
+	}
+	require.Equal(t, 1, typeErrCount, "type error in q_type.sql must surface")
+	require.Equal(t, 1, nameErrCount, "name error in q_name.sql must surface")
 }
 
 // TestValidateCmdCLIOverridesConfig verifies that an explicit -e
@@ -698,7 +855,6 @@ func TestValidateCmdSchemaUnknownTable(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Equal(t, output.TierSchemaFile, env.Tier)
 	require.Len(t, env.Errors, 1)
-	require.Nil(t, env.Data)
 
 	diagErr := env.Errors[0]
 	require.Equal(t, "42P01", diagErr.Code)
@@ -707,6 +863,16 @@ func TestValidateCmdSchemaUnknownTable(t *testing.T) {
 	avail, ok := diagErr.Context["available_tables"].([]any)
 	require.True(t, ok, "available_tables must be a JSON array")
 	require.Equal(t, []any{"users"}, avail)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.False(t, payload.Valid)
+	require.Equal(t, "failed", payload.Checks.NameResolution)
 }
 
 // TestValidateCmdSchemaKnownTable verifies the success path with
@@ -762,7 +928,6 @@ func TestValidateCmdSchemaUnknownColumn(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Equal(t, output.TierSchemaFile, env.Tier)
 	require.Len(t, env.Errors, 1)
-	require.Nil(t, env.Data)
 
 	diagErr := env.Errors[0]
 	require.Equal(t, "42703", diagErr.Code)
@@ -774,6 +939,16 @@ func TestValidateCmdSchemaUnknownColumn(t *testing.T) {
 	avail, ok := diagErr.Context["available_columns"].([]any)
 	require.True(t, ok, "available_columns must be a JSON array")
 	require.Equal(t, []any{"id", "name"}, avail)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			NameResolution string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.False(t, payload.Valid)
+	require.Equal(t, "failed", payload.Checks.NameResolution)
 }
 
 // TestValidateCmdSchemaUnknownTableText verifies that unknown-table

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -191,12 +191,21 @@ func TestIntegrationValidateSQL(t *testing.T) {
 		res := callTool(t, c, tools.ValidateSQLToolName, map[string]any{"sql": "SELECT 1 + 'abc'"})
 		env := decodeEnvelope(t, res)
 		require.Equal(t, output.TierZeroConfig, env.Tier)
-		require.NotEmpty(t, env.Errors, "type-check failure must populate envelope errors")
+		// The Tier 0 path also emits a capability_required warning
+		// when schemas are absent, so the type error is no longer
+		// guaranteed to be at index 0. Find it by severity.
+		var typeErr *output.Error
+		for i := range env.Errors {
+			if env.Errors[i].Severity == output.SeverityError {
+				typeErr = &env.Errors[i]
+				break
+			}
+		}
+		require.NotNil(t, typeErr, "type-check failure must populate envelope errors")
 		// Type errors carry a SQLSTATE from the parser/type checker;
 		// avoid pinning the exact code so a parser bump that refines
 		// the diagnosis (e.g. 42883 → 42804) does not break the test.
-		require.NotEmpty(t, env.Errors[0].Code)
-		require.Equal(t, output.SeverityError, env.Errors[0].Severity)
+		require.NotEmpty(t, typeErr.Code)
 	})
 
 	t.Run("missing sql parameter is tool error", func(t *testing.T) {

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -344,6 +344,69 @@ func TestValidateSQLHandlerStampsTargetVersionOnSchemaFilePath(t *testing.T) {
 		"target_version must be stamped even on the schema_file path")
 }
 
+// TestValidateSQLHandlerFailurePayloadShapes pins the Result.Checks
+// emitted on each failure path so MCP consumers can branch on the
+// per-phase status without inspecting error codes. The CLI surface
+// has equivalent coverage in TestValidateCmdJSONError /
+// TestValidateCmdTypeErrorJSON; this test guarantees the MCP envelope
+// does not drift from that contract.
+func TestValidateSQLHandlerFailurePayloadShapes(t *testing.T) {
+	const usersDDL = "CREATE TABLE users (id INT PRIMARY KEY)"
+
+	tests := []struct {
+		name                   string
+		args                   map[string]any
+		expectedSyntax         validateresult.CheckStatus
+		expectedTypeCheck      validateresult.CheckStatus
+		expectedNameResolution validateresult.CheckStatus
+	}{
+		{
+			name:                   "parse error skips downstream phases",
+			args:                   map[string]any{"sql": "SELECT FROM"},
+			expectedSyntax:         validateresult.CheckFailed,
+			expectedTypeCheck:      validateresult.CheckSkipped,
+			expectedNameResolution: validateresult.CheckSkipped,
+		},
+		{
+			name:                   "type error without schemas leaves name resolution skipped",
+			args:                   map[string]any{"sql": "SELECT 1 + 'x'"},
+			expectedSyntax:         validateresult.CheckOK,
+			expectedTypeCheck:      validateresult.CheckFailed,
+			expectedNameResolution: validateresult.CheckSkipped,
+		},
+		{
+			name: "unknown table marks name resolution failed",
+			args: map[string]any{
+				"sql":     "SELECT * FROM nope",
+				"schemas": []any{map[string]any{"sql": usersDDL}},
+			},
+			expectedSyntax:         validateresult.CheckOK,
+			expectedTypeCheck:      validateresult.CheckOK,
+			expectedNameResolution: validateresult.CheckFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.NotNil(t, env.Data, "failure path must emit a Result payload")
+
+			var result validateresult.Result
+			require.NoError(t, json.Unmarshal(env.Data, &result))
+			require.False(t, result.Valid)
+			require.Equal(t, tc.expectedSyntax, result.Checks.Syntax)
+			require.Equal(t, tc.expectedTypeCheck, result.Checks.TypeCheck)
+			require.Equal(t, tc.expectedNameResolution, result.Checks.NameResolution)
+		})
+	}
+}
+
 func TestValidateSQLHandler(t *testing.T) {
 	const usersDDL = "CREATE TABLE users (id INT PRIMARY KEY, email TEXT)"
 
@@ -358,6 +421,13 @@ func TestValidateSQLHandler(t *testing.T) {
 		expectedNameResolution validateresult.CheckStatus
 		expectCapabilityWarn   bool
 		expectSchemaWarning    bool
+		// expectNoFailureData is true for failure paths that pre-empt
+		// validation (e.g. a malformed --schema input): the SQL was
+		// never checked, so no Result payload is produced. Other
+		// failure paths (parse, type, name) emit
+		// {valid:false, checks:{...}} so consumers can branch on
+		// Result.Checks without inspecting error codes.
+		expectNoFailureData bool
 	}{
 		{
 			name:                   "valid SQL without schema reports name_resolution skipped",
@@ -422,9 +492,10 @@ func TestValidateSQLHandler(t *testing.T) {
 				"sql":     "SELECT 1",
 				"schemas": []any{map[string]any{"sql": "CREATE TABLEE bad (id INT)"}},
 			},
-			expectedEnvErrs: true,
-			expectedCode:    "42601",
-			expectedTier:    output.TierSchemaFile,
+			expectedEnvErrs:     true,
+			expectedCode:        "42601",
+			expectedTier:        output.TierSchemaFile,
+			expectNoFailureData: true,
 		},
 		{
 			name: "duplicate-table schema surfaces schema_warning alongside successful resolution",
@@ -493,10 +564,16 @@ func TestValidateSQLHandler(t *testing.T) {
 
 			if tc.expectedEnvErrs {
 				require.NotEmpty(t, env.Errors)
-				require.Nil(t, env.Data)
 				if tc.expectedCode != "" {
 					require.Equal(t, tc.expectedCode, env.Errors[0].Code)
 				}
+				if tc.expectNoFailureData {
+					require.Nil(t, env.Data)
+					return
+				}
+				var failResult validateresult.Result
+				require.NoError(t, json.Unmarshal(env.Data, &failResult))
+				require.False(t, failResult.Valid)
 				return
 			}
 

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -78,42 +78,44 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 		stmts, parseErr := parser.Parse(sql)
 		if parseErr != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(parseErr, sql))
-			return envelopeResult(env)
+			return failureEnvelope(env, validateresult.Checks{
+				Syntax:         validateresult.CheckFailed,
+				TypeCheck:      validateresult.CheckSkipped,
+				NameResolution: validateresult.CheckSkipped,
+			})
 		}
 
-		if typeErrs := semcheck.CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
-			env.Errors = append(env.Errors, typeErrs...)
-			return envelopeResult(env)
-		}
-
+		// Version-aware feature warnings are advisory and emitted
+		// regardless of whether semantic checks pass — see the CLI
+		// path's matching comment for rationale.
 		env.Errors = append(env.Errors, version.Inspect(stmts, target, nil)...)
 
-		checks := validateresult.Checks{
-			Syntax:    validateresult.CheckOK,
-			TypeCheck: validateresult.CheckOK,
-		}
+		checks := validateresult.Checks{Syntax: validateresult.CheckOK}
 
+		var cat *catalog.Catalog
 		if len(sources) == 0 {
-			checks.NameResolution = validateresult.CheckSkipped
 			env.Errors = append(env.Errors, validateresult.CapabilityRequiredError(
 				validateresult.CapabilityNameResolution,
 				"name resolution skipped: schemas not provided",
 				"pass the schemas argument to enable table name resolution",
 			))
 		} else {
-			cat, err := catalog.Load(sources)
+			loaded, err := catalog.Load(sources)
 			if err != nil {
 				env.Errors = append(env.Errors, schemaLoadEnvelopeError(err))
 				return envelopeResult(env)
 			}
+			cat = loaded
 			schemawarn.Append(&env, cat)
-			nameErrs := semcheck.CheckTableNames(stmts, sql, cat)
-			nameErrs = append(nameErrs, semcheck.CheckColumnNames(stmts, sql, cat)...)
-			if len(nameErrs) > 0 {
-				env.Errors = append(env.Errors, nameErrs...)
-				return envelopeResult(env)
-			}
-			checks.NameResolution = validateresult.CheckOK
+		}
+
+		semRes, semErrs := semcheck.Run(stmts, sql, cat)
+		checks.TypeCheck = semRes.TypeCheck
+		checks.NameResolution = semRes.NameResolution
+
+		if len(semErrs) > 0 {
+			env.Errors = append(env.Errors, semErrs...)
+			return failureEnvelope(env, checks)
 		}
 
 		data, err := json.Marshal(validateresult.Result{Valid: true, Checks: checks})
@@ -123,4 +125,27 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 		env.Data = data
 		return envelopeResult(env)
 	}
+}
+
+// failureEnvelope marshals checks into env.Data as a Result{Valid:false}
+// payload before delegating to envelopeResult. Sharing this helper across
+// the parse-error and semantic-error branches keeps the failure-path
+// JSON shape identical so consumers can branch on Result.Checks without
+// special-casing the producing phase. Callers append every diagnostic
+// to env.Errors before invoking failureEnvelope, so that even an
+// (essentially impossible) marshal failure of the tiny Result struct
+// still emits the diagnostics through the standard envelope path
+// rather than collapsing them into an opaque tool-level error.
+func failureEnvelope(env output.Envelope, checks validateresult.Checks) (*mcp.CallToolResult, error) {
+	data, err := json.Marshal(validateresult.Result{Valid: false, Checks: checks})
+	if err != nil {
+		env.Errors = append(env.Errors, output.Error{
+			Code:     "internal_error",
+			Severity: output.SeverityError,
+			Message:  fmt.Sprintf("encode result: %v", err),
+		})
+		return envelopeResult(env)
+	}
+	env.Data = data
+	return envelopeResult(env)
 }

--- a/internal/semcheck/runner.go
+++ b/internal/semcheck/runner.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
+)
+
+// Result reports the per-phase outcome of a Run. The fields mirror
+// validateresult.Checks (minus Syntax, which is the parser's
+// responsibility) so callers can copy directly into the envelope's
+// Checks payload without translation.
+type Result struct {
+	TypeCheck      validateresult.CheckStatus
+	NameResolution validateresult.CheckStatus
+}
+
+// Run executes every semantic check against the parsed input and
+// returns the per-phase Result together with the accumulated
+// diagnostics in a stable phase order: type errors, then table-name
+// errors, then column-name errors. Errors from later phases are not
+// suppressed by errors in earlier phases — the runner exists so a
+// single invocation surfaces every diagnostic the user could fix in
+// one editing pass.
+//
+// Cascade suppression for downstream column references against an
+// unresolved table is the responsibility of CheckColumnNames (see
+// unknownSource in names.go), not the runner; Run simply chains the
+// existing checkers.
+//
+// cat may be nil. When nil, name resolution is skipped and
+// NameResolution is reported as CheckSkipped — the caller decides
+// whether to also append a capability_required warning to the
+// envelope (today only the CLI's --schema-less single-input path
+// does this).
+//
+// Inputs are not copied: stmts and sql are read by the underlying
+// checkers and must remain valid for the duration of the call.
+func Run(stmts statements.Statements, sql string, cat *catalog.Catalog) (Result, []output.Error) {
+	var errs []output.Error
+
+	res := Result{TypeCheck: validateresult.CheckOK}
+	if typeErrs := CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
+		errs = append(errs, typeErrs...)
+		res.TypeCheck = validateresult.CheckFailed
+	}
+
+	if cat == nil {
+		res.NameResolution = validateresult.CheckSkipped
+		return res, errs
+	}
+
+	res.NameResolution = validateresult.CheckOK
+	tableErrs := CheckTableNames(stmts, sql, cat)
+	colErrs := CheckColumnNames(stmts, sql, cat)
+	if len(tableErrs) > 0 || len(colErrs) > 0 {
+		res.NameResolution = validateresult.CheckFailed
+	}
+	errs = append(errs, tableErrs...)
+	errs = append(errs, colErrs...)
+	return res, errs
+}

--- a/internal/semcheck/runner_test.go
+++ b/internal/semcheck/runner_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/catalog"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/validateresult"
+)
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name                   string
+		sql                    string
+		withCatalog            bool
+		expectedCategories     []string
+		expectedTypeCheck      validateresult.CheckStatus
+		expectedNameResolution validateresult.CheckStatus
+	}{
+		{
+			name:                   "all clean",
+			sql:                    "SELECT 1; SELECT * FROM users",
+			withCatalog:            true,
+			expectedTypeCheck:      validateresult.CheckOK,
+			expectedNameResolution: validateresult.CheckOK,
+		},
+		{
+			name:                   "name resolution skipped without catalog",
+			sql:                    "SELECT * FROM usrs",
+			expectedTypeCheck:      validateresult.CheckOK,
+			expectedNameResolution: validateresult.CheckSkipped,
+		},
+		{
+			name:        "two distinct typos in one envelope",
+			sql:         "SELECT * FROM usrs; SELECT nme FROM users",
+			withCatalog: true,
+			expectedCategories: []string{
+				diag.CategoryUnknownTable,
+				diag.CategoryUnknownColumn,
+			},
+			expectedTypeCheck:      validateresult.CheckOK,
+			expectedNameResolution: validateresult.CheckFailed,
+		},
+		{
+			name:        "type error in stmt 1 does not hide name error in stmt 2",
+			sql:         "SELECT 1 + 'hello'; SELECT * FROM usrs",
+			withCatalog: true,
+			expectedCategories: []string{
+				diag.CategoryTypeMismatch,
+				diag.CategoryUnknownTable,
+			},
+			expectedTypeCheck:      validateresult.CheckFailed,
+			expectedNameResolution: validateresult.CheckFailed,
+		},
+		{
+			name:        "unknown table suppresses cascaded column error",
+			sql:         "SELECT nme FROM nosuch; SELECT 1",
+			withCatalog: true,
+			expectedCategories: []string{
+				diag.CategoryUnknownTable,
+			},
+			expectedTypeCheck:      validateresult.CheckOK,
+			expectedNameResolution: validateresult.CheckFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+
+			var cat *catalog.Catalog
+			if tc.withCatalog {
+				cat = usersOnlyCatalog(t)
+			}
+
+			res, errs := Run(stmts, tc.sql, cat)
+
+			require.Equal(t, tc.expectedTypeCheck, res.TypeCheck)
+			require.Equal(t, tc.expectedNameResolution, res.NameResolution)
+			require.Len(t, errs, len(tc.expectedCategories))
+			for i, want := range tc.expectedCategories {
+				// Type-check errors carry only the SQLSTATE code
+				// (diag.FromTypeError does not populate Category),
+				// while name-check errors set Category directly.
+				// CategoryForCode normalises both into the same
+				// taxonomy so the test reads one way.
+				got := errs[i].Category
+				if got == "" {
+					got = diag.CategoryForCode(errs[i].Code)
+				}
+				require.Equal(t, want, got,
+					"error %d: code=%q message=%q",
+					i, errs[i].Code, errs[i].Message)
+			}
+		})
+	}
+}
+
+// TestRunPhaseOrdering pins the phase order so consumers (and the
+// validate command's text renderer) can rely on it. Type-check errors
+// always come before table-name errors, which always come before
+// column-name errors.
+func TestRunPhaseOrdering(t *testing.T) {
+	const sql = "SELECT 1 + 'x'; SELECT * FROM usrs; SELECT u.nme FROM users u"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	res, errs := Run(stmts, sql, usersOnlyCatalog(t))
+
+	require.Equal(t, validateresult.CheckFailed, res.TypeCheck)
+	require.Equal(t, validateresult.CheckFailed, res.NameResolution)
+	require.Len(t, errs, 3)
+
+	require.Equal(t, diag.CategoryTypeMismatch, diag.CategoryForCode(errs[0].Code))
+	require.Equal(t, diag.CategoryUnknownTable, errs[1].Category)
+	require.Equal(t, diag.CategoryUnknownColumn, errs[2].Category)
+}

--- a/internal/validateresult/validateresult.go
+++ b/internal/validateresult/validateresult.go
@@ -23,13 +23,17 @@ import "github.com/spilchen/sql-ai-tools/internal/output"
 // "okay" reach the wire. JSON marshaling is unchanged.
 type CheckStatus string
 
-// CheckStatus values. A phase is either CheckOK (ran and passed) or
-// CheckSkipped (its prerequisite — typically --schema or the schemas
-// MCP argument — was missing). A failing phase aborts the request via
-// an envelope error, so a "fail" status never appears here.
+// CheckStatus values. CheckOK means the phase ran and produced no
+// errors; CheckSkipped means its prerequisite (typically --schema or
+// the schemas MCP argument) was missing; CheckFailed means the phase
+// ran but produced one or more errors. The failure path emits Checks
+// alongside Errors so consumers can attribute errors to phases and
+// see which downstream phases (if any) were skipped because an
+// upstream phase could not produce usable input.
 const (
 	CheckOK      CheckStatus = "ok"
 	CheckSkipped CheckStatus = "skipped"
+	CheckFailed  CheckStatus = "failed"
 )
 
 // CapabilityRequiredCode is the envelope error Code (and Category) for
@@ -43,19 +47,23 @@ const CapabilityRequiredCode = "capability_required"
 // and in the Checks field name so the two cannot drift.
 const CapabilityNameResolution = "name_resolution"
 
-// Checks records which validation phases ran on the success path.
-// Each field is one of CheckOK or CheckSkipped. Adding a phase means
-// adding a field here and updating both surfaces' rendering paths.
+// Checks records the per-phase outcome for a validation run. Each
+// field is CheckOK, CheckSkipped, or CheckFailed. Both the success
+// and failure paths populate this struct so agents always learn which
+// phases ran. Adding a phase means adding a field here and updating
+// both surfaces (CLI and MCP) on each path (success and failure) — four
+// rendering sites total.
 type Checks struct {
 	Syntax         CheckStatus `json:"syntax"`
 	TypeCheck      CheckStatus `json:"type_check"`
 	NameResolution CheckStatus `json:"name_resolution"`
 }
 
-// Result is the success-path JSON payload for SQL validation. The
-// expanded shape (vs. a bare {valid: true}) exposes which phases ran,
-// so agents can tell whether name resolution was skipped due to a
-// missing schema.
+// Result is the JSON payload for SQL validation. Valid is true on
+// the success path (no errors emitted) and false when one or more
+// phases produced errors. Checks reports the per-phase outcome in
+// either case so agents can tell whether name resolution was
+// skipped, ran cleanly, or failed.
 type Result struct {
 	Valid  bool   `json:"valid"`
 	Checks Checks `json:"checks"`


### PR DESCRIPTION
Before this change the single-input validate path (CLI and MCP) used an
early-return pipeline: if any expression failed type checking, name
resolution never ran. A two-statement input where the first statement
had a type error and the second had an unknown table only surfaced the
type error; the user had to fix and re-run to see the rest. The Result
envelope was also dropped on the failure path, so JSON consumers could
not tell which phases had run.

Introduce `internal/semcheck/runner.go` with a single `Run` entry point
that orchestrates `CheckExprTypes`, `CheckTableNames`, and
`CheckColumnNames` into one accumulated `[]output.Error` in stable phase
order, together with a per-phase `Result` mirroring
`validateresult.Checks`. Cascade suppression for downstream column refs
against an unresolved table is already implemented in
`CheckColumnNames` (`unknownSource`), so the runner is a thin
orchestrator over checkers that already do the right thing within each
call.

Wire both surfaces through it:
- `cmd/validate.go`'s single-input path and `validateQueryFile` now
  call `semcheck.Run`; new `renderValidateFailure` marshals the Result
  payload on the failure path so Checks is always emitted.
- `internal/mcp/tools/validate.go` uses the runner with a parallel
  `failureEnvelope` helper so the MCP envelope shape matches.

Add `CheckFailed` to `validateresult.CheckStatus` and document that
Checks is now populated on both the success and failure paths. Existing
tests that asserted `env.Data == nil` on the failure path are updated
to expect `{valid:false, checks:{...}}`.

Resolves: #16