### PR TITLE
summarize: add referenced_columns and select_star to per-statement output

### DIFF
--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -35,9 +36,11 @@ func newSummarizeCmd(state *rootState) *cobra.Command {
 		Short: "Structured summary of SQL statements",
 		Long: `Produce a structured per-statement summary of SQL: operation
 (SELECT/INSERT/UPDATE/DELETE/UPSERT/OTHER), tables touched, top-level
-WHERE predicates, joins, columns mutated by DML, and a risk level
-delegated to the same rules as 'crdb-sql risk'. Input is read from the
--e flag, a positional file argument, or stdin.`,
+WHERE predicates, joins, columns mutated by DML (affected_columns),
+the full read-and-write column footprint (referenced_columns), a
+select_star flag set when the projection uses '*' or 't.*', and a
+risk level delegated to the same rules as 'crdb-sql risk'. Input is
+read from the -e flag, a positional file argument, or stdin.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
@@ -102,6 +105,8 @@ func renderSummaryText(w io.Writer, s summarize.Summary) error {
 		{"joins", joinSummaryStrings(s.Joins)},
 		{"predicates", joinOrNone(s.Predicates)},
 		{"affected_columns", joinOrNone(s.AffectedColumns)},
+		{"referenced_columns", joinOrNone(s.ReferencedColumns)},
+		{"select_star", strconv.FormatBool(s.SelectStar)},
 		{"risk", string(s.RiskLevel)},
 	}
 	for _, row := range rows {

--- a/cmd/summarize_test.go
+++ b/cmd/summarize_test.go
@@ -37,6 +37,40 @@ func TestSummarizeCmdText(t *testing.T) {
 	require.Contains(t, got, "DELETE")
 	require.Contains(t, got, "orders")
 	require.Contains(t, got, "status = 'x'")
+	// New rows added for issue #100 must appear in text output.
+	require.Contains(t, got, "referenced_columns:")
+	require.Contains(t, got, "status")
+	require.Contains(t, got, "select_star:")
+	require.Contains(t, got, "false")
+}
+
+// TestSummarizeCmdSelectStarJSON verifies that select_star is
+// serialized as a true boolean (not omitted, not "true" string) and
+// that referenced_columns is emitted as an empty JSON array rather
+// than null when a bare * leaves no other refs.
+func TestSummarizeCmdSelectStarJSON(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"summarize", "-e", "SELECT * FROM t", "--output", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	// Wire-format anchors (the renderer pretty-prints, so match the
+	// indented form): select_star must serialize as a true bool,
+	// not be omitted; referenced_columns must be an empty array,
+	// not null.
+	require.Contains(t, string(env.Data), `"select_star": true`)
+	require.Contains(t, string(env.Data), `"referenced_columns": []`)
+
+	var summaries []summarize.Summary
+	require.NoError(t, json.Unmarshal(env.Data, &summaries))
+	require.Len(t, summaries, 1)
+	require.True(t, summaries[0].SelectStar)
+	require.Empty(t, summaries[0].ReferencedColumns)
 }
 
 // TestSummarizeCmdJSONIssueDemo verifies that the issue's demo
@@ -68,6 +102,8 @@ func TestSummarizeCmdJSONIssueDemo(t *testing.T) {
 	require.Equal(t, []string{"status = 'x'"}, s.Predicates)
 	require.Empty(t, s.Joins)
 	require.Empty(t, s.AffectedColumns)
+	require.Equal(t, []string{"status"}, s.ReferencedColumns)
+	require.False(t, s.SelectStar)
 	require.Equal(t, risk.SeverityInfo, s.RiskLevel)
 }
 

--- a/internal/mcp/tools/summarize.go
+++ b/internal/mcp/tools/summarize.go
@@ -22,7 +22,7 @@ import (
 func SummarizeSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		SummarizeSQLToolName,
-		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected columns, and risk level."),
+		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected_columns (DML write set), referenced_columns (full read+write footprint), select_star (true when projection uses '*' or 't.*' so referenced_columns is a lower bound), and risk level."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to summarize")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)

--- a/internal/summarize/columns.go
+++ b/internal/summarize/columns.go
@@ -1,0 +1,274 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package summarize
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// collectReferences returns every column the statement reads or
+// writes, deduplicated case-insensitively in first-seen order. Refs
+// are emitted as the user wrote them: bare "col" when unqualified,
+// "qualifier.col" when the source SQL named a table prefix. We do not
+// resolve bare names against table schemas — there is no catalog
+// here, so a bare "id" in a multi-table FROM stays bare.
+//
+// Mutated targets stored as tree.NameList (INSERT explicit column
+// list at Insert.Columns, UPDATE SET LHS at UpdateExpr.Names, ON
+// CONFLICT arbiter cols at OnConflict.Columns, JOIN USING cols at
+// UsingJoinCond.Cols) are not Expr nodes, so the visitor cannot
+// reach them. INSERT and UPDATE LHS sets are unioned in by
+// summarizeStatement via mergeColumns(refs, AffectedColumns) so the
+// "ReferencedColumns ⊇ AffectedColumns" invariant holds for those
+// cases. ON CONFLICT arbiter cols and DO UPDATE SET LHS are added
+// by addOnConflictNameLists below because no Expr walker reaches
+// them. JOIN USING cols remain unsurfaced — documented in the test
+// expectations.
+//
+// Star projections (SELECT *, t.*) are deliberately skipped — see
+// hasProjectionStar for the separate flag agents use to detect that
+// the column list is incomplete.
+func collectReferences(stmt tree.Statement) []string {
+	v := newReferenceCollector()
+	tree.WalkStmt(v, stmt)
+	if ins, ok := stmt.(*tree.Insert); ok && ins.OnConflict != nil {
+		v.addOnConflictNameLists(ins.OnConflict)
+	}
+	return v.ordered
+}
+
+// hasProjectionStar reports whether the statement's outermost
+// projection list contains a bare "*" or qualified "t.*". Function
+// arguments like count(*) are NOT counted: they don't introduce an
+// unenumerated column footprint.
+//
+// "Outermost" includes the branches of a top-level set operation
+// (UNION/INTERSECT/EXCEPT) — both sides contribute to the result
+// shape. Stars deeper inside a CTE body or scalar subquery do not
+// set this flag; the outer query still names its own columns
+// explicitly (or is itself a star, which would fire the check at
+// its own level). Note: this leaves a star-driven gap when an outer
+// query selects from a CTE that itself uses SELECT * — the outer
+// projection looks complete but its source is incomplete. Agents
+// needing that level of catalog-free incompleteness detection will
+// need a future enhancement.
+//
+// For INSERT ... SELECT we look at the embedded SELECT's projection
+// because that is what determines the source-row column shape; for
+// UPDATE/DELETE/OTHER, false (those statements have no projection).
+func hasProjectionStar(stmt tree.Statement) bool {
+	switch n := stmt.(type) {
+	case *tree.Select:
+		return selectStatementHasStar(n.Select)
+	case *tree.Insert:
+		if n.Rows != nil {
+			return selectStatementHasStar(n.Rows.Select)
+		}
+	}
+	return false
+}
+
+// selectStatementHasStar inspects one SelectStatement node. It
+// recurses into UnionClause branches so a top-level set operation
+// where either side projects "*" still flips the flag. VALUES
+// clauses and unrecognized SelectStatement shapes return false: a
+// VALUES literal cannot be a star, and unknown shapes are treated
+// as "no detectable star" rather than panicking.
+func selectStatementHasStar(s tree.SelectStatement) bool {
+	switch n := s.(type) {
+	case *tree.SelectClause:
+		for _, e := range n.Exprs {
+			if isStarExpr(e.Expr) {
+				return true
+			}
+		}
+		return false
+	case *tree.UnionClause:
+		if n.Left != nil && selectStatementHasStar(n.Left.Select) {
+			return true
+		}
+		if n.Right != nil && selectStatementHasStar(n.Right.Select) {
+			return true
+		}
+	}
+	return false
+}
+
+// isStarExpr identifies the AST shapes the parser produces for a
+// star token in projection position:
+//   - tree.UnqualifiedStar — bare "*"
+//   - *tree.AllColumnsSelector — "t.*" after name resolution
+//   - *tree.UnresolvedName with Star=true — "t.*" before name
+//     resolution, which is the form the raw parser produces and
+//     thus the form summarize sees in practice (summarize never
+//     runs name resolution)
+func isStarExpr(e tree.Expr) bool {
+	switch n := e.(type) {
+	case tree.UnqualifiedStar:
+		return true
+	case *tree.AllColumnsSelector:
+		return true
+	case *tree.UnresolvedName:
+		return n.Star
+	}
+	return false
+}
+
+// referenceCollector implements tree.ExtendedVisitor to gather column
+// references from every Expr-typed position in a statement: SELECT
+// projection, WHERE, JOIN ON, GROUP BY, HAVING, ORDER BY, RETURNING,
+// and any nested subquery or CTE bodies. ExtendedVisitor (rather
+// than plain Visitor) is required so WalkStmt descends into
+// TableExpr subtrees where JOIN ON conditions live.
+//
+// Positions stored as tree.NameList — JOIN USING (col), INSERT
+// (col, col), UPDATE SET col=…'s LHS, ON CONFLICT (col) — are not
+// Expr nodes and the visitor cannot reach them. See collectReferences
+// for how the affected→referenced merge and the manual OnConflict
+// walk fill those gaps.
+//
+// Lifecycle: one collector per top-level statement. seen dedupes by
+// case-folded "qualifier.name" key so "T.ID" and "t.id" collapse,
+// with the first-seen casing winning in the ordered output. ordered
+// preserves first-seen AST-walk order for stable JSON.
+type referenceCollector struct {
+	seen    map[string]struct{}
+	ordered []string
+}
+
+func newReferenceCollector() *referenceCollector {
+	return &referenceCollector{
+		seen:    make(map[string]struct{}),
+		ordered: []string{},
+	}
+}
+
+var _ tree.ExtendedVisitor = (*referenceCollector)(nil)
+
+func (v *referenceCollector) VisitPost(expr tree.Expr) tree.Expr                 { return expr }
+func (v *referenceCollector) VisitTablePost(e tree.TableExpr) tree.TableExpr     { return e }
+func (v *referenceCollector) VisitStatementPost(s tree.Statement) tree.Statement { return s }
+func (v *referenceCollector) VisitStatementPre(s tree.Statement) (bool, tree.Statement) {
+	return true, s
+}
+func (v *referenceCollector) VisitTablePre(e tree.TableExpr) (bool, tree.TableExpr) {
+	return true, e
+}
+
+// VisitPre dispatches on Expr subtype. Leaf cases (UnresolvedName,
+// ColumnItem) collect a ref and return recurse=false because there
+// is nothing inside a column reference to walk. Star cases collect
+// nothing — SelectStar is handled separately by hasProjectionStar —
+// and likewise stop. The default returns recurse=true so the walker
+// descends into composite expressions (BinaryExpr, FuncExpr,
+// ComparisonExpr, CaseExpr, Tuple, Subquery, …). If a new
+// column-bearing AST shape ever needs to be recognized (e.g. tree
+// rewrites that emit *tree.IndexedVar — currently never reached
+// because summarize consumes only freshly parsed input), it must be
+// added as an explicit case here or it will be silently missed.
+func (v *referenceCollector) VisitPre(expr tree.Expr) (bool, tree.Expr) {
+	switch n := expr.(type) {
+	case *tree.UnresolvedName:
+		// Star is a column-list shorthand, not a column reference.
+		if n.Star {
+			return false, expr
+		}
+		v.add(refFromUnresolved(n))
+		return false, expr
+	case *tree.ColumnItem:
+		v.add(refFromColumnItem(n))
+		return false, expr
+	case tree.UnqualifiedStar, *tree.AllColumnsSelector:
+		return false, expr
+	}
+	return true, expr
+}
+
+// addOnConflictNameLists adds the column names that live inside an
+// ON CONFLICT clause as NameList values (not Expr nodes), so the
+// expression walker cannot reach them. Specifically: the arbiter
+// list "ON CONFLICT (col, col)" and each "DO UPDATE SET col=..."
+// LHS. The Expr-typed parts (arbiter predicate, SET RHS, UPDATE
+// WHERE) are walked by the upstream parser when it sees an
+// ExtendedVisitor; they don't need help here.
+func (v *referenceCollector) addOnConflictNameLists(oc *tree.OnConflict) {
+	for _, n := range oc.Columns {
+		v.add("", string(n))
+	}
+	for _, e := range oc.Exprs {
+		// Defensive: the parser does not emit nil entries today.
+		if e == nil {
+			continue
+		}
+		for _, n := range e.Names {
+			v.add("", string(n))
+		}
+	}
+}
+
+// add records a (qualifier, name) ref, deduplicating
+// case-insensitively. The empty-name guard is defensive: every
+// caller is expected to filter unnamed inputs upstream
+// (refFromUnresolved guards on n.Star, VisitPre guards on
+// UnresolvedName.Star), so reaching this branch with name=="" would
+// indicate an unexpected AST shape and is silently ignored rather
+// than panicking.
+func (v *referenceCollector) add(qualifier, name string) {
+	if name == "" {
+		return
+	}
+	rendered := name
+	if qualifier != "" {
+		rendered = qualifier + "." + name
+	}
+	key := strings.ToLower(rendered)
+	if _, dup := v.seen[key]; dup {
+		return
+	}
+	v.seen[key] = struct{}{}
+	v.ordered = append(v.ordered, rendered)
+}
+
+// refFromUnresolved extracts (qualifier, name) from an UnresolvedName.
+// UnresolvedName.Parts is stored in reverse order (column, table,
+// schema, catalog), so Parts[0] is always the column and Parts[1],
+// when present, is the table-or-alias qualifier. Schema/catalog
+// prefixes (Parts[2], Parts[3]) are dropped — they don't help an
+// agent reasoning about column footprints.
+//
+// The Star branch returns ("","") so VisitPre's pre-filter has a
+// safe fallback if the caller order ever changes; callers should
+// still filter on n.Star themselves so the dispatch reads cleanly.
+//
+// Mirrors the helper in internal/semcheck/names.go; duplicated
+// rather than imported to keep summarize free of a semcheck
+// dependency.
+func refFromUnresolved(n *tree.UnresolvedName) (qualifier, name string) {
+	if n.Star {
+		return "", ""
+	}
+	name = n.Parts[0]
+	if n.NumParts >= 2 {
+		qualifier = n.Parts[1]
+	}
+	return qualifier, name
+}
+
+// refFromColumnItem extracts (qualifier, name) from a ColumnItem.
+// Most refs surface as UnresolvedName because summarize consumes
+// raw parser output without running name resolution; ColumnItem
+// appears after tree.NormalizeColumnItem and is handled here only
+// as a defensive case so callers don't have to special-case it if
+// summarize ever starts accepting normalized input.
+func refFromColumnItem(c *tree.ColumnItem) (qualifier, name string) {
+	name = string(c.ColumnName)
+	if c.TableName != nil && c.TableName.NumParts >= 1 {
+		qualifier = c.TableName.Parts[0]
+	}
+	return qualifier, name
+}

--- a/internal/summarize/summarize.go
+++ b/internal/summarize/summarize.go
@@ -54,25 +54,41 @@ const (
 // field and any future MCP tool result.
 //
 // Field discipline:
-//   - Tables, Predicates, Joins, AffectedColumns are emitted as empty
-//     JSON arrays rather than null when there are no entries, so
-//     consumers can iterate without nil checks.
-//   - AffectedColumns contains only columns mutated by DML (INSERT
-//     explicit column list, UPDATE SET targets). It is empty for
-//     DELETE and SELECT. See issue #100 for tracking expansion to
-//     all referenced columns.
+//   - Tables, Predicates, Joins, AffectedColumns, ReferencedColumns
+//     are emitted as empty JSON arrays rather than null when there
+//     are no entries, so consumers can iterate without nil checks.
+//   - AffectedColumns contains only columns mutated by DML: the
+//     INSERT explicit column list, the UPDATE SET targets, and (for
+//     INSERT ... ON CONFLICT DO UPDATE) the conflict-resolution
+//     SET targets. It is empty for DELETE and SELECT.
+//   - ReferencedColumns is the full read-and-write footprint: every
+//     column the statement names in any expression position (SELECT
+//     projection, WHERE, JOIN ON, GROUP BY, HAVING, ORDER BY,
+//     RETURNING, ON CONFLICT body, plus subquery and CTE bodies)
+//     unioned with AffectedColumns. It is therefore a superset of
+//     AffectedColumns whenever any mutated columns are known.
+//     Known gap: JOIN USING (col) names are stored as a NameList,
+//     not an Expr, and are not surfaced.
+//   - SelectStar is true when the statement's outermost projection
+//     uses "*" or "t.*" (and for INSERT ... SELECT, when the embedded
+//     SELECT does). When set, ReferencedColumns is a lower bound:
+//     summarize never expands a star against a catalog because it has
+//     no schema. Function-argument stars like count(*) do not set
+//     this flag — they don't introduce an unenumerated footprint.
 //   - RiskLevel is the highest severity reported by risk.Analyze for
 //     the statement; risk.SeverityInfo is the baseline meaning "no
 //     risks detected", not "an info-level risk was detected".
 type Summary struct {
-	Operation       Operation     `json:"operation"`
-	Tag             string        `json:"tag"`
-	Tables          []string      `json:"tables"`
-	Predicates      []string      `json:"predicates"`
-	Joins           []Join        `json:"joins"`
-	AffectedColumns []string      `json:"affected_columns"`
-	RiskLevel       risk.Severity `json:"risk_level"`
-	Position        risk.Position `json:"position"`
+	Operation         Operation     `json:"operation"`
+	Tag               string        `json:"tag"`
+	Tables            []string      `json:"tables"`
+	Predicates        []string      `json:"predicates"`
+	Joins             []Join        `json:"joins"`
+	AffectedColumns   []string      `json:"affected_columns"`
+	ReferencedColumns []string      `json:"referenced_columns"`
+	SelectStar        bool          `json:"select_star"`
+	RiskLevel         risk.Severity `json:"risk_level"`
+	Position          risk.Position `json:"position"`
 }
 
 // Join describes one JOIN clause inside a statement.
@@ -117,11 +133,12 @@ func Summarize(sql string) ([]Summary, error) {
 // entry point fills them in because both require the full SQL text.
 func summarizeStatement(stmt tree.Statement) Summary {
 	s := Summary{
-		Tag:             stmt.StatementTag(),
-		Tables:          collectTables(stmt),
-		Predicates:      []string{},
-		Joins:           []Join{},
-		AffectedColumns: []string{},
+		Tag:               stmt.StatementTag(),
+		Tables:            collectTables(stmt),
+		Predicates:        []string{},
+		Joins:             []Join{},
+		AffectedColumns:   []string{},
+		ReferencedColumns: []string{},
 	}
 
 	switch n := stmt.(type) {
@@ -135,7 +152,7 @@ func summarizeStatement(stmt tree.Statement) Summary {
 		} else {
 			s.Operation = OpInsert
 		}
-		s.AffectedColumns = nameListToStrings(n.Columns)
+		s.AffectedColumns = insertAffectedColumns(n)
 		// INSERT ... SELECT can have a WHERE inside the embedded
 		// SELECT; surface those predicates so agents see the full
 		// row-selection footprint.
@@ -155,7 +172,43 @@ func summarizeStatement(stmt tree.Statement) Summary {
 	default:
 		s.Operation = OpOther
 	}
+
+	// Read footprint is computed independently of the per-op switch
+	// above so the same walker handles SELECT/DML/CTEs uniformly.
+	// Mutated columns are then unioned in to preserve the documented
+	// "referenced ⊇ affected" invariant for INSERT/UPDATE.
+	s.ReferencedColumns = mergeColumns(collectReferences(stmt), s.AffectedColumns)
+	s.SelectStar = hasProjectionStar(stmt)
 	return s
+}
+
+// mergeColumns returns refs ∪ extras, preserving refs' order and
+// appending any extras not already present (case-insensitive). Both
+// slices are treated as immutable; the result is freshly allocated so
+// callers may store either input independently.
+func mergeColumns(refs, extras []string) []string {
+	if len(refs) == 0 && len(extras) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(refs)+len(extras))
+	seen := make(map[string]struct{}, len(refs)+len(extras))
+	for _, r := range refs {
+		key := strings.ToLower(r)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, r)
+	}
+	for _, e := range extras {
+		key := strings.ToLower(e)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, e)
+	}
+	return out
 }
 
 // selectWhere returns the WHERE clause attached to the leaf
@@ -214,6 +267,22 @@ func updateTargets(exprs tree.UpdateExprs) []string {
 		return []string{}
 	}
 	return out
+}
+
+// insertAffectedColumns returns the columns an INSERT statement
+// mutates: the explicit (col, col, …) list plus, for ON CONFLICT DO
+// UPDATE, the SET LHS columns of the conflict-resolution UPDATE.
+// ON CONFLICT DO NOTHING contributes nothing. Insert columns come
+// first (the row being inserted), then any DO UPDATE SET targets
+// not already listed; case-insensitive dedup keeps the per-column
+// shape stable when an INSERT and its ON CONFLICT body name the
+// same column.
+func insertAffectedColumns(n *tree.Insert) []string {
+	out := nameListToStrings(n.Columns)
+	if n.OnConflict == nil || n.OnConflict.DoNothing {
+		return out
+	}
+	return mergeColumns(out, updateTargets(n.OnConflict.Exprs))
 }
 
 // nameListToStrings is NameList.ToStrings normalized to never return

--- a/internal/summarize/summarize_test.go
+++ b/internal/summarize/summarize_test.go
@@ -18,95 +18,114 @@ import (
 // has its own dedicated case so a regression there is obvious.
 func TestSummarize(t *testing.T) {
 	tests := []struct {
-		name             string
-		sql              string
-		expectedOp       Operation
-		expectedTag      string
-		expectedTables   []string
-		expectedPreds    []string
-		expectedJoins    []Join
-		expectedAffected []string
-		expectedRisk     risk.Severity
+		name               string
+		sql                string
+		expectedOp         Operation
+		expectedTag        string
+		expectedTables     []string
+		expectedPreds      []string
+		expectedJoins      []Join
+		expectedAffected   []string
+		expectedReferenced []string
+		expectedSelectStar bool
+		expectedRisk       risk.Severity
 	}{
 		{
-			name:             "issue demo: delete with WHERE",
-			sql:              "DELETE FROM orders WHERE status='x'",
-			expectedOp:       OpDelete,
-			expectedTables:   []string{"orders"},
-			expectedPreds:    []string{"status = 'x'"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "issue demo: delete with WHERE",
+			sql:                "DELETE FROM orders WHERE status='x'",
+			expectedOp:         OpDelete,
+			expectedTables:     []string{"orders"},
+			expectedPreds:      []string{"status = 'x'"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"status"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "delete without WHERE delegates risk",
-			sql:              "DELETE FROM orders",
-			expectedOp:       OpDelete,
-			expectedTables:   []string{"orders"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityCritical,
+			name:               "delete without WHERE delegates risk",
+			sql:                "DELETE FROM orders",
+			expectedOp:         OpDelete,
+			expectedTables:     []string{"orders"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityCritical,
 		},
 		{
-			name:             "insert with explicit column list",
-			sql:              "INSERT INTO t (a, b) VALUES (1, 2)",
-			expectedOp:       OpInsert,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"a", "b"},
-			expectedRisk:     risk.SeverityInfo,
+			// VALUES literals are not column references; the explicit
+			// (a, b) target list comes in via the affected→referenced
+			// union, so referenced_columns echoes affected_columns.
+			name:               "insert with explicit column list",
+			sql:                "INSERT INTO t (a, b) VALUES (1, 2)",
+			expectedOp:         OpInsert,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a", "b"},
+			expectedReferenced: []string{"a", "b"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "insert without column list leaves affected empty",
-			sql:              "INSERT INTO t VALUES (1, 2)",
-			expectedOp:       OpInsert,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "insert without column list leaves affected empty",
+			sql:                "INSERT INTO t VALUES (1, 2)",
+			expectedOp:         OpInsert,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "upsert short form detected",
-			sql:              "UPSERT INTO t (a) VALUES (1)",
-			expectedOp:       OpUpsert,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"a"},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "upsert short form detected",
+			sql:                "UPSERT INTO t (a) VALUES (1)",
+			expectedOp:         OpUpsert,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a"},
+			expectedReferenced: []string{"a"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "update set targets become affected columns",
-			sql:              "UPDATE t SET a=1, b=2 WHERE id=3",
-			expectedOp:       OpUpdate,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{"id = 3"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"a", "b"},
-			expectedRisk:     risk.SeverityInfo,
+			// referenced_columns is a superset of affected_columns:
+			// id is read by WHERE; a and b are written by SET.
+			name:               "update set targets become affected columns",
+			sql:                "UPDATE t SET a=1, b=2 WHERE id=3",
+			expectedOp:         OpUpdate,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"id = 3"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a", "b"},
+			expectedReferenced: []string{"id", "a", "b"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "select WHERE splits on top-level AND",
-			sql:              "SELECT 1 FROM t WHERE a=1 AND b>2 AND c IS NULL",
-			expectedOp:       OpSelect,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{"a = 1", "b > 2", "c IS NULL"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "select WHERE splits on top-level AND",
+			sql:                "SELECT 1 FROM t WHERE a=1 AND b>2 AND c IS NULL",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"a = 1", "b > 2", "c IS NULL"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a", "b", "c"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "select star raises low risk",
-			sql:              "SELECT * FROM t",
-			expectedOp:       OpSelect,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityLow,
+			// select_star is set because the projection is a bare *;
+			// referenced_columns stays empty since there is no other
+			// expression position contributing column refs.
+			name:               "select star raises low risk",
+			sql:                "SELECT * FROM t",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedSelectStar: true,
+			expectedRisk:       risk.SeverityLow,
 		},
 		{
 			name:           "inner join with ON",
@@ -117,10 +136,16 @@ func TestSummarize(t *testing.T) {
 			expectedJoins: []Join{
 				{Type: "INNER", Left: "a", Right: "b", Condition: "a.id = b.id"},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a.id", "b.id"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
+			// USING (id) names a column shared by both sides; the
+			// parser stores it as a NameList rather than an Expr, so
+			// the reference walker doesn't see it. Documenting via
+			// expectations here: USING column names are NOT surfaced
+			// in referenced_columns today.
 			name:           "left join with USING",
 			sql:            "SELECT 1 FROM a LEFT JOIN b USING (id)",
 			expectedOp:     OpSelect,
@@ -129,8 +154,9 @@ func TestSummarize(t *testing.T) {
 			expectedJoins: []Join{
 				{Type: "LEFT", Left: "a", Right: "b", Condition: "USING (id)"},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			name:           "three-way join produces two join entries",
@@ -142,53 +168,58 @@ func TestSummarize(t *testing.T) {
 				{Type: "INNER", Left: "a", Right: "b", Condition: "a.id = b.id"},
 				{Type: "INNER", Left: "", Right: "c", Condition: "b.id = c.id"},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a.id", "b.id", "c.id"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "schema-qualified table renders bare name",
-			sql:              "SELECT 1 FROM public.users",
-			expectedOp:       OpSelect,
-			expectedTables:   []string{"users"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "schema-qualified table renders bare name",
+			sql:                "SELECT 1 FROM public.users",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"users"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "CTE alias excluded from tables",
-			sql:              "WITH x AS (SELECT 1 FROM t) SELECT 2 FROM x",
-			expectedOp:       OpSelect,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "CTE alias excluded from tables",
+			sql:                "WITH x AS (SELECT 1 FROM t) SELECT 2 FROM x",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			// The walker visits projection → WHERE → FROM, so the
 			// subquery's table appears before the outer FROM table.
 			// The ordering is intentional and documented on
 			// collectTables.
-			name:             "subquery tables roll up",
-			sql:              "SELECT 1 FROM t WHERE id IN (SELECT id FROM u)",
-			expectedOp:       OpSelect,
-			expectedTables:   []string{"u", "t"},
-			expectedPreds:    []string{"id IN (SELECT id FROM u)"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "subquery tables roll up",
+			sql:                "SELECT 1 FROM t WHERE id IN (SELECT id FROM u)",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"u", "t"},
+			expectedPreds:      []string{"id IN (SELECT id FROM u)"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"id"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "DDL fallback to OTHER with tag and risk",
-			sql:              "DROP TABLE foo",
-			expectedOp:       OpOther,
-			expectedTag:      "DROP TABLE",
-			expectedTables:   []string{},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityCritical,
+			name:               "DDL fallback to OTHER with tag and risk",
+			sql:                "DROP TABLE foo",
+			expectedOp:         OpOther,
+			expectedTag:        "DROP TABLE",
+			expectedTables:     []string{},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityCritical,
 		},
 		{
 			// NATURAL JOIN must not flatten to plain INNER — agents
@@ -202,8 +233,9 @@ func TestSummarize(t *testing.T) {
 			expectedJoins: []Join{
 				{Type: "NATURAL", Left: "a", Right: "b", Condition: "NATURAL"},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			name:           "natural left join combines markers",
@@ -214,8 +246,9 @@ func TestSummarize(t *testing.T) {
 			expectedJoins: []Join{
 				{Type: "NATURAL LEFT", Left: "a", Right: "b", Condition: "NATURAL"},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			name:           "cross join has empty condition",
@@ -226,56 +259,225 @@ func TestSummarize(t *testing.T) {
 			expectedJoins: []Join{
 				{Type: "CROSS", Left: "a", Right: "b", Condition: ""},
 			},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			expectedAffected:   []string{},
+			expectedReferenced: []string{},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			// DELETE ... USING must collect both the target and the
 			// USING tables; otherwise change-impact analysis would
 			// silently drop the second table.
-			name:             "delete using collects both tables",
-			sql:              "DELETE FROM a USING b WHERE a.id=b.id",
-			expectedOp:       OpDelete,
-			expectedTables:   []string{"a", "b"},
-			expectedPreds:    []string{"a.id = b.id"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "delete using collects both tables",
+			sql:                "DELETE FROM a USING b WHERE a.id=b.id",
+			expectedOp:         OpDelete,
+			expectedTables:     []string{"a", "b"},
+			expectedPreds:      []string{"a.id = b.id"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a.id", "b.id"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
-			name:             "update from collects both tables",
-			sql:              "UPDATE a SET x=b.y FROM b WHERE a.id=b.id",
-			expectedOp:       OpUpdate,
-			expectedTables:   []string{"a", "b"},
-			expectedPreds:    []string{"a.id = b.id"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"x"},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "update from collects both tables",
+			sql:                "UPDATE a SET x=b.y FROM b WHERE a.id=b.id",
+			expectedOp:         OpUpdate,
+			expectedTables:     []string{"a", "b"},
+			expectedPreds:      []string{"a.id = b.id"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"x"},
+			expectedReferenced: []string{"b.y", "a.id", "b.id", "x"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			// Only the bare UPSERT keyword is OpUpsert; the explicit
 			// ON CONFLICT DO UPDATE form stays as OpInsert because
 			// OnConflict.IsUpsertAlias() distinguishes them.
-			name:             "explicit on conflict do update stays as insert",
-			sql:              "INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a=2",
-			expectedOp:       OpInsert,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"a"},
-			expectedRisk:     risk.SeverityInfo,
+			//
+			// affected_columns dedupes the insert column 'a' against
+			// the DO UPDATE SET LHS 'a'; referenced_columns picks up
+			// the arbiter column 'a' from the OnConflict walker.
+			name:               "explicit on conflict do update stays as insert",
+			sql:                "INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a=2",
+			expectedOp:         OpInsert,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a"},
+			expectedReferenced: []string{"a"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 		{
 			// Tuple SET targets flatten into individual column names
 			// per updateTargets's documented contract.
-			name:             "tuple update flattens to individual columns",
-			sql:              "UPDATE t SET (a,b)=(1,2) WHERE id=3",
-			expectedOp:       OpUpdate,
-			expectedTables:   []string{"t"},
-			expectedPreds:    []string{"id = 3"},
-			expectedJoins:    []Join{},
-			expectedAffected: []string{"a", "b"},
-			expectedRisk:     risk.SeverityInfo,
+			name:               "tuple update flattens to individual columns",
+			sql:                "UPDATE t SET (a,b)=(1,2) WHERE id=3",
+			expectedOp:         OpUpdate,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"id = 3"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a", "b"},
+			expectedReferenced: []string{"id", "a", "b"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// Issue #100 demo: explicit projection plus WHERE
+			// predicates roll up into referenced_columns in source
+			// order.
+			name:               "issue demo: select projection plus WHERE",
+			sql:                "SELECT a, b FROM t WHERE c = 1 AND d > 2",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"c = 1", "d > 2"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a", "b", "c", "d"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// Function-argument stars (count(*)) MUST NOT trigger
+			// select_star: they don't introduce an unenumerated column
+			// footprint; they count rows. GROUP BY / HAVING / ORDER
+			// BY positions all contribute to referenced_columns.
+			name:               "group by having order by reach referenced",
+			sql:                "SELECT count(*) FROM t GROUP BY g HAVING count(*) > 1 ORDER BY g",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"g"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// CTE bodies contribute their refs but the CTE alias name
+			// itself does not appear as a column.
+			name:               "CTE body refs roll up",
+			sql:                "WITH x AS (SELECT a FROM t WHERE b=1) SELECT a FROM x",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a", "b"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// Correlated EXISTS subquery: outer t.a is read inside the
+			// inner WHERE; the outer projection adds the bare 'a'. The
+			// qualifier stays as the user wrote it.
+			name:               "correlated subquery refs",
+			sql:                "SELECT a FROM t WHERE EXISTS (SELECT 1 FROM o WHERE o.x = t.a)",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"o", "t"},
+			expectedPreds:      []string{"EXISTS (SELECT 1 FROM o WHERE o.x = t.a)"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"a", "o.x", "t.a"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// INSERT ... SELECT: the source SELECT contributes its
+			// own projection and predicate refs; the destination
+			// column list is unioned in via the affected→referenced
+			// merge.
+			name:               "insert select unions source and target columns",
+			sql:                "INSERT INTO t (a, b) SELECT x, y FROM src WHERE z = 1",
+			expectedOp:         OpInsert,
+			expectedTables:     []string{"t", "src"},
+			expectedPreds:      []string{"z = 1"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a", "b"},
+			expectedReferenced: []string{"x", "y", "z", "a", "b"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// Qualified t.* sets select_star just like a bare *;
+			// agents must not assume the column footprint is complete.
+			name:               "qualified star sets select_star",
+			sql:                "SELECT t.* FROM t WHERE c = 1",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"c = 1"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"c"},
+			expectedSelectStar: true,
+			// t.* raises the same SELECT-star risk as a bare *.
+			expectedRisk: risk.SeverityLow,
+		},
+		{
+			// Case-folded dedup with first-seen casing wins. The
+			// parser lowercases unquoted identifiers, so quoted
+			// "ID" surfaces as "ID" and bare id surfaces as "id".
+			// Their lowercased dedup key is the same ("id"), so the
+			// first form ("ID") is kept and the later bare "id" is
+			// dropped. Same pattern for "Foo" vs foo.
+			name:               "case insensitive dedup keeps first casing",
+			sql:                `SELECT "ID", id, "Foo", foo FROM t`,
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"ID", "Foo"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// RETURNING is walked by the upstream parser; lock in
+			// that its expressions contribute to referenced_columns.
+			name:               "RETURNING expressions reach referenced",
+			sql:                "UPDATE t SET a=1 WHERE id=2 RETURNING a, t.b",
+			expectedOp:         OpUpdate,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{"id = 2"},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a"},
+			expectedReferenced: []string{"id", "a", "t.b"},
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// Top-level UNION with one branch projecting * must set
+			// select_star; both branches' projections are part of
+			// the result shape.
+			//
+			// The risk registry inspects the top-level statement
+			// shape (SetOp, not a bare SELECT), so its SELECT-*
+			// rule does not fire here even though a star is
+			// present. summarize's select_star captures what the
+			// risk rule misses.
+			name:               "union branch with star sets select_star",
+			sql:                "SELECT * FROM t UNION SELECT b FROM u",
+			expectedOp:         OpSelect,
+			expectedTables:     []string{"t", "u"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{},
+			expectedReferenced: []string{"b"},
+			expectedSelectStar: true,
+			expectedRisk:       risk.SeverityInfo,
+		},
+		{
+			// ON CONFLICT DO UPDATE: the parser walks the body's
+			// Expr-typed parts (RHS expressions, UPDATE WHERE) when
+			// passed an ExtendedVisitor, so excluded.x and t.id
+			// surface first. addOnConflictNameLists then appends
+			// the arbiter cols (a) and SET LHS (b) — both NameList
+			// values that no Expr walker can reach.
+			//
+			// "excluded" is the conflict-row pseudo-table — it
+			// surfaces only as a qualifier on column refs, never as
+			// a real TableExpr, so it does not appear in tables.
+			// affected_columns includes both the insert column "a"
+			// and the DO UPDATE SET target "b".
+			name:               "on conflict do update body refs surface",
+			sql:                "INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET b = excluded.x WHERE t.id = 5",
+			expectedOp:         OpInsert,
+			expectedTables:     []string{"t"},
+			expectedPreds:      []string{},
+			expectedJoins:      []Join{},
+			expectedAffected:   []string{"a", "b"},
+			expectedReferenced: []string{"excluded.x", "t.id", "a", "b"},
+			expectedRisk:       risk.SeverityInfo,
 		},
 	}
 
@@ -294,6 +496,8 @@ func TestSummarize(t *testing.T) {
 			require.Equal(t, tc.expectedPreds, s.Predicates)
 			require.Equal(t, tc.expectedJoins, s.Joins)
 			require.Equal(t, tc.expectedAffected, s.AffectedColumns)
+			require.Equal(t, tc.expectedReferenced, s.ReferencedColumns)
+			require.Equal(t, tc.expectedSelectStar, s.SelectStar)
 			require.Equal(t, tc.expectedRisk, s.RiskLevel)
 		})
 	}


### PR DESCRIPTION
## Summary

`summarize.Summary` previously surfaced only `affected_columns`, the
DML write set (INSERT explicit column list, UPDATE SET targets). Read
positions — SELECT projection, WHERE, JOIN ON, GROUP BY, HAVING,
ORDER BY, RETURNING, plus subquery and CTE bodies — were not exposed,
so agents asking "what columns does this statement read?" got nothing
useful.

This PR adds two non-breaking fields to `Summary`:

- `referenced_columns []string` — full read+write footprint, the union
  of every column ref the AST walker finds in expression positions
  with the existing `affected_columns` set. The documented invariant
  `referenced ⊇ affected` holds for all DML. Refs are emitted as the
  user wrote them (bare `col` when unqualified, `qualifier.col` when
  the source named a table prefix). Dedup is case-insensitive with
  first-seen casing winning.
- `select_star bool` — true when the outermost projection (and for
  `INSERT ... SELECT`, the embedded source SELECT) names `*` or
  `t.*`. Recurses into UNION/INTERSECT/EXCEPT branches because both
  sides shape the result. Signals that `referenced_columns` is a
  lower bound. Function-argument stars like `count(*)` do **not** set
  the flag — they don't introduce an unenumerated column footprint.

`ON CONFLICT DO UPDATE` is fully covered: the parser walks the body's
Expr-typed parts (arbiter predicate, SET RHS, UPDATE WHERE) when
passed an `ExtendedVisitor`, and a small helper adds the NameList-
typed parts (arbiter columns, SET LHS) that no Expr walker can reach.
The DO UPDATE SET LHS columns also flow into `affected_columns` so
the write set reflects every column the upsert mutates.

The CLI text renderer adds two new rows under `affected_columns` and
the MCP `summarize_sql` tool description is extended so agents see
the new fields and their semantics.

## Known limitation

JOIN `USING (col)` column names are stored as a `NameList`, not an
`Expr`, and remain unsurfaced. Documented in field comments and
pinned in the test expectations.

Resolves: #100