### PR TITLE
semcheck: detect unknown function names with did-you-mean suggestions

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -100,9 +100,10 @@ matched by the config and reports per-file results in one envelope.`,
 				// and the rest as Skipped. Consumers can branch on
 				// the Checks payload without inspecting error codes.
 				parseChecks := validateresult.Checks{
-					Syntax:         validateresult.CheckFailed,
-					TypeCheck:      validateresult.CheckSkipped,
-					NameResolution: validateresult.CheckSkipped,
+					Syntax:             validateresult.CheckFailed,
+					TypeCheck:          validateresult.CheckSkipped,
+					FunctionResolution: validateresult.CheckSkipped,
+					NameResolution:     validateresult.CheckSkipped,
 				}
 				return renderValidateFailure(r, baseEnv,
 					[]output.Error{diag.FromParseError(parseErr, sql)}, parseChecks)
@@ -136,6 +137,7 @@ matched by the config and reports per-file results in one envelope.`,
 
 			semRes, semErrs := semcheck.Run(stmts, sql, cat)
 			checks.TypeCheck = semRes.TypeCheck
+			checks.FunctionResolution = semRes.FunctionResolution
 			checks.NameResolution = semRes.NameResolution
 
 			if len(semErrs) > 0 {

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -80,14 +80,16 @@ func TestValidateCmdJSONSuccess(t *testing.T) {
 	var payload struct {
 		Valid  bool `json:"valid"`
 		Checks struct {
-			Syntax         string `json:"syntax"`
-			TypeCheck      string `json:"type_check"`
-			NameResolution string `json:"name_resolution"`
+			Syntax             string `json:"syntax"`
+			FunctionResolution string `json:"function_resolution"`
+			TypeCheck          string `json:"type_check"`
+			NameResolution     string `json:"name_resolution"`
 		} `json:"checks"`
 	}
 	require.NoError(t, json.Unmarshal(env.Data, &payload))
 	require.True(t, payload.Valid)
 	require.Equal(t, "ok", payload.Checks.Syntax)
+	require.Equal(t, "ok", payload.Checks.FunctionResolution)
 	require.Equal(t, "ok", payload.Checks.TypeCheck)
 	require.Equal(t, "skipped", payload.Checks.NameResolution)
 }
@@ -143,14 +145,16 @@ func TestValidateCmdJSONError(t *testing.T) {
 	var payload struct {
 		Valid  bool `json:"valid"`
 		Checks struct {
-			Syntax         string `json:"syntax"`
-			TypeCheck      string `json:"type_check"`
-			NameResolution string `json:"name_resolution"`
+			Syntax             string `json:"syntax"`
+			FunctionResolution string `json:"function_resolution"`
+			TypeCheck          string `json:"type_check"`
+			NameResolution     string `json:"name_resolution"`
 		} `json:"checks"`
 	}
 	require.NoError(t, json.Unmarshal(env.Data, &payload))
 	require.False(t, payload.Valid)
 	require.Equal(t, "failed", payload.Checks.Syntax)
+	require.Equal(t, "skipped", payload.Checks.FunctionResolution)
 	require.Equal(t, "skipped", payload.Checks.TypeCheck)
 	require.Equal(t, "skipped", payload.Checks.NameResolution)
 }
@@ -331,15 +335,76 @@ func TestValidateCmdTypeErrorJSON(t *testing.T) {
 	var payload struct {
 		Valid  bool `json:"valid"`
 		Checks struct {
-			Syntax         string `json:"syntax"`
-			TypeCheck      string `json:"type_check"`
-			NameResolution string `json:"name_resolution"`
+			Syntax             string `json:"syntax"`
+			FunctionResolution string `json:"function_resolution"`
+			TypeCheck          string `json:"type_check"`
+			NameResolution     string `json:"name_resolution"`
 		} `json:"checks"`
 	}
 	require.NoError(t, json.Unmarshal(env.Data, &payload))
 	require.False(t, payload.Valid)
 	require.Equal(t, "ok", payload.Checks.Syntax)
+	require.Equal(t, "ok", payload.Checks.FunctionResolution)
 	require.Equal(t, "failed", payload.Checks.TypeCheck)
+	require.Equal(t, "skipped", payload.Checks.NameResolution)
+}
+
+// TestValidateCmdUnknownFunction is the end-to-end demo from issue
+// #107: a typo'd function name surfaces a structured 42883 with
+// did-you-mean suggestions and an available_functions sample, and
+// the envelope's checks payload reports function_resolution=failed
+// while everything else either ran cleanly or was skipped.
+func TestValidateCmdUnknownFunction(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"validate", "--output", "json", "-e", "SELECT now_()"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+
+	// Find the 42883 diagnostic; the envelope also carries the
+	// capability_required warning for the missing --schema, which
+	// is not what we're asserting here.
+	var funcErr *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == "42883" {
+			funcErr = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, funcErr, "expected a 42883 diagnostic in envelope")
+	require.Equal(t, "unknown_function", funcErr.Category)
+	require.Contains(t, funcErr.Message, "now_")
+	require.NotNil(t, funcErr.Position)
+	require.Equal(t, 1, funcErr.Position.Line)
+	require.Equal(t, 8, funcErr.Position.Column)
+
+	avail, ok := funcErr.Context["available_functions"].([]any)
+	require.True(t, ok, "available_functions must be a JSON array")
+	require.NotEmpty(t, avail)
+
+	require.NotEmpty(t, funcErr.Suggestions)
+	require.Equal(t, "now", funcErr.Suggestions[0].Replacement)
+
+	var payload struct {
+		Valid  bool `json:"valid"`
+		Checks struct {
+			Syntax             string `json:"syntax"`
+			FunctionResolution string `json:"function_resolution"`
+			TypeCheck          string `json:"type_check"`
+			NameResolution     string `json:"name_resolution"`
+		} `json:"checks"`
+	}
+	require.NoError(t, json.Unmarshal(env.Data, &payload))
+	require.False(t, payload.Valid)
+	require.Equal(t, "ok", payload.Checks.Syntax)
+	require.Equal(t, "failed", payload.Checks.FunctionResolution)
+	require.Equal(t, "ok", payload.Checks.TypeCheck)
 	require.Equal(t, "skipped", payload.Checks.NameResolution)
 }
 

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -13,12 +13,25 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spilchen/sql-ai-tools/internal/builtinstubs"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
 	"github.com/spilchen/sql-ai-tools/internal/summarize"
 	"github.com/spilchen/sql-ai-tools/internal/validateresult"
 )
+
+// init populates the builtin function registry that
+// semcheck.CheckFunctionNames consults. Production binaries (the CLI
+// and the MCP server) call builtinstubs.Init from their main; tests
+// in this package previously did not exercise the function-name path
+// so the registry could be empty without consequence. Issue #107
+// changed that — without this init, the unknown-function check would
+// flag every name (including legitimate builtins like "length") as
+// unknown.
+func init() {
+	builtinstubs.Init("")
+}
 
 const testParserVersion = "v0.26.2"
 
@@ -354,25 +367,28 @@ func TestValidateSQLHandlerFailurePayloadShapes(t *testing.T) {
 	const usersDDL = "CREATE TABLE users (id INT PRIMARY KEY)"
 
 	tests := []struct {
-		name                   string
-		args                   map[string]any
-		expectedSyntax         validateresult.CheckStatus
-		expectedTypeCheck      validateresult.CheckStatus
-		expectedNameResolution validateresult.CheckStatus
+		name                       string
+		args                       map[string]any
+		expectedSyntax             validateresult.CheckStatus
+		expectedFunctionResolution validateresult.CheckStatus
+		expectedTypeCheck          validateresult.CheckStatus
+		expectedNameResolution     validateresult.CheckStatus
 	}{
 		{
-			name:                   "parse error skips downstream phases",
-			args:                   map[string]any{"sql": "SELECT FROM"},
-			expectedSyntax:         validateresult.CheckFailed,
-			expectedTypeCheck:      validateresult.CheckSkipped,
-			expectedNameResolution: validateresult.CheckSkipped,
+			name:                       "parse error skips downstream phases",
+			args:                       map[string]any{"sql": "SELECT FROM"},
+			expectedSyntax:             validateresult.CheckFailed,
+			expectedFunctionResolution: validateresult.CheckSkipped,
+			expectedTypeCheck:          validateresult.CheckSkipped,
+			expectedNameResolution:     validateresult.CheckSkipped,
 		},
 		{
-			name:                   "type error without schemas leaves name resolution skipped",
-			args:                   map[string]any{"sql": "SELECT 1 + 'x'"},
-			expectedSyntax:         validateresult.CheckOK,
-			expectedTypeCheck:      validateresult.CheckFailed,
-			expectedNameResolution: validateresult.CheckSkipped,
+			name:                       "type error without schemas leaves name resolution skipped",
+			args:                       map[string]any{"sql": "SELECT 1 + 'x'"},
+			expectedSyntax:             validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedTypeCheck:          validateresult.CheckFailed,
+			expectedNameResolution:     validateresult.CheckSkipped,
 		},
 		{
 			name: "unknown table marks name resolution failed",
@@ -380,9 +396,18 @@ func TestValidateSQLHandlerFailurePayloadShapes(t *testing.T) {
 				"sql":     "SELECT * FROM nope",
 				"schemas": []any{map[string]any{"sql": usersDDL}},
 			},
-			expectedSyntax:         validateresult.CheckOK,
-			expectedTypeCheck:      validateresult.CheckOK,
-			expectedNameResolution: validateresult.CheckFailed,
+			expectedSyntax:             validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckFailed,
+		},
+		{
+			name:                       "unknown function flips function_resolution to failed",
+			args:                       map[string]any{"sql": "SELECT now_()"},
+			expectedSyntax:             validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckFailed,
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckSkipped,
 		},
 	}
 
@@ -401,10 +426,48 @@ func TestValidateSQLHandlerFailurePayloadShapes(t *testing.T) {
 			require.NoError(t, json.Unmarshal(env.Data, &result))
 			require.False(t, result.Valid)
 			require.Equal(t, tc.expectedSyntax, result.Checks.Syntax)
+			require.Equal(t, tc.expectedFunctionResolution, result.Checks.FunctionResolution)
 			require.Equal(t, tc.expectedTypeCheck, result.Checks.TypeCheck)
 			require.Equal(t, tc.expectedNameResolution, result.Checks.NameResolution)
 		})
 	}
+}
+
+// TestValidateSQLHandlerUnknownFunctionShape pins the end-to-end MCP
+// envelope shape for issue #107: an unknown bare function name produces
+// a 42883 error with did-you-mean suggestions and an
+// available_functions sample, in addition to the failed
+// function_resolution check status.
+func TestValidateSQLHandlerUnknownFunctionShape(t *testing.T) {
+	handler := ValidateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"sql": "SELECT now_()"}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	var funcErr *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == "42883" {
+			funcErr = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, funcErr, "expected a 42883 diagnostic in MCP envelope")
+	require.Equal(t, "unknown_function", funcErr.Category)
+	require.Contains(t, funcErr.Message, "now_")
+	require.NotNil(t, funcErr.Position)
+	avail, ok := funcErr.Context["available_functions"].([]any)
+	require.True(t, ok, "available_functions must be a JSON array")
+	require.NotEmpty(t, avail)
+	require.NotEmpty(t, funcErr.Suggestions)
+	require.Equal(t, "now", funcErr.Suggestions[0].Replacement)
+
+	var result validateresult.Result
+	require.NoError(t, json.Unmarshal(env.Data, &result))
+	require.False(t, result.Valid)
+	require.Equal(t, validateresult.CheckFailed, result.Checks.FunctionResolution)
 }
 
 func TestValidateSQLHandler(t *testing.T) {

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -79,9 +79,10 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 		if parseErr != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(parseErr, sql))
 			return failureEnvelope(env, validateresult.Checks{
-				Syntax:         validateresult.CheckFailed,
-				TypeCheck:      validateresult.CheckSkipped,
-				NameResolution: validateresult.CheckSkipped,
+				Syntax:             validateresult.CheckFailed,
+				TypeCheck:          validateresult.CheckSkipped,
+				FunctionResolution: validateresult.CheckSkipped,
+				NameResolution:     validateresult.CheckSkipped,
 			})
 		}
 
@@ -111,6 +112,7 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 
 		semRes, semErrs := semcheck.Run(stmts, sql, cat)
 		checks.TypeCheck = semRes.TypeCheck
+		checks.FunctionResolution = semRes.FunctionResolution
 		checks.NameResolution = semRes.NameResolution
 
 		if len(semErrs) > 0 {

--- a/internal/semcheck/expr.go
+++ b/internal/semcheck/expr.go
@@ -5,21 +5,28 @@
 
 // Package semcheck provides Tier 1 (zero-config) semantic checks that
 // operate on parsed ASTs without a schema catalog or cluster
-// connection. Currently the only check is expression type checking,
-// which detects type mismatches in literal expressions (e.g. 1 +
-// 'hello') and builtin function calls (e.g. upper(123)) using
-// MakeSemaContext(nil). Builtin function metadata is registered at
-// startup via internal/builtinstubs, enabling function-name validation
-// and overload resolution without a live database.
+// connection. Today there are two zero-config phases: function-name
+// resolution (CheckFunctionNames, which surfaces 42883 typos with
+// "did you mean?" suggestions) and expression type checking
+// (CheckExprTypes, which detects type mismatches in literal
+// expressions and builtin function calls using MakeSemaContext(nil)).
+// Builtin function metadata is registered at startup via
+// internal/builtinstubs, enabling both phases to operate without a
+// live database.
 //
-// Expressions that reference columns, subqueries, or placeholders are
-// silently skipped because resolving those names requires a catalog
-// (Tier 2) or connection (Tier 3).
+// Expressions that reference columns, subqueries, placeholders, or
+// FuncExprs whose bare names are unknown to the builtin registry are
+// silently skipped by CheckExprTypes. Columns/subqueries/placeholders
+// are skipped because resolving them requires a catalog (Tier 2) or
+// connection (Tier 3); unknown function names are skipped to avoid
+// double-reporting the structured 42883 already produced by
+// CheckFunctionNames.
 package semcheck
 
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
@@ -51,6 +58,14 @@ func CheckExprTypes(stmts statements.Statements, fullSQL string) []output.Error 
 				return false, expr, nil
 			}
 			if containsVariable(expr) {
+				return true, expr, nil
+			}
+			// CheckFunctionNames already owns the 42883 diagnostic
+			// for bare-unknown calls; type-checking the same node
+			// would emit a second error pointing at the same span.
+			// Recurse without checking so any well-formed sibling
+			// expressions still get type-checked.
+			if containsUnknownFunc(expr) {
 				return true, expr, nil
 			}
 
@@ -108,6 +123,52 @@ func (d *variableDetector) VisitPre(expr tree.Expr) (bool, tree.Expr) {
 }
 
 func (d *variableDetector) VisitPost(expr tree.Expr) tree.Expr { return expr }
+
+// containsUnknownFunc walks expr and returns true if any descendant is
+// a *tree.FuncExpr whose bare name (the rightmost UnresolvedName Part)
+// is not registered in tree.FunDefs. Schema-qualified calls and
+// pre-resolved references (FunctionDefinition / ResolvedFunction-
+// Definition / FunctionOID — produced by grammar rules like
+// WrapFunction for keywords) are not counted because CheckFunctionNames
+// also skips them.
+func containsUnknownFunc(expr tree.Expr) bool {
+	var found bool
+	v := unknownFuncDetector{found: &found}
+	tree.WalkExprConst(&v, expr)
+	return found
+}
+
+type unknownFuncDetector struct {
+	found *bool
+}
+
+func (d *unknownFuncDetector) VisitPre(expr tree.Expr) (bool, tree.Expr) {
+	if *d.found {
+		return false, expr
+	}
+	fn, ok := expr.(*tree.FuncExpr)
+	if !ok {
+		return true, expr
+	}
+	un, ok := fn.Func.FunctionReference.(*tree.UnresolvedName)
+	if !ok {
+		return true, expr
+	}
+	if un.NumParts != 1 {
+		return true, expr
+	}
+	name := strings.ToLower(un.Parts[0])
+	if name == "" {
+		return true, expr
+	}
+	if _, known := tree.FunDefs[name]; !known {
+		*d.found = true
+		return false, expr
+	}
+	return true, expr
+}
+
+func (d *unknownFuncDetector) VisitPost(expr tree.Expr) tree.Expr { return expr }
 
 // safeTypeCheck type-checks expr, recovering from panics that the
 // type-checker may trigger for certain expression types (e.g.

--- a/internal/semcheck/expr_test.go
+++ b/internal/semcheck/expr_test.go
@@ -58,10 +58,14 @@ func TestCheckExprTypes(t *testing.T) {
 			expectedMsg:   "unknown signature",
 		},
 		{
-			name:          "unknown function detected",
+			// Unknown bare function names are owned by
+			// CheckFunctionNames, which emits the structured
+			// 42883 with suggestions. CheckExprTypes deliberately
+			// skips the FuncExpr (see containsUnknownFunc) so the
+			// user sees exactly one diagnostic per typo.
+			name:          "unknown function skipped by type check",
 			sql:           "SELECT now_()",
-			expectedCount: 1,
-			expectedMsg:   "unknown function",
+			expectedCount: 0,
 		},
 		{
 			name:          "subquery skipped",
@@ -130,4 +134,47 @@ func TestCheckExprTypesPosition(t *testing.T) {
 func TestCheckExprTypesEmptyStatements(t *testing.T) {
 	errs := CheckExprTypes(nil, "")
 	require.Empty(t, errs)
+}
+
+// TestCheckExprTypesUnknownFuncCrossTalk pins the contract documented
+// on containsUnknownFunc: skipping a FuncExpr whose bare name is
+// unresolved must not silence type errors in sibling sub-expressions.
+// Without this guarantee, a single typo would suppress every
+// type-mismatch in the same statement and the user would see a new
+// error after each fix-and-retry.
+func TestCheckExprTypesUnknownFuncCrossTalk(t *testing.T) {
+	tests := []struct {
+		name          string
+		sql           string
+		expectedCount int
+		expectedMsg   string
+	}{
+		{
+			name:          "type error in sibling of unknown call",
+			sql:           "SELECT 1 + 'x', bogus_fn()",
+			expectedCount: 1,
+			expectedMsg:   "unsupported binary operator",
+		},
+		{
+			name:          "type error nested in arg list of known call wrapping unknown",
+			sql:           "SELECT length(bogus_fn(), 1+'x')",
+			expectedCount: 1,
+			expectedMsg:   "unsupported binary operator",
+		},
+		{
+			name:          "type error in same binary expression as unknown call",
+			sql:           "SELECT 1 + 'x' + bogus_fn()",
+			expectedCount: 1,
+			expectedMsg:   "unsupported binary operator",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			errs := CheckExprTypes(stmts, tc.sql)
+			require.Len(t, errs, tc.expectedCount)
+			require.Contains(t, errs[0].Message, tc.expectedMsg)
+		})
+	}
 }

--- a/internal/semcheck/functions.go
+++ b/internal/semcheck/functions.go
@@ -1,0 +1,309 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// unknownFunctionCode is the SQLSTATE for "undefined_function" (PG
+// 42883). The parser also surfaces this code from its own type-check
+// path, but CheckFunctionNames runs first and CheckExprTypes skips
+// FuncExprs with unresolved bare names so consumers see exactly one
+// 42883 per typo — the structured one with suggestions and sampled
+// available_functions context.
+const unknownFunctionCode = "42883"
+
+// availableFunctionsSampleSize caps the number of names returned in
+// the Context["available_functions"] payload. The full builtin
+// registry contains hundreds of names — dumping all of them inflates
+// the wire payload without helping an agent narrow down a typo. The
+// sample is the top-N nearest names by Levenshtein distance, which
+// subsumes the suggestions[] cap (3) and gives the agent a few extra
+// near-misses to consider.
+const availableFunctionsSampleSize = 25
+
+// builtinFuncNamesSnapshot returns the sorted slice of bare builtin
+// function names registered in tree.FunDefs, computed exactly once per
+// process. The registry is populated at init time by
+// internal/builtinstubs and is immutable thereafter, so a single
+// process-wide snapshot is correct and avoids re-walking ~10^3 names
+// on every CheckFunctionNames call.
+var builtinFuncNamesSnapshot = sync.OnceValue(builtinFunctionNames)
+
+// CheckFunctionNames walks every statement in stmts and reports calls
+// to function names that do not exist in the builtin registry
+// (tree.FunDefs, populated by internal/builtinstubs at process start).
+//
+// Errors are deduplicated by lowercased function name across the whole
+// input — a single missing name referenced from two statements
+// produces one error, not two. The first reference's source position
+// is reported.
+//
+// Schema-qualified calls (e.g. pg_catalog.foo()) are intentionally
+// skipped: this check is name-existence only, and a meaningful
+// schema-qualified lookup needs the per-search-path resolver that lives
+// behind a catalog (out of scope for issue #107).
+//
+// fullSQL is the original SQL text used to compute 1-based line/column
+// positions and to feed diag.Suggest's byte range. Returns nil when
+// stmts is empty or every call resolves.
+func CheckFunctionNames(stmts statements.Statements, fullSQL string) []output.Error {
+	if len(stmts) == 0 {
+		return nil
+	}
+
+	var errs []output.Error
+	seen := make(map[string]struct{})
+
+	stmtStart := 0
+	for i := range stmts {
+		stmt := stmts[i].AST
+		if stmt == nil {
+			continue
+		}
+		stmtSQL := stmts[i].SQL
+		stmtEnd := stmtStart + len(stmtSQL)
+		if rel := strings.Index(fullSQL[stmtStart:], stmtSQL); rel >= 0 {
+			stmtStart += rel
+			stmtEnd = stmtStart + len(stmtSQL)
+		}
+
+		v := &funcNameVisitor{
+			fullSQL:   fullSQL,
+			stmtStart: stmtStart,
+			stmtEnd:   stmtEnd,
+			seen:      seen,
+			errs:      &errs,
+		}
+		tree.WalkStmt(v, stmt)
+
+		stmtStart = stmtEnd
+	}
+	return errs
+}
+
+// funcNameVisitor walks one top-level statement collecting unresolved
+// function-call references.
+//
+// Lifecycle: one visitor per statement; created by CheckFunctionNames
+// and discarded once WalkStmt returns. seen is shared across statements
+// so the same missing name only produces one error per input.
+// stmtStart/stmtEnd bound the byte range searched by positionFor (the
+// helper from names.go), keeping position lookups inside the current
+// statement so a typo'd name in stmt 2 doesn't get located in stmt 1.
+//
+// The visitor implements tree.ExtendedVisitor — required because a
+// plain tree.Visitor skips TableExpr subtrees during WalkStmt, but
+// function calls can appear inside FROM (table-valued functions),
+// JOIN ON conditions, and subqueries within FROM.
+type funcNameVisitor struct {
+	fullSQL   string
+	stmtStart int
+	stmtEnd   int
+	seen      map[string]struct{}
+	errs      *[]output.Error
+}
+
+var _ tree.ExtendedVisitor = (*funcNameVisitor)(nil)
+
+func (v *funcNameVisitor) VisitPost(expr tree.Expr) tree.Expr                        { return expr }
+func (v *funcNameVisitor) VisitTablePre(e tree.TableExpr) (bool, tree.TableExpr)     { return true, e }
+func (v *funcNameVisitor) VisitTablePost(e tree.TableExpr) tree.TableExpr            { return e }
+func (v *funcNameVisitor) VisitStatementPre(s tree.Statement) (bool, tree.Statement) { return true, s }
+func (v *funcNameVisitor) VisitStatementPost(s tree.Statement) tree.Statement        { return s }
+
+func (v *funcNameVisitor) VisitPre(expr tree.Expr) (bool, tree.Expr) {
+	fn, ok := expr.(*tree.FuncExpr)
+	if !ok {
+		return true, expr
+	}
+	v.checkFunc(fn)
+	return true, expr
+}
+
+// checkFunc reports fn's referenced name as unknown when the bare name
+// is not in tree.FunDefs. Already-resolved function references (e.g.
+// the grammar's WrapFunction calls for keywords like current_timestamp)
+// and schema-qualified names are silently skipped; both are out of
+// scope for the bare-name typo detection issue #107 targets.
+func (v *funcNameVisitor) checkFunc(fn *tree.FuncExpr) {
+	un, ok := fn.Func.FunctionReference.(*tree.UnresolvedName)
+	if !ok {
+		return
+	}
+	if un.NumParts != 1 {
+		return
+	}
+	name := un.Parts[0]
+	if name == "" {
+		return
+	}
+	lower := strings.ToLower(name)
+	if _, found := tree.FunDefs[lower]; found {
+		return
+	}
+	if _, dup := v.seen[lower]; dup {
+		return
+	}
+	v.seen[lower] = struct{}{}
+
+	pos := v.positionFor(name)
+	all := builtinFuncNamesSnapshot()
+	*v.errs = append(*v.errs, output.Error{
+		Code:     unknownFunctionCode,
+		Severity: output.SeverityError,
+		Message:  fmt.Sprintf("unknown function: %s()", name),
+		Position: pos,
+		Category: diag.CategoryUnknownFunction,
+		Context: map[string]any{
+			"available_functions": sampleNearest(name, all, availableFunctionsSampleSize),
+		},
+		Suggestions: diag.Suggest(name, all, pos),
+	})
+}
+
+// positionFor mirrors tableNameVisitor.positionFor in names.go: it
+// locates name within the current statement's byte range with word-
+// boundary checks so a search for "now" doesn't match the "now" inside
+// "snowflake". A separate copy here (rather than a shared free
+// function) keeps the visitor's stmtStart/stmtEnd plumbing local; the
+// underlying helpers (indexFold, isWordBoundary) live in names.go and
+// are reused.
+func (v *funcNameVisitor) positionFor(name string) *output.Position {
+	if name == "" {
+		return nil
+	}
+	stmtText := v.fullSQL[v.stmtStart:v.stmtEnd]
+	for off := 0; off < len(stmtText); {
+		rel := indexFold(stmtText[off:], name)
+		if rel < 0 {
+			return nil
+		}
+		abs := v.stmtStart + off + rel
+		if isWordBoundary(v.fullSQL, abs, abs+len(name)) {
+			return diag.PositionFromByteOffset(v.fullSQL, abs)
+		}
+		off += rel + 1
+	}
+	return nil
+}
+
+// builtinFunctionNames returns a sorted snapshot of every bare builtin
+// function name registered in tree.FunDefs. Schema-qualified entries
+// (e.g. "pg_catalog.length") are excluded so the suggestion candidate
+// set matches the bare-name keys an unresolved UnresolvedName carries.
+//
+// Callers should invoke through builtinFuncNamesSnapshot, the
+// package-level sync.OnceValue wrapper, so the work happens at most
+// once per process. The function copies out of the global map under
+// the assumption that internal/builtinstubs.Init has already run —
+// registration is a one-shot init-time event, so the snapshot does
+// not need to handle concurrent mutation.
+func builtinFunctionNames() []string {
+	names := make([]string, 0, len(tree.FunDefs))
+	for name := range tree.FunDefs {
+		if strings.Contains(name, ".") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sampleNearest returns up to limit candidate names ranked by
+// Levenshtein edit distance to misspelled. Unlike diag.Suggest it
+// applies no distance threshold — the caller already gets a high-
+// confidence subset via Suggestions; this sample is for the agent's
+// fallback "show me what's nearby" use case, where even a moderately
+// distant name (e.g. unrelated suffix variants) is useful context.
+//
+// Ties are broken alphabetically so the sample is deterministic across
+// runs and across the suggestions[] subset (which uses the same
+// secondary sort).
+func sampleNearest(misspelled string, candidates []string, limit int) []string {
+	if limit <= 0 || len(candidates) == 0 {
+		return nil
+	}
+	type scored struct {
+		name     string
+		distance int
+	}
+	hits := make([]scored, 0, len(candidates))
+	low := strings.ToLower(misspelled)
+	for _, cand := range candidates {
+		if cand == "" || strings.EqualFold(cand, misspelled) {
+			continue
+		}
+		d := levenshtein(low, strings.ToLower(cand))
+		hits = append(hits, scored{name: cand, distance: d})
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].distance != hits[j].distance {
+			return hits[i].distance < hits[j].distance
+		}
+		return hits[i].name < hits[j].name
+	})
+	if len(hits) > limit {
+		hits = hits[:limit]
+	}
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.name
+	}
+	return out
+}
+
+// levenshtein duplicates the two-row DP from diag.Suggest because
+// that helper is unexported. The two implementations must stay
+// behaviourally identical: sampleNearest's "available_functions"
+// ranking and diag.Suggest's "did you mean?" ranking are presented
+// side-by-side to the agent, and a divergence (e.g. one adopting
+// transposition support or an early-exit optimization) would yield
+// inconsistent orderings that look like a bug. If you change either
+// copy, change the other — or promote the helper to a shared utility
+// (e.g. an exported diag.Levenshtein) and delete one.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}

--- a/internal/semcheck/functions_test.go
+++ b/internal/semcheck/functions_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package semcheck
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+func TestCheckFunctionNames(t *testing.T) {
+	tests := []struct {
+		name              string
+		sql               string
+		expectedCount     int
+		expectedFirstName string
+		expectedFirstCode string
+	}{
+		{
+			name:          "known builtin call passes",
+			sql:           "SELECT now()",
+			expectedCount: 0,
+		},
+		{
+			name:          "case insensitive match",
+			sql:           "SELECT NoW()",
+			expectedCount: 0,
+		},
+		{
+			name:              "unknown bare name flagged",
+			sql:               "SELECT now_()",
+			expectedCount:     1,
+			expectedFirstName: "now_",
+			expectedFirstCode: "42883",
+		},
+		{
+			name:          "schema-qualified call skipped",
+			sql:           "SELECT pg_catalog.fake_function_xyz()",
+			expectedCount: 0,
+		},
+		{
+			name:              "unknown function in WHERE clause",
+			sql:               "SELECT 1 FROM t WHERE bogus_fn(x) = 1",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in INSERT VALUES",
+			sql:               "INSERT INTO t (a) VALUES (bogus_fn())",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in UPDATE SET",
+			sql:               "UPDATE t SET a = bogus_fn() WHERE id = 1",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in DELETE WHERE",
+			sql:               "DELETE FROM t WHERE bogus_fn(x) = 1",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in JOIN ON",
+			sql:               "SELECT 1 FROM a JOIN b ON bogus_fn(a.x) = b.y",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in subquery",
+			sql:               "SELECT (SELECT bogus_fn() FROM t)",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:              "unknown function in RETURNING",
+			sql:               "INSERT INTO t (a) VALUES (1) RETURNING bogus_fn(a)",
+			expectedCount:     1,
+			expectedFirstName: "bogus_fn",
+		},
+		{
+			name:          "deduplicates across statements",
+			sql:           "SELECT now_(); SELECT now_()",
+			expectedCount: 1,
+		},
+		{
+			name:          "deduplicates across calls in one statement",
+			sql:           "SELECT bogus_fn(), bogus_fn()",
+			expectedCount: 1,
+		},
+		{
+			name:          "two distinct typos produce two errors",
+			sql:           "SELECT now_(), uppr('hi')",
+			expectedCount: 2,
+		},
+		{
+			name:          "nested calls inside known function",
+			sql:           "SELECT length(bogus_fn())",
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+
+			errs := CheckFunctionNames(stmts, tc.sql)
+			require.Len(t, errs, tc.expectedCount)
+			if tc.expectedCount == 0 {
+				return
+			}
+			if tc.expectedFirstCode != "" {
+				require.Equal(t, tc.expectedFirstCode, errs[0].Code)
+			}
+			if tc.expectedFirstName != "" {
+				require.Contains(t, errs[0].Message, tc.expectedFirstName)
+			}
+		})
+	}
+}
+
+func TestCheckFunctionNamesEmptyStatements(t *testing.T) {
+	require.Empty(t, CheckFunctionNames(nil, ""))
+}
+
+func TestCheckFunctionNamesDiagnosticShape(t *testing.T) {
+	const sql = "SELECT now_()"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckFunctionNames(stmts, sql)
+	require.Len(t, errs, 1)
+	e := errs[0]
+
+	require.Equal(t, "42883", e.Code)
+	require.Equal(t, output.SeverityError, e.Severity)
+	require.Equal(t, diag.CategoryUnknownFunction, e.Category)
+	require.Contains(t, e.Message, "now_")
+
+	require.NotNil(t, e.Position, "position should be populated for word-boundary match")
+	require.Equal(t, 1, e.Position.Line)
+	// "SELECT " is 7 bytes, then "now_" starts at byte 7, column 8.
+	require.Equal(t, 8, e.Position.Column)
+
+	avail, ok := e.Context["available_functions"].([]string)
+	require.True(t, ok, "available_functions should be a []string")
+	require.NotEmpty(t, avail)
+	require.LessOrEqual(t, len(avail), availableFunctionsSampleSize)
+
+	require.NotEmpty(t, e.Suggestions, "did-you-mean suggestions should be present for a near-match")
+	require.Equal(t, "now", e.Suggestions[0].Replacement)
+	require.Greater(t, e.Suggestions[0].Confidence, 0.5)
+}
+
+func TestCheckFunctionNamesPositionWordBoundary(t *testing.T) {
+	// "now_" appears inside the column alias and inside a string
+	// literal; positionFor must locate the actual call site, which is
+	// the third occurrence (preceded by a SELECT and a non-identifier
+	// boundary).
+	const sql = "SELECT 'now_value' AS now_alias, now_()"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckFunctionNames(stmts, sql)
+	require.Len(t, errs, 1)
+	require.NotNil(t, errs[0].Position)
+	// The call site is the only occurrence flanked on both sides by
+	// non-identifier bytes (', ' before, '(' after); the alias
+	// "now_alias" extends past "now_" so its boundary check fails.
+	idx := strings.Index(sql, "now_(")
+	require.Equal(t, idx, errs[0].Position.ByteOffset)
+}
+
+// TestCheckFunctionNamesDedupReportsFirstPosition pins the doc-comment
+// claim that "the first reference's source position is reported" when
+// the same unknown name appears in multiple statements. Without this
+// test, a future refactor could silently start reporting the last (or
+// an arbitrary) occurrence.
+func TestCheckFunctionNamesDedupReportsFirstPosition(t *testing.T) {
+	const sql = "SELECT 1; SELECT bogus_fn(); SELECT bogus_fn()"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckFunctionNames(stmts, sql)
+	require.Len(t, errs, 1)
+	require.NotNil(t, errs[0].Position)
+	firstCall := strings.Index(sql, "bogus_fn(")
+	require.Equal(t, firstCall, errs[0].Position.ByteOffset)
+}
+
+func TestCheckFunctionNamesAvailableFunctionsRanked(t *testing.T) {
+	// Sampling should rank by Levenshtein distance, so the closest
+	// names ("now") appear before unrelated names ("avg", "min", ...).
+	const sql = "SELECT now_()"
+	stmts, err := parser.Parse(sql)
+	require.NoError(t, err)
+
+	errs := CheckFunctionNames(stmts, sql)
+	require.Len(t, errs, 1)
+	avail, ok := errs[0].Context["available_functions"].([]string)
+	require.True(t, ok)
+	require.Contains(t, avail, "now", "the closest known builtin should be in the sample")
+	require.Equal(t, "now", avail[0], "closest match should rank first")
+}

--- a/internal/semcheck/runner.go
+++ b/internal/semcheck/runner.go
@@ -16,19 +16,28 @@ import (
 // Result reports the per-phase outcome of a Run. The fields mirror
 // validateresult.Checks (minus Syntax, which is the parser's
 // responsibility) so callers can copy directly into the envelope's
-// Checks payload without translation.
+// Checks payload without translation. Field declaration order
+// matches Run's phase-execution order.
 type Result struct {
-	TypeCheck      validateresult.CheckStatus
-	NameResolution validateresult.CheckStatus
+	FunctionResolution validateresult.CheckStatus
+	TypeCheck          validateresult.CheckStatus
+	NameResolution     validateresult.CheckStatus
 }
 
 // Run executes every semantic check against the parsed input and
 // returns the per-phase Result together with the accumulated
-// diagnostics in a stable phase order: type errors, then table-name
-// errors, then column-name errors. Errors from later phases are not
-// suppressed by errors in earlier phases — the runner exists so a
-// single invocation surfaces every diagnostic the user could fix in
-// one editing pass.
+// diagnostics in a stable phase order: function-name errors, then
+// type errors, then table-name errors, then column-name errors.
+// Errors from later phases are not suppressed by errors in earlier
+// phases — the runner exists so a single invocation surfaces every
+// diagnostic the user could fix in one editing pass.
+//
+// Function-name resolution runs first because its diagnostics are the
+// most actionable output for the common typo case, and because
+// CheckExprTypes deliberately skips FuncExprs whose bare names are
+// unresolved (see containsUnknownFunc in expr.go) so the user sees
+// exactly one structured 42883 per typo rather than a duplicate from
+// the type checker.
 //
 // Cascade suppression for downstream column references against an
 // unresolved table is the responsibility of CheckColumnNames (see
@@ -39,14 +48,30 @@ type Result struct {
 // NameResolution is reported as CheckSkipped — the caller decides
 // whether to also append a capability_required warning to the
 // envelope (today only the CLI's --schema-less single-input path
-// does this).
+// does this). Function-name resolution does not need a catalog (the
+// builtin registry is process-global) and always runs.
 //
 // Inputs are not copied: stmts and sql are read by the underlying
 // checkers and must remain valid for the duration of the call.
 func Run(stmts statements.Statements, sql string, cat *catalog.Catalog) (Result, []output.Error) {
 	var errs []output.Error
 
-	res := Result{TypeCheck: validateresult.CheckOK}
+	// Initialize all phases to CheckOK up front. Each phase downgrades
+	// its own field on failure, and the cat==nil branch overrides
+	// NameResolution to CheckSkipped. Initializing here (rather than
+	// in branches) prevents the empty-string zero value from leaking
+	// out through any future early-return path.
+	res := Result{
+		FunctionResolution: validateresult.CheckOK,
+		TypeCheck:          validateresult.CheckOK,
+		NameResolution:     validateresult.CheckOK,
+	}
+
+	if funcErrs := CheckFunctionNames(stmts, sql); len(funcErrs) > 0 {
+		errs = append(errs, funcErrs...)
+		res.FunctionResolution = validateresult.CheckFailed
+	}
+
 	if typeErrs := CheckExprTypes(stmts, sql); len(typeErrs) > 0 {
 		errs = append(errs, typeErrs...)
 		res.TypeCheck = validateresult.CheckFailed
@@ -57,7 +82,6 @@ func Run(stmts statements.Statements, sql string, cat *catalog.Catalog) (Result,
 		return res, errs
 	}
 
-	res.NameResolution = validateresult.CheckOK
 	tableErrs := CheckTableNames(stmts, sql, cat)
 	colErrs := CheckColumnNames(stmts, sql, cat)
 	if len(tableErrs) > 0 || len(colErrs) > 0 {

--- a/internal/semcheck/runner_test.go
+++ b/internal/semcheck/runner_test.go
@@ -18,25 +18,28 @@ import (
 
 func TestRun(t *testing.T) {
 	tests := []struct {
-		name                   string
-		sql                    string
-		withCatalog            bool
-		expectedCategories     []string
-		expectedTypeCheck      validateresult.CheckStatus
-		expectedNameResolution validateresult.CheckStatus
+		name                       string
+		sql                        string
+		withCatalog                bool
+		expectedCategories         []string
+		expectedTypeCheck          validateresult.CheckStatus
+		expectedFunctionResolution validateresult.CheckStatus
+		expectedNameResolution     validateresult.CheckStatus
 	}{
 		{
-			name:                   "all clean",
-			sql:                    "SELECT 1; SELECT * FROM users",
-			withCatalog:            true,
-			expectedTypeCheck:      validateresult.CheckOK,
-			expectedNameResolution: validateresult.CheckOK,
+			name:                       "all clean",
+			sql:                        "SELECT 1; SELECT * FROM users",
+			withCatalog:                true,
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckOK,
 		},
 		{
-			name:                   "name resolution skipped without catalog",
-			sql:                    "SELECT * FROM usrs",
-			expectedTypeCheck:      validateresult.CheckOK,
-			expectedNameResolution: validateresult.CheckSkipped,
+			name:                       "name resolution skipped without catalog",
+			sql:                        "SELECT * FROM usrs",
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckSkipped,
 		},
 		{
 			name:        "two distinct typos in one envelope",
@@ -46,8 +49,9 @@ func TestRun(t *testing.T) {
 				diag.CategoryUnknownTable,
 				diag.CategoryUnknownColumn,
 			},
-			expectedTypeCheck:      validateresult.CheckOK,
-			expectedNameResolution: validateresult.CheckFailed,
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckFailed,
 		},
 		{
 			name:        "type error in stmt 1 does not hide name error in stmt 2",
@@ -57,8 +61,9 @@ func TestRun(t *testing.T) {
 				diag.CategoryTypeMismatch,
 				diag.CategoryUnknownTable,
 			},
-			expectedTypeCheck:      validateresult.CheckFailed,
-			expectedNameResolution: validateresult.CheckFailed,
+			expectedTypeCheck:          validateresult.CheckFailed,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckFailed,
 		},
 		{
 			name:        "unknown table suppresses cascaded column error",
@@ -67,8 +72,31 @@ func TestRun(t *testing.T) {
 			expectedCategories: []string{
 				diag.CategoryUnknownTable,
 			},
-			expectedTypeCheck:      validateresult.CheckOK,
-			expectedNameResolution: validateresult.CheckFailed,
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckOK,
+			expectedNameResolution:     validateresult.CheckFailed,
+		},
+		{
+			name: "unknown function flagged without catalog",
+			sql:  "SELECT now_()",
+			expectedCategories: []string{
+				diag.CategoryUnknownFunction,
+			},
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckFailed,
+			expectedNameResolution:     validateresult.CheckSkipped,
+		},
+		{
+			name:        "unknown function and unknown table reported together",
+			sql:         "SELECT now_() FROM usrs",
+			withCatalog: true,
+			expectedCategories: []string{
+				diag.CategoryUnknownFunction,
+				diag.CategoryUnknownTable,
+			},
+			expectedTypeCheck:          validateresult.CheckOK,
+			expectedFunctionResolution: validateresult.CheckFailed,
+			expectedNameResolution:     validateresult.CheckFailed,
 		},
 	}
 
@@ -85,6 +113,7 @@ func TestRun(t *testing.T) {
 			res, errs := Run(stmts, tc.sql, cat)
 
 			require.Equal(t, tc.expectedTypeCheck, res.TypeCheck)
+			require.Equal(t, tc.expectedFunctionResolution, res.FunctionResolution)
 			require.Equal(t, tc.expectedNameResolution, res.NameResolution)
 			require.Len(t, errs, len(tc.expectedCategories))
 			for i, want := range tc.expectedCategories {
@@ -106,21 +135,24 @@ func TestRun(t *testing.T) {
 }
 
 // TestRunPhaseOrdering pins the phase order so consumers (and the
-// validate command's text renderer) can rely on it. Type-check errors
-// always come before table-name errors, which always come before
-// column-name errors.
+// validate command's text renderer) can rely on it. Function-name
+// errors come first (they carry the most actionable did-you-mean
+// suggestions), then type-check errors, then table-name, then
+// column-name.
 func TestRunPhaseOrdering(t *testing.T) {
-	const sql = "SELECT 1 + 'x'; SELECT * FROM usrs; SELECT u.nme FROM users u"
+	const sql = "SELECT now_(); SELECT 1 + 'x'; SELECT * FROM usrs; SELECT u.nme FROM users u"
 	stmts, err := parser.Parse(sql)
 	require.NoError(t, err)
 
 	res, errs := Run(stmts, sql, usersOnlyCatalog(t))
 
+	require.Equal(t, validateresult.CheckFailed, res.FunctionResolution)
 	require.Equal(t, validateresult.CheckFailed, res.TypeCheck)
 	require.Equal(t, validateresult.CheckFailed, res.NameResolution)
-	require.Len(t, errs, 3)
+	require.Len(t, errs, 4)
 
-	require.Equal(t, diag.CategoryTypeMismatch, diag.CategoryForCode(errs[0].Code))
-	require.Equal(t, diag.CategoryUnknownTable, errs[1].Category)
-	require.Equal(t, diag.CategoryUnknownColumn, errs[2].Category)
+	require.Equal(t, diag.CategoryUnknownFunction, errs[0].Category)
+	require.Equal(t, diag.CategoryTypeMismatch, diag.CategoryForCode(errs[1].Code))
+	require.Equal(t, diag.CategoryUnknownTable, errs[2].Category)
+	require.Equal(t, diag.CategoryUnknownColumn, errs[3].Category)
 }

--- a/internal/validateresult/validateresult.go
+++ b/internal/validateresult/validateresult.go
@@ -53,10 +53,18 @@ const CapabilityNameResolution = "name_resolution"
 // phases ran. Adding a phase means adding a field here and updating
 // both surfaces (CLI and MCP) on each path (success and failure) — four
 // rendering sites total.
+// Field declaration order matches the phase-execution order in
+// semcheck.Run (and the prose order in its doc comment): syntax,
+// then function-name resolution, then expression type-checking, then
+// table/column name resolution. Keeping the two in lockstep means a
+// reader can use either source as the authoritative ordering and the
+// JSON envelope renders fields in execution order, which makes
+// failure paths easier to scan.
 type Checks struct {
-	Syntax         CheckStatus `json:"syntax"`
-	TypeCheck      CheckStatus `json:"type_check"`
-	NameResolution CheckStatus `json:"name_resolution"`
+	Syntax             CheckStatus `json:"syntax"`
+	FunctionResolution CheckStatus `json:"function_resolution"`
+	TypeCheck          CheckStatus `json:"type_check"`
+	NameResolution     CheckStatus `json:"name_resolution"`
 }
 
 // Result is the JSON payload for SQL validation. Valid is true on


### PR DESCRIPTION
Walk function-call expressions in every parsed statement and emit a
structured 42883 diagnostic when the bare name is not registered in
the builtin stubs (tree.FunDefs, populated at startup by
internal/builtinstubs). Each diagnostic carries the standard
suggestions[] payload from diag.Suggest plus a sampled
available_functions context — the top 25 names by Levenshtein
distance, which keeps the wire payload small while still giving an
agent fallback context beyond the 3 high-confidence suggestions.

The check runs as a new FunctionResolution phase that executes before
type checking. CheckExprTypes now skips FuncExprs whose bare names
are unresolved (containsUnknownFunc) so the user sees exactly one
diagnostic per typo rather than a duplicate from the parser's own
type-check path. Schema-qualified calls and pre-resolved references
(grammar-wrapped keywords like current_timestamp) are intentionally
out of scope and pass through silently.

Both validate surfaces report the new phase: validateresult.Checks
gains a function_resolution field and the CLI/MCP handlers copy
semRes.FunctionResolution on every success and failure path.

Demo:

\`\`\`
$ crdb-sql validate -e "SELECT now_()"
1:8: unknown function: now_() [42883]
  did you mean: now (75% confidence)
  did you mean: pow (50% confidence)
\`\`\`

Resolves: #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)