### PR TITLE
safety: add read-only allowlist gating Tier 3 explain commands

### DIFF
--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 )
 
@@ -28,10 +30,18 @@ import (
 // (the raw EXPLAIN tabular rows) and json (structured envelope with
 // header, plan tree, and raw rows).
 //
-// This is a Tier 3 (connected) command. Read-only safety enforcement
-// (statement allowlist, transaction wrapping) is deferred to issue #21.
+// This is a Tier 3 (connected) command. The --mode flag (default
+// read_only) and --timeout flag (default 30s) gate the cluster call:
+// the safety allowlist (internal/safety) rejects DML/DDL inner
+// statements before any pgwire round-trip, and the read-only
+// transaction wrapper inside conn.Manager applies the statement
+// timeout for defense-in-depth.
 func newExplainCmd(state *rootState) *cobra.Command {
-	var expr string
+	var (
+		expr    string
+		mode    string
+		timeout time.Duration
+	)
 
 	cmd := &cobra.Command{
 		Use:   "explain [file]",
@@ -39,7 +49,12 @@ func newExplainCmd(state *rootState) *cobra.Command {
 		Long: `Connect to a CockroachDB cluster and run EXPLAIN against the supplied
 DML statement. The wrapped statement is not executed. Input is read from
 the -e flag (inline SQL), a positional file argument, or stdin. The
-connection string is read from --dsn or CRDB_DSN (flag wins).`,
+connection string is read from --dsn or CRDB_DSN (flag wins).
+
+The --mode flag selects the safety policy applied before the cluster
+call. Default is "read_only", which permits SELECT, SHOW, and other
+non-mutating statements. "safe_write" and "full_access" are reserved
+for follow-up issues and currently reject every statement.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -58,7 +73,26 @@ connection string is read from --dsn or CRDB_DSN (flag wins).`,
 					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
 			}
 
-			mgr := conn.NewManager(state.dsn)
+			parsedMode, err := safety.ParseMode(mode)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			// Safety check runs before any cluster contact: a
+			// rejection produces a structured envelope with
+			// connection_status=disconnected, exactly as if --dsn
+			// were missing.
+			violation, err := safety.Check(parsedMode, safety.OpExplain, sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+			}
+			if violation != nil {
+				return r.RenderErrorEntry(baseEnv,
+					fmt.Errorf("safety violation: %s", violation.Reason),
+					safety.Envelope(violation))
+			}
+
+			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
 			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
 
 			result, err := mgr.Explain(cmd.Context(), sql)
@@ -86,6 +120,10 @@ connection string is read from --dsn or CRDB_DSN (flag wins).`,
 	}
 
 	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to explain")
+	cmd.Flags().StringVar(&mode, "mode", string(safety.DefaultMode),
+		"safety mode: read_only (default), safe_write, full_access")
+	cmd.Flags().DurationVar(&timeout, "timeout", conn.DefaultStatementTimeout,
+		"statement timeout for the wrapped EXPLAIN call")
 
 	return cmd
 }

--- a/cmd/explain_ddl.go
+++ b/cmd/explain_ddl.go
@@ -10,12 +10,14 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 )
 
@@ -31,11 +33,17 @@ import (
 //
 // Like explain, this is a Tier 3 (connected) command. EXPLAIN (DDL,
 // SHAPE) does not execute the wrapped DDL — it only asks the
-// declarative schema changer to compile a plan — but the read-only
-// allowlist (issue #21) will still wrap this path so non-DDL statements
-// are rejected before reaching the cluster.
+// declarative schema changer to compile a plan — and the safety
+// allowlist still gates the call: in the default read_only mode every
+// DDL is rejected (since DDL modifies schema), so users must escalate
+// to --mode=safe_write or --mode=full_access (issues #28/#29) to
+// exercise this command.
 func newExplainDDLCmd(state *rootState) *cobra.Command {
-	var expr string
+	var (
+		expr    string
+		mode    string
+		timeout time.Duration
+	)
 
 	cmd := &cobra.Command{
 		Use:   "explain-ddl [file]",
@@ -44,7 +52,13 @@ func newExplainDDLCmd(state *rootState) *cobra.Command {
 against the supplied DDL statement. The wrapped statement is not executed
 — the declarative schema changer only compiles a plan. Input is read
 from the -e flag (inline SQL), a positional file argument, or stdin. The
-connection string is read from --dsn or CRDB_DSN (flag wins).`,
+connection string is read from --dsn or CRDB_DSN (flag wins).
+
+The --mode flag selects the safety policy applied before the cluster
+call. The default "read_only" rejects every DDL (since DDL modifies
+schema), so this command requires --mode=safe_write or
+--mode=full_access — both reserved for follow-up issues #28 and #29
+and currently rejected with a "not yet implemented" violation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -63,7 +77,22 @@ connection string is read from --dsn or CRDB_DSN (flag wins).`,
 					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
 			}
 
-			mgr := conn.NewManager(state.dsn)
+			parsedMode, err := safety.ParseMode(mode)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			violation, err := safety.Check(parsedMode, safety.OpExplainDDL, sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+			}
+			if violation != nil {
+				return r.RenderErrorEntry(baseEnv,
+					fmt.Errorf("safety violation: %s", violation.Reason),
+					safety.Envelope(violation))
+			}
+
+			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
 			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
 
 			result, err := mgr.ExplainDDL(cmd.Context(), sql)
@@ -87,6 +116,10 @@ connection string is read from --dsn or CRDB_DSN (flag wins).`,
 	}
 
 	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline DDL to explain")
+	cmd.Flags().StringVar(&mode, "mode", string(safety.DefaultMode),
+		"safety mode: read_only (default), safe_write, full_access")
+	cmd.Flags().DurationVar(&timeout, "timeout", conn.DefaultStatementTimeout,
+		"statement timeout for the wrapped EXPLAIN (DDL, SHAPE) call")
 
 	return cmd
 }

--- a/cmd/explain_ddl_test.go
+++ b/cmd/explain_ddl_test.go
@@ -77,12 +77,14 @@ func TestExplainDDLCmdNoInput(t *testing.T) {
 	require.Contains(t, env.Errors[0].Message, "no SQL input")
 }
 
-// TestExplainDDLCmdReachesConnectAttempt verifies that with a SQL input
-// and an unreachable DSN, explain-ddl gets past input parsing and DSN
-// validation and fails at the connect step. The same "connect to
-// CockroachDB" wording as ping/explain locks in that the conn.Manager
-// path is shared.
-func TestExplainDDLCmdReachesConnectAttempt(t *testing.T) {
+// TestExplainDDLCmdReachesSafetyCheck verifies that with a SQL input
+// and a valid DSN, explain-ddl gets past input parsing and DSN
+// validation and the safety allowlist intercepts the DDL before any
+// cluster contact. The default --mode=read_only rejects every DDL
+// (since DDL modifies schema), so a safety_violation envelope is the
+// expected stop point. The cluster is never reached, so no connect
+// error is produced.
+func TestExplainDDLCmdReachesSafetyCheck(t *testing.T) {
 	t.Setenv("CRDB_DSN", "")
 
 	stdout, err := runExplainDDL(t, "", "--output", "json",
@@ -92,14 +94,18 @@ func TestExplainDDLCmdReachesConnectAttempt(t *testing.T) {
 
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+		"safety rejection must short-circuit before any cluster contact")
 	require.Len(t, env.Errors, 1)
-	require.NotContains(t, env.Errors[0].Message, "no connection string")
-	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+	require.Equal(t, "ALTER TABLE", env.Errors[0].Context["tag"])
+	require.Equal(t, "read_only", env.Errors[0].Context["mode"])
 }
 
 // TestExplainDDLCmdReadsFromFileArg verifies that a positional file
-// argument is plumbed through sqlinput.ReadSQL and reaches the connect
-// step (rather than failing at input resolution).
+// argument is plumbed through sqlinput.ReadSQL and reaches the safety
+// check (rather than failing at input resolution). A safety_violation
+// for the file's ALTER TABLE proves the file was read and parsed.
 func TestExplainDDLCmdReadsFromFileArg(t *testing.T) {
 	t.Setenv("CRDB_DSN", "")
 
@@ -115,12 +121,13 @@ func TestExplainDDLCmdReadsFromFileArg(t *testing.T) {
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Len(t, env.Errors, 1)
-	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
-		"file arg must reach the connect step, not fail at input parsing")
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code,
+		"file arg must reach the safety check, not fail at input parsing")
+	require.Equal(t, "ALTER TABLE", env.Errors[0].Context["tag"])
 }
 
 // TestExplainDDLCmdReadsFromStdin verifies that piped SQL on stdin
-// reaches the connect step.
+// reaches the safety check. Same pattern as the file-arg test above.
 func TestExplainDDLCmdReadsFromStdin(t *testing.T) {
 	t.Setenv("CRDB_DSN", "")
 
@@ -131,8 +138,47 @@ func TestExplainDDLCmdReadsFromStdin(t *testing.T) {
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Len(t, env.Errors, 1)
-	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
-		"stdin input must reach the connect step, not fail at input parsing")
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code,
+		"stdin input must reach the safety check, not fail at input parsing")
+	require.Equal(t, "ALTER TABLE", env.Errors[0].Context["tag"])
+}
+
+// TestExplainDDLCmdSafetyRejectsNonDDL verifies that under read_only,
+// explain-ddl rejects a non-DDL inner statement with the
+// "explain_ddl requires a DDL statement" reason — distinct from the
+// "modifies schema" rejection that fires for DDL inputs. The two reject
+// reasons differ; this test pins the SELECT case so the distinction
+// cannot regress to a single generic error.
+func TestExplainDDLCmdSafetyRejectsNonDDL(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+	stdout, err := runExplainDDL(t, "", "--output", "json",
+		"--dsn", "postgres://nope:1/db?connect_timeout=1",
+		"-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+	require.Equal(t, "SELECT", env.Errors[0].Context["tag"])
+	require.Contains(t, env.Errors[0].Context["reason"], "requires a DDL statement")
+}
+
+// TestExplainDDLCmdInvalidMode mirrors TestExplainCmdInvalidMode for
+// the explain-ddl surface so the --mode validation error is consistent.
+func TestExplainDDLCmdInvalidMode(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runExplainDDL(t, "", "--output", "json",
+		"--mode", "yolo",
+		"-e", "ALTER TABLE t ADD COLUMN x INT")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "invalid safety mode")
 }
 
 // TestExplainDDLCmdRejectsExtraArgs verifies that more than one

--- a/cmd/explain_test.go
+++ b/cmd/explain_test.go
@@ -141,6 +141,63 @@ func TestExplainCmdReadsFromStdin(t *testing.T) {
 		"stdin input must reach the connect step, not fail at input parsing")
 }
 
+// TestExplainCmdSafetyRejection verifies that the read-only safety
+// allowlist rejects mutating inner statements before any cluster
+// contact. The DSN points at an unreachable host on purpose: if the
+// safety check ever stops short-circuiting, this test will fail with
+// a connect error instead of the safety_violation it expects.
+func TestExplainCmdSafetyRejection(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		expectedTag string
+	}{
+		{name: "drop table", sql: "DROP TABLE users", expectedTag: "DROP TABLE"},
+		{name: "delete", sql: "DELETE FROM t WHERE id = 1", expectedTag: "DELETE"},
+		{name: "insert", sql: "INSERT INTO t VALUES (1)", expectedTag: "INSERT"},
+		{name: "update", sql: "UPDATE t SET x = 1 WHERE id = 1", expectedTag: "UPDATE"},
+		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)", expectedTag: "CREATE TABLE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRDB_DSN", "")
+			stdout, err := runExplain(t, "", "--output", "json",
+				"--dsn", "postgres://nope:1/db?connect_timeout=1",
+				"-e", tc.sql)
+			require.ErrorIs(t, err, output.ErrRendered)
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+				"safety rejection must short-circuit before any cluster contact")
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, "read_only", env.Errors[0].Context["mode"])
+			require.Equal(t, "explain", env.Errors[0].Context["operation"])
+		})
+	}
+}
+
+// TestExplainCmdInvalidMode verifies that --mode rejects unknown
+// values with an actionable error that lists the valid choices,
+// before any input reading or cluster contact.
+func TestExplainCmdInvalidMode(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runExplain(t, "", "--output", "json",
+		"--mode", "yolo",
+		"-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "invalid safety mode")
+	require.Contains(t, env.Errors[0].Message, "read_only")
+}
+
 // TestExplainCmdRejectsExtraArgs verifies that more than one positional
 // argument is rejected (the optional positional is the SQL file).
 func TestExplainCmdRejectsExtraArgs(t *testing.T) {

--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -20,9 +20,17 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
+
+// DefaultStatementTimeout is the per-EXPLAIN statement_timeout applied
+// inside the read-only transaction wrapper when the caller does not
+// override it via WithStatementTimeout. 30s is generous enough for
+// EXPLAIN and EXPLAIN (DDL, SHAPE) on large schemas while still
+// preventing a runaway plan from hanging an agent indefinitely.
+const DefaultStatementTimeout = 30 * time.Second
 
 // dsnCredentialPattern matches the userinfo portion of a postgres URI
 // (e.g. "user:password@") so it can be redacted from error messages.
@@ -60,16 +68,53 @@ type ExplainResult struct {
 // The dsn field is unexported and the type intentionally has no
 // Stringer or GoStringer implementation, so accidental logging via
 // %v or %+v cannot leak credentials.
+//
+// The stmtTimeout field is the SET LOCAL statement_timeout applied
+// inside the read-only transaction that wraps every Explain /
+// ExplainDDL call. It is set once at construction (default
+// DefaultStatementTimeout) via WithStatementTimeout; the Manager is
+// not safe for concurrent use, so the field never needs synchronisation.
 type Manager struct {
-	dsn  string
-	conn *pgx.Conn // nil until the first successful connect
+	dsn         string
+	stmtTimeout time.Duration
+	conn        *pgx.Conn // nil until the first successful connect
+}
+
+// Option configures a Manager at construction time. Implemented via
+// the functional-options pattern so future knobs (e.g. application_name,
+// retry budget) extend the API without breaking call sites.
+type Option func(*Manager)
+
+// WithStatementTimeout overrides the per-EXPLAIN statement_timeout
+// applied inside the read-only transaction wrapper. A non-positive
+// value falls back to DefaultStatementTimeout so callers cannot
+// accidentally disable the guardrail by passing a zero duration.
+func WithStatementTimeout(d time.Duration) Option {
+	return func(m *Manager) {
+		if d <= 0 {
+			m.stmtTimeout = DefaultStatementTimeout
+			return
+		}
+		m.stmtTimeout = d
+	}
 }
 
 // NewManager creates a Manager that will connect to the cluster
 // identified by dsn on first use. It does not validate or parse the
 // DSN — invalid values surface as connection errors on first use.
-func NewManager(dsn string) *Manager {
-	return &Manager{dsn: dsn}
+//
+// Options are applied in order; later options override earlier ones.
+// Callers that pass no options get DefaultStatementTimeout for the
+// EXPLAIN-wrapper guardrail.
+func NewManager(dsn string, opts ...Option) *Manager {
+	m := &Manager{
+		dsn:         dsn,
+		stmtTimeout: DefaultStatementTimeout,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // Ping connects to the cluster (if not already connected) and returns
@@ -101,16 +146,21 @@ func (m *Manager) Ping(ctx context.Context) (ClusterInfo, error) {
 // Explain runs `EXPLAIN <sql>` against the cluster and returns the
 // parsed plan tree alongside the raw tabular output.
 //
-// EXPLAIN (without ANALYZE) does not execute the wrapped statement, so
-// no read-only safety wrapper is applied here; the dedicated allowlist
-// (issue #21) layers on top. Cluster errors (syntax in the wrapped
-// statement, perm denied, etc.) are returned wrapped; callers surface
-// them as generic envelope errors today. SQLSTATE-aware enrichment for
-// pgwire errors is a future enhancement, not a current contract.
+// EXPLAIN (without ANALYZE) does not execute the wrapped statement,
+// but as defense-in-depth the call still runs inside a BEGIN READ ONLY
+// transaction with SET LOCAL statement_timeout = m.stmtTimeout. The
+// txn guarantees that any future shape change (e.g. an EXPLAIN flavor
+// that does write) cannot escape the read-only sandbox at this layer.
+// The companion AST allowlist in internal/safety is the first line of
+// defense and runs before this method is reached. Cluster errors
+// (syntax in the wrapped statement, perm denied, etc.) are returned
+// wrapped; callers surface them as generic envelope errors today.
+// SQLSTATE-aware enrichment for pgwire errors is a future enhancement,
+// not a current contract.
 //
-// On any query/scan/parse failure after a successful connect, the
-// underlying connection is closed and the Manager reverts to its
-// pre-connect state, mirroring Ping's recovery contract.
+// On any begin/exec/query/scan/parse failure after a successful
+// connect, the underlying connection is closed and the Manager reverts
+// to its pre-connect state, mirroring Ping's recovery contract.
 func (m *Manager) Explain(ctx context.Context, sql string) (ExplainResult, error) {
 	if err := m.connect(ctx); err != nil {
 		return ExplainResult{}, err
@@ -125,13 +175,36 @@ func (m *Manager) Explain(ctx context.Context, sql string) (ExplainResult, error
 	return result, nil
 }
 
-// runExplain is the inner half of Explain that owns the query/scan/parse
-// pipeline. Splitting it out lets Explain centralize the connection
-// recovery: any error returned here triggers the same close-and-nil
-// sequence in the caller, so the three failure modes (Query, Scan,
-// rows.Err, parse) cannot drift apart.
+// runExplain is the inner half of Explain that owns the
+// txn/query/scan/parse pipeline. Splitting it out lets Explain
+// centralize the connection recovery: any error returned here triggers
+// the same close-and-nil sequence in the caller, so the failure modes
+// (BeginTx, Exec timeout, Query, Scan, rows.Err, parse, Commit) cannot
+// drift apart.
+//
+// The txn is opened with pgx.ReadOnly so any DML or DDL that somehow
+// reaches this method is rejected by the cluster with SQLSTATE 25006
+// ("read-only transaction"), mirroring the AST-layer rejection from
+// internal/safety.
 func (m *Manager) runExplain(ctx context.Context, sql string) (ExplainResult, error) {
-	rows, err := m.conn.Query(ctx, "EXPLAIN "+sql)
+	tx, err := m.conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("begin read-only txn: %w", err)
+	}
+	// Rollback is best-effort and a no-op after a successful Commit;
+	// the deferred call exists so any early return below releases the
+	// txn rather than leaving it open on the connection (which the
+	// caller is about to close on error anyway, but the explicit
+	// rollback matches the documented contract for callers reading
+	// the code).
+	defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+	if _, err := tx.Exec(ctx,
+		fmt.Sprintf("SET LOCAL statement_timeout = '%dms'", m.stmtTimeout.Milliseconds())); err != nil {
+		return ExplainResult{}, fmt.Errorf("set statement_timeout: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, "EXPLAIN "+sql)
 	if err != nil {
 		return ExplainResult{}, fmt.Errorf("run EXPLAIN: %w", err)
 	}
@@ -148,6 +221,17 @@ func (m *Manager) runExplain(ctx context.Context, sql string) (ExplainResult, er
 	if err := rows.Err(); err != nil {
 		return ExplainResult{}, fmt.Errorf("read EXPLAIN rows: %w", err)
 	}
+	// Explicit Close before Commit: pgx requires releasing any open
+	// rows handle before reusing the conn for another command. The
+	// deferred rows.Close above is harmless when called twice (pgx
+	// makes Close idempotent), so the close error here is the same
+	// late-driver-error condition the deferred close would surface;
+	// either way it would be eclipsed by the Commit attempt below.
+	rows.Close() //nolint:errcheck // see comment above
+
+	if err := tx.Commit(ctx); err != nil {
+		return ExplainResult{}, fmt.Errorf("commit read-only txn: %w", err)
+	}
 
 	header, plan, err := parseExplainTree(raw)
 	if err != nil {
@@ -161,14 +245,19 @@ func (m *Manager) runExplain(ctx context.Context, sql string) (ExplainResult, er
 // cluster returned.
 //
 // EXPLAIN (DDL, SHAPE) does not execute the wrapped DDL — it only asks
-// the declarative schema changer to compile a plan — so no read-only
-// safety wrapper is applied here; the dedicated allowlist (issue #21)
-// will layer on top by intercepting the SQL before it reaches this
-// method, leaving runExplainDDL as the single chokepoint to wrap.
+// the declarative schema changer to compile a plan. The call runs
+// inside a transaction so SET LOCAL statement_timeout = m.stmtTimeout
+// applies, but the txn is NOT opened in pgx.ReadOnly mode: the cluster
+// rejects `EXPLAIN (DDL, SHAPE) <ddl>` inside a read-only txn with
+// SQLSTATE 25006 ("cannot execute <ddl-tag> in a read-only
+// transaction") because the txn-mode check fires on the inner stmt
+// type before the SHAPE-only flag is consulted. The AST-layer
+// allowlist in internal/safety is the first line of defense for
+// rejecting unwanted DDL; statement_timeout is the second.
 //
-// On any query/scan/parse failure after a successful connect, the
-// underlying connection is closed and the Manager reverts to its
-// pre-connect state, mirroring Explain's recovery contract.
+// On any begin/exec/query/scan/parse failure after a successful
+// connect, the underlying connection is closed and the Manager reverts
+// to its pre-connect state, mirroring Explain's recovery contract.
 func (m *Manager) ExplainDDL(ctx context.Context, sql string) (DDLExplainResult, error) {
 	if err := m.connect(ctx); err != nil {
 		return DDLExplainResult{}, err
@@ -184,16 +273,41 @@ func (m *Manager) ExplainDDL(ctx context.Context, sql string) (DDLExplainResult,
 }
 
 // runExplainDDL is the inner half of ExplainDDL that owns the
-// query/scan/parse pipeline. SHAPE output is contractually a single row
-// whose `info` column is the entire multi-line plan; we iterate with
-// Query (rather than QueryRow) so we can fail loudly on a future CRDB
-// version that splits the output across rows, matching the parser's
-// "be strict so format changes surface here" discipline. Splitting this
-// out lets ExplainDDL centralize the connection-recovery sequence so
-// the failure modes (Query, Scan, rows.Err, multi-row, parse) cannot
-// drift apart.
+// txn/query/scan/parse pipeline. SHAPE output is contractually a single
+// row whose `info` column is the entire multi-line plan; we iterate
+// with Query (rather than QueryRow) so we can fail loudly on a future
+// CRDB version that splits the output across rows, matching the
+// parser's "be strict so format changes surface here" discipline.
+// Splitting this out lets ExplainDDL centralize the connection-recovery
+// sequence so the failure modes (BeginTx, Exec timeout, Query, Scan,
+// rows.Err, multi-row, parse, Commit) cannot drift apart.
+//
+// Unlike runExplain, the txn is opened in default (read-write) mode:
+// the cluster's read-only-txn check fires on the inner DDL stmt before
+// the SHAPE-only flag is consulted, so wrapping in pgx.ReadOnly would
+// reject every well-formed call with SQLSTATE 25006. The AST-layer
+// allowlist in internal/safety is the load-bearing safety check for
+// this surface; the txn here exists solely so SET LOCAL
+// statement_timeout scopes to this call.
 func (m *Manager) runExplainDDL(ctx context.Context, sql string) (DDLExplainResult, error) {
-	rows, err := m.conn.Query(ctx, "EXPLAIN (DDL, SHAPE) "+sql)
+	tx, err := m.conn.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return DDLExplainResult{}, fmt.Errorf("begin txn: %w", err)
+	}
+	// Rollback is best-effort and a no-op after Commit. Although this
+	// txn is read-write, swallowing the rollback error is safe because
+	// the only Exec between BEGIN and Commit is `SET LOCAL` (no data
+	// writes), and EXPLAIN (DDL, SHAPE) is documented to compile a
+	// plan without executing the wrapped DDL. If a future CRDB version
+	// changes either invariant, this nolint deserves revisiting.
+	defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+	if _, err := tx.Exec(ctx,
+		fmt.Sprintf("SET LOCAL statement_timeout = '%dms'", m.stmtTimeout.Milliseconds())); err != nil {
+		return DDLExplainResult{}, fmt.Errorf("set statement_timeout: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, "EXPLAIN (DDL, SHAPE) "+sql)
 	if err != nil {
 		return DDLExplainResult{}, fmt.Errorf("run EXPLAIN (DDL, SHAPE): %w", err)
 	}
@@ -213,6 +327,14 @@ func (m *Manager) runExplainDDL(ctx context.Context, sql string) (DDLExplainResu
 	if len(raw) != 1 {
 		return DDLExplainResult{}, fmt.Errorf(
 			"EXPLAIN (DDL, SHAPE) returned %d rows, expected exactly 1 (CRDB output format may have changed)", len(raw))
+	}
+	// Explicit Close before Commit: see the matching comment in
+	// runExplain. pgx requires releasing the rows handle before
+	// reusing the conn, and the deferred Close above is idempotent.
+	rows.Close() //nolint:errcheck // see comment above
+
+	if err := tx.Commit(ctx); err != nil {
+		return DDLExplainResult{}, fmt.Errorf("commit txn: %w", err)
 	}
 
 	text := raw[0]

--- a/internal/conn/manager_integration_test.go
+++ b/internal/conn/manager_integration_test.go
@@ -199,6 +199,95 @@ func TestIntegrationManagerExplainDDLRecoversAfterError(t *testing.T) {
 		"recovered call should return a real plan, not zero value")
 }
 
+// TestIntegrationManagerExplainEnforcesStatementTimeout pins the
+// defense-in-depth contract added in issue #21: every Explain call
+// runs inside a SET LOCAL statement_timeout, so a slow EXPLAIN cannot
+// hang an agent indefinitely. We pass an aggressive 1ms timeout via
+// WithStatementTimeout and explain a query that pg_sleeps for far
+// longer; the cluster must reject with SQLSTATE 57014
+// ("query_canceled") before the explain returns. A regression that
+// drops the SET LOCAL would let the EXPLAIN succeed and fail this
+// test loudly.
+//
+// We use EXPLAIN ANALYZE rather than plain EXPLAIN because plain
+// EXPLAIN does not execute the wrapped statement (so pg_sleep would
+// not actually run). ANALYZE forces execution, exercising the timeout.
+func TestIntegrationManagerExplainEnforcesStatementTimeout(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN, conn.WithStatementTimeout(1*time.Millisecond))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := mgr.Explain(ctx, "ANALYZE SELECT pg_sleep(5)")
+	require.Error(t, err, "EXPLAIN ANALYZE pg_sleep(5) under a 1ms timeout must fail")
+	// SQLSTATE 57014 is the pg-standard "query_canceled" code that
+	// statement_timeout produces. Asserting on it rather than on a
+	// fragile message substring locks in the wire-protocol contract.
+	require.Contains(t, err.Error(), "57014",
+		"timeout error must carry SQLSTATE 57014 (query_canceled)")
+}
+
+// TestIntegrationManagerExplainRunsInReadOnlyTxn pins the second half
+// of the issue #21 wrapper: every Explain call runs inside a BEGIN
+// READ ONLY transaction. We invoke the Manager directly with an
+// EXPLAIN ANALYZE of an INSERT — ANALYZE forces execution of the
+// wrapped statement, and the read-only txn rejects the INSERT with
+// SQLSTATE 25006 ("cannot execute INSERT in a read-only transaction").
+// A regression that drops the pgx.ReadOnly access mode from
+// runExplain would let the INSERT succeed (or fail for a different
+// reason), and this test would fail loudly.
+//
+// Note: this bypasses internal/safety on purpose — the safety
+// allowlist would reject EXPLAIN ANALYZE INSERT before the cluster
+// is reached. We exercise Manager.Explain directly to test the
+// Manager-side wrapper independently of the AST allowlist.
+func TestIntegrationManagerExplainRunsInReadOnlyTxn(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE IF NOT EXISTS read_only_explain_probe (id INT PRIMARY KEY)")
+
+	_, err := mgr.Explain(ctx, "ANALYZE INSERT INTO read_only_explain_probe VALUES (1)")
+	require.Error(t, err, "EXPLAIN ANALYZE INSERT must be rejected by the read-only txn wrapper")
+	require.Contains(t, err.Error(), "25006",
+		"rejection must carry SQLSTATE 25006 (read_only_sql_transaction)")
+}
+
+// TestIntegrationManagerExplainDDLEnforcesStatementTimeout mirrors
+// TestIntegrationManagerExplainEnforcesStatementTimeout for the DDL
+// path. runExplainDDL has a duplicated SET LOCAL statement_timeout
+// block (see comment in runExplain about why the txn shape differs),
+// so a regression that drops it from one path but not the other would
+// pass the SELECT timeout test while breaking DDL planning.
+//
+// We use a fast-but-non-trivial DDL plan and a 1ms timeout: even
+// EXPLAIN (DDL, SHAPE) compilation takes longer than 1ms when it
+// exercises the schema changer.
+func TestIntegrationManagerExplainDDLEnforcesStatementTimeout(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN, conn.WithStatementTimeout(1*time.Millisecond))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE IF NOT EXISTS explain_ddl_timeout_probe (id INT PRIMARY KEY)")
+
+	_, err := mgr.ExplainDDL(ctx,
+		"ALTER TABLE explain_ddl_timeout_probe ADD COLUMN y INT")
+	require.Error(t, err, "ExplainDDL under a 1ms timeout must fail")
+	require.Contains(t, err.Error(), "57014",
+		"timeout error must carry SQLSTATE 57014 (query_canceled)")
+}
+
 // mustExec opens a one-off pgx connection and runs sql, failing the
 // test on any error. Used to perform DDL setup outside the Manager:
 // Manager intentionally exposes no general Exec, so tests that need a

--- a/internal/conn/manager_test.go
+++ b/internal/conn/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +20,51 @@ import (
 func TestNewManagerDoesNotConnect(t *testing.T) {
 	mgr := NewManager("postgres://localhost:26257/defaultdb")
 	require.Nil(t, mgr.conn, "NewManager must not connect eagerly")
+}
+
+// TestWithStatementTimeoutFallback pins the load-bearing safety
+// behaviour of WithStatementTimeout: a non-positive duration must
+// fall back to DefaultStatementTimeout, never propagate as
+// `SET LOCAL statement_timeout = '0ms'` (which CRDB interprets as
+// "no timeout" and would silently disable the guardrail). A regression
+// that flips the comparison from `<= 0` to `< 0` would let
+// WithStatementTimeout(0) leak through and is exactly the bug this
+// test exists to catch.
+func TestWithStatementTimeoutFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		input time.Duration
+	}{
+		{name: "zero falls back to default", input: 0},
+		{name: "negative falls back to default", input: -1},
+		{name: "large negative falls back to default", input: -1 * time.Hour},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewManager("postgres://localhost:26257/defaultdb",
+				WithStatementTimeout(tc.input))
+			require.Equal(t, DefaultStatementTimeout, mgr.stmtTimeout,
+				"non-positive duration must fall back to DefaultStatementTimeout")
+		})
+	}
+}
+
+// TestWithStatementTimeoutHonorsPositive verifies the happy path:
+// positive durations are stored verbatim. Pairs with the fallback
+// test so the boundary at zero is unambiguously exercised on both
+// sides.
+func TestWithStatementTimeoutHonorsPositive(t *testing.T) {
+	mgr := NewManager("postgres://localhost:26257/defaultdb",
+		WithStatementTimeout(5*time.Second))
+	require.Equal(t, 5*time.Second, mgr.stmtTimeout)
+}
+
+// TestNewManagerDefaultStatementTimeout pins the no-options default
+// so a future refactor that drops the field initialisation in
+// NewManager cannot silently regress to a zero timeout.
+func TestNewManagerDefaultStatementTimeout(t *testing.T) {
+	mgr := NewManager("postgres://localhost:26257/defaultdb")
+	require.Equal(t, DefaultStatementTimeout, mgr.stmtTimeout)
 }
 
 // TestCloseWhenNotConnected verifies that Close is a safe no-op when

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
 )
 
 // ExplainSQLTool returns the MCP tool definition for explain_sql. The
@@ -29,6 +30,8 @@ func ExplainSQLTool() mcp.Tool {
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL DML statement to explain")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
+		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
 	)
 }
 
@@ -58,10 +61,33 @@ func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		mode, toolErr := resolveSafetyMode(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		timeout, toolErr := resolveStatementTimeout(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
 		env := connectedEnvelope(parserVersion, target)
 
-		mgr := conn.NewManager(dsn)
+		// Safety check runs before any cluster contact: a rejection
+		// surfaces in env.Errors with connection_status=disconnected,
+		// matching the CLI's behaviour. Parse errors propagate via
+		// diag.FromParseError so the agent gets the SQLSTATE-tagged
+		// syntax diagnostic, not a misleading safety violation.
+		violation, err := safety.Check(mode, safety.OpExplain, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+		if violation != nil {
+			env.Errors = []output.Error{safety.Envelope(violation)}
+			return envelopeResult(env)
+		}
+
+		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.Explain(ctx, sql)

--- a/internal/mcp/tools/explain_schema_change.go
+++ b/internal/mcp/tools/explain_schema_change.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
 )
 
 // ExplainSchemaChangeTool returns the MCP tool definition for
@@ -35,6 +36,8 @@ func ExplainSchemaChangeTool() mcp.Tool {
 		mcp.WithString("sql", mcp.Required(), mcp.Description("DDL statement to plan (e.g. ALTER TABLE ... ADD COLUMN ...)")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
+		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
 	)
 }
 
@@ -63,10 +66,28 @@ func ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion string) serv
 		if toolErr != nil {
 			return toolErr, nil
 		}
+		mode, toolErr := resolveSafetyMode(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		timeout, toolErr := resolveStatementTimeout(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
 
 		env := connectedEnvelope(parserVersion, target)
 
-		mgr := conn.NewManager(dsn)
+		violation, err := safety.Check(mode, safety.OpExplainDDL, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+		if violation != nil {
+			env.Errors = []output.Error{safety.Envelope(violation)}
+			return envelopeResult(env)
+		}
+
+		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.ExplainDDL(ctx, sql)

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -26,10 +26,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
 )
 
 // Registered MCP tool names.
@@ -56,6 +59,29 @@ const TargetVersionParamName = "target_version"
 // for the target_version parameter so every tool documents the
 // argument identically.
 const TargetVersionParamDescription = "Optional target CockroachDB version (MAJOR.MINOR or MAJOR.MINOR.PATCH, with optional leading 'v'). Overrides the server-level default for this call."
+
+// ModeParamName is the optional MCP tool parameter name that lets a
+// client override the safety mode applied before any cluster contact.
+// Mirrors the CLI's --mode flag. Tier 3 tools that accept it run the
+// safety.Check allowlist before opening a connection.
+const ModeParamName = "mode"
+
+// ModeParamDescription is the shared MCP-schema description for the
+// mode parameter so every Tier 3 tool documents the argument
+// identically.
+const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" and "full_access" are reserved for follow-up work and currently reject every statement.`
+
+// StatementTimeoutParamName is the optional MCP tool parameter name
+// that lets a client override the per-call SET LOCAL statement_timeout
+// applied inside the read-only transaction wrapper. The value is in
+// milliseconds (numeric) so the wire format matches MCP's JSON
+// type-system without parsing duration strings.
+const StatementTimeoutParamName = "statement_timeout_ms"
+
+// StatementTimeoutParamDescription is the shared MCP-schema
+// description for the statement_timeout_ms parameter so every Tier 3
+// tool documents the argument identically.
+const StatementTimeoutParamDescription = "Optional statement_timeout (milliseconds) applied inside the read-only transaction wrapper. Default 30000 (30s). Non-positive values fall back to the default."
 
 // extractRequiredString validates and returns a required string
 // parameter from an MCP tool request. Leading and trailing whitespace
@@ -196,6 +222,56 @@ func resolveTargetVersion(req mcp.CallToolRequest, defaultTargetVersion string) 
 			"%s parameter: %v", TargetVersionParamName, err))
 	}
 	return canonical, nil
+}
+
+// resolveSafetyMode picks the safety mode for a single Tier 3 tool
+// call. Missing or empty mode arguments fall back to safety.DefaultMode
+// (read_only). A non-string value is a hard error (tool-level) because
+// there is no reasonable interpretation. An unknown mode token is also
+// a tool-level error so the agent gets a precise "valid choices are…"
+// message rather than a misleading safety violation.
+//
+// On success the returned *mcp.CallToolResult is nil. On any malformed
+// argument it is a pre-built tool error.
+func resolveSafetyMode(req mcp.CallToolRequest) (safety.Mode, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[ModeParamName]
+	if !exists {
+		return safety.DefaultMode, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter must be a string, got %T", ModeParamName, raw))
+	}
+	m, err := safety.ParseMode(strings.TrimSpace(s))
+	if err != nil {
+		return "", mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter: %v", ModeParamName, err))
+	}
+	return m, nil
+}
+
+// resolveStatementTimeout picks the statement_timeout for a single
+// Tier 3 tool call. Missing or non-positive values fall back to
+// conn.DefaultStatementTimeout (the same fallback WithStatementTimeout
+// applies, repeated here so the resolved duration is observable to
+// callers and tests). MCP delivers numeric arguments as float64; an
+// integer-valued float is the canonical wire form for milliseconds.
+// A non-numeric value is a tool-level error.
+func resolveStatementTimeout(req mcp.CallToolRequest) (time.Duration, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[StatementTimeoutParamName]
+	if !exists {
+		return conn.DefaultStatementTimeout, nil
+	}
+	ms, ok := raw.(float64)
+	if !ok {
+		return 0, mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter must be a number (milliseconds), got %T", StatementTimeoutParamName, raw))
+	}
+	if ms <= 0 {
+		return conn.DefaultStatementTimeout, nil
+	}
+	return time.Duration(ms) * time.Millisecond, nil
 }
 
 // envelopeResult marshals env as JSON and wraps it in a successful MCP

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -195,16 +195,22 @@ func TestExplainSchemaChangeToolAdvertisesTargetVersionParam(t *testing.T) {
 		"explain_schema_change schema must advertise the target_version property")
 }
 
-// TestExplainSchemaChangeHandlerConnectionFailureSurfacesEnvelopeError
-// verifies that when the cluster is unreachable, the handler returns a
-// successful MCP tool result whose envelope carries the error — not a
-// tool-level error. Same discipline as explain_sql.
-func TestExplainSchemaChangeHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
+// TestExplainSchemaChangeHandlerSafetyRejectionSurfacesEnvelopeError
+// verifies that the safety allowlist rejects DDL in the default
+// read_only mode and the rejection lands as an envelope error (not a
+// tool-level error), with no cluster contact. The previous "connect
+// failure" assertion was retired when issue #21 added the safety
+// gate: a DDL inner statement now stops at the AST classifier before
+// any pgwire round-trip.
+func TestExplainSchemaChangeHandlerSafetyRejectionSurfacesEnvelopeError(t *testing.T) {
 	handler := ExplainSchemaChangeHandler(testParserVersion, "" /* defaultTargetVersion */)
 	req := mcpgo.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"sql": "ALTER TABLE t ADD COLUMN x INT",
-		// Unreachable host — connection will fail before any query.
+		// DSN points at an unreachable host on purpose: if the safety
+		// check ever stops short-circuiting, this test will fail with
+		// a connect error instead of the safety_violation we expect,
+		// surfacing the regression loudly.
 		"dsn": "postgres://nope:1/db?connect_timeout=1",
 	}
 
@@ -213,9 +219,71 @@ func TestExplainSchemaChangeHandlerConnectionFailureSurfacesEnvelopeError(t *tes
 	env := requireEnvelope(t, res)
 	require.Equal(t, output.TierConnected, env.Tier)
 	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
-		"failed connect must leave status disconnected")
+		"safety rejection must short-circuit before any cluster contact")
 	require.Len(t, env.Errors, 1)
-	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+	require.Equal(t, "ALTER TABLE", env.Errors[0].Context["tag"])
+	require.Equal(t, "read_only", env.Errors[0].Context["mode"])
+}
+
+// TestExplainSQLHandlerSafetyRejection verifies that the read_only
+// allowlist intercepts mutating inner statements before any cluster
+// contact, in the MCP surface. Mirror of the CLI safety-rejection
+// test in cmd/explain_test.go.
+func TestExplainSQLHandlerSafetyRejection(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql": "DROP TABLE users",
+		// Unreachable on purpose: a regression that lets the safety
+		// check fall through would surface here as a connect error
+		// instead of the safety_violation we expect.
+		"dsn": "postgres://nope:1/db?connect_timeout=1",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+	require.Equal(t, "DROP TABLE", env.Errors[0].Context["tag"])
+	require.Equal(t, "explain", env.Errors[0].Context["operation"])
+}
+
+// TestExplainSQLHandlerRejectsInvalidMode covers the tool-level error
+// path for a malformed mode argument: an unknown token must produce a
+// clear "valid choices are…" error rather than a misleading envelope
+// entry.
+func TestExplainSQLHandlerRejectsInvalidMode(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":  "SELECT 1",
+		"dsn":  "postgres://nope:1/db",
+		"mode": "yolo",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "invalid mode must produce a tool-level error, not an envelope")
+}
+
+// TestExplainSQLHandlerRejectsNonNumericTimeout covers the tool-level
+// error path for a malformed statement_timeout_ms argument: a string
+// (instead of a number) must produce a clear type error.
+func TestExplainSQLHandlerRejectsNonNumericTimeout(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":                  "SELECT 1",
+		"dsn":                  "postgres://nope:1/db",
+		"statement_timeout_ms": "not-a-number",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "non-numeric timeout must produce a tool-level error")
 }
 
 func TestExtractSQL(t *testing.T) {

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -111,6 +111,15 @@ const (
 	// agents can branch programmatically without parsing the
 	// human-readable Message.
 	CodeFeatureNotYetIntroduced = "feature_not_yet_introduced"
+
+	// CodeSafetyViolation is emitted by the Tier 3 safety allowlist
+	// (internal/safety) when a statement is rejected before any
+	// cluster round-trip. The accompanying Error.Context carries the
+	// tag (e.g. "DROP TABLE"), mode (e.g. "read_only"), operation
+	// (e.g. "explain"), and reason keys so agents can branch
+	// programmatically — for example, prompt the user to escalate the
+	// safety mode — without parsing the human-readable Message.
+	CodeSafetyViolation = "safety_violation"
 )
 
 // Severity is the severity level of a structured Error. Values use the

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -1,0 +1,246 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// Operation identifies the cluster-bound surface that is about to run
+// the user's SQL. The allowlist applies a different rule per
+// (Mode, Operation) pair — for example, OpExplainDDL must accept DDL
+// (otherwise the underlying EXPLAIN (DDL, SHAPE) would always error),
+// while OpExplain must reject it (because the inner statement of plain
+// EXPLAIN is what defines the read/write character of the call).
+type Operation int
+
+// Operation values. New surfaces (e.g. an eventual OpExecute for
+// issue #29) extend this enum; the existing rules stay untouched.
+const (
+	OpExplain Operation = iota + 1
+	OpExplainDDL
+)
+
+// String returns the wire-stable token for op. Used in violation
+// payloads so agents can branch on operation programmatically.
+func (op Operation) String() string {
+	switch op {
+	case OpExplain:
+		return "explain"
+	case OpExplainDDL:
+		return "explain_ddl"
+	default:
+		return "unknown"
+	}
+}
+
+// Violation is the structured payload returned by Check when a
+// statement is rejected. It carries everything an agent (or the
+// envelope helper) needs to render an actionable error without
+// reparsing the input.
+//
+// Lifecycle: built once by Check, consumed once by Envelope (for the
+// CLI/MCP path) or by tests. No long-lived state.
+type Violation struct {
+	// Tag is the cockroachdb-parser StatementTag for the offending
+	// statement (e.g. "DROP TABLE", "INSERT", "SELECT"). Stable across
+	// CRDB versions for any given statement type.
+	Tag string
+
+	// Reason is a short human-readable explanation of why the
+	// statement was rejected (e.g. "writes data", "modifies schema",
+	// "expected DDL"). Embedded into the rendered Message; agents
+	// should branch on Mode/Operation/Tag rather than Reason.
+	Reason string
+
+	// Mode is the safety mode that was in effect when the violation
+	// was raised. Lets agents recognise that escalating to a higher
+	// mode would unblock the call.
+	Mode Mode
+
+	// Op is the cluster-bound surface that triggered the check. Lets
+	// agents distinguish "explain rejected DROP TABLE" from
+	// "explain-ddl rejected SELECT", which point at different fixes.
+	Op Operation
+}
+
+// Check parses sql and decides whether every statement in it is
+// permitted under (mode, op). It is the single decision point for the
+// allowlist: every Tier 3 surface (CLI, MCP) calls Check before opening
+// a connection.
+//
+// The check is pure — no I/O, no cluster access — so it is cheap to
+// run on every request and easy to unit-test. The same parser used
+// elsewhere in crdb-sql (parser.Parse) is used here, so the
+// classification cannot drift from what downstream consumers see.
+//
+// Return contract (the first three cases are mutually exclusive — Check
+// never returns both a non-nil *Violation and a non-nil error):
+//
+//   - (nil, nil) — sql parses to one or more statements and every one
+//     is permitted.
+//   - (nil, err) — sql failed to parse. The caller should surface this
+//     as a parse-error diagnostic (diag.FromParseError) rather than as
+//     a safety violation: the input is malformed, not denied. The
+//     error is the raw parser error so SQLSTATE and position survive.
+//   - (*Violation, nil) — sql parses but is denied. Either the first
+//     offending statement triggers a rule (multi-statement inputs
+//     short-circuit on the first reject) or the batch is empty (a
+//     defensive case so empty input cannot bypass the gate).
+//
+// Multi-statement inputs surface the first violation. This matches the
+// "fail closed" discipline: if any statement in a batch would be
+// rejected, the batch is rejected. Agents that care which statement
+// failed can read Violation.Tag and re-issue individually.
+func Check(mode Mode, op Operation, sql string) (*Violation, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(stmts) == 0 {
+		// Defensive: parser.Parse("") returns zero stmts and no error.
+		// The CLI's sqlinput layer rejects empty input upstream, but
+		// the safety package's contract is "the single decision point"
+		// — keep the gate self-contained so a future caller that
+		// bypasses sqlinput cannot pass an empty batch through.
+		return &Violation{
+			Reason: "no statements parsed",
+			Mode:   mode,
+			Op:     op,
+		}, nil
+	}
+	for _, s := range stmts {
+		if v := classify(mode, op, s.AST); v != nil {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
+// classify applies the (mode, op) rule to a single parsed statement.
+// Returns nil when the statement is permitted; a populated *Violation
+// otherwise. Pulled out of Check so the per-statement decision tree
+// stays readable as new (mode, op) combinations are added.
+func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
+	switch mode {
+	case ModeReadOnly:
+		return classifyReadOnly(op, stmt)
+	case ModeSafeWrite, ModeFullAccess:
+		// Modes are recognised at the flag layer (so the CLI accepts
+		// --mode=safe_write today without a "bad value" error), but
+		// no statement is admitted until issues #28/#29 wire the
+		// per-mode rules. Returning a violation here keeps the
+		// rejection path uniform with read_only.
+		return &Violation{
+			Tag:    stmt.StatementTag(),
+			Reason: fmt.Sprintf("safety mode %q is not yet implemented", mode),
+			Mode:   mode,
+			Op:     op,
+		}
+	default:
+		// Defensive: ParseMode should have rejected this earlier.
+		// Treat as a violation rather than admitting unknown modes.
+		return &Violation{
+			Tag:    stmt.StatementTag(),
+			Reason: fmt.Sprintf("unknown safety mode %q", mode),
+			Mode:   mode,
+			Op:     op,
+		}
+	}
+}
+
+// classifyReadOnly is the read-only-mode rule. The decision differs by
+// Operation because the cluster-side wrapper changes what "read-only"
+// means for the inner statement:
+//
+//   - OpExplain runs `EXPLAIN <inner>`. EXPLAIN does not execute the
+//     inner statement, but agents still benefit from the inner-stmt
+//     guard: it prevents nested EXPLAIN/EXPLAIN ANALYZE wrappers from
+//     bypassing the AST allowlist (since tree.CanWriteData and
+//     tree.CanModifySchema do not descend into *Explain/*ExplainAnalyze
+//     AST nodes — an `EXPLAIN ANALYZE INSERT ...` would otherwise look
+//     read-only at the top level). For the same reason, we reject any
+//     inner statement that itself writes data or modifies schema. The
+//     final allowlist matches the design doc's read-only set
+//     (SELECT/SHOW/etc.).
+//
+//   - OpExplainDDL runs `EXPLAIN (DDL, SHAPE) <inner>`. The inner
+//     statement must be DDL by construction, so a SELECT here is a
+//     user error. But because read_only mode is meant to forbid all
+//     schema modification, we reject DDL too — leaving OpExplainDDL
+//     effectively unusable in read_only mode. Users must escalate to
+//     safe_write or full_access (issues #28/#29) to use explain-ddl.
+//     The reason text names the escalation path so the rejection is
+//     actionable.
+func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
+	tag := stmt.StatementTag()
+	switch op {
+	case OpExplain:
+		// Reject nested EXPLAIN wrappers explicitly. The inner stmt of
+		// an *Explain or *ExplainAnalyze node is not classified by
+		// tree.CanWriteData/CanModifySchema, so without this branch a
+		// caller could submit `EXPLAIN ANALYZE INSERT ...` and have it
+		// admitted as read-only at the AST layer. The cluster's
+		// BEGIN READ ONLY wrapper would still catch the write at
+		// runtime (SQLSTATE 25006), but the AST allowlist's job is to
+		// reject before any cluster contact.
+		switch stmt.(type) {
+		case *tree.Explain, *tree.ExplainAnalyze:
+			return &Violation{
+				Tag:    tag,
+				Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
+		}
+		if tree.CanWriteData(stmt) {
+			return &Violation{
+				Tag:    tag,
+				Reason: "statement writes data; read_only mode forbids it",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
+		}
+		if tree.CanModifySchema(stmt) {
+			return &Violation{
+				Tag:    tag,
+				Reason: "statement modifies schema; read_only mode forbids it",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
+		}
+		return nil
+	case OpExplainDDL:
+		if stmt.StatementType() != tree.TypeDDL {
+			return &Violation{
+				Tag:    tag,
+				Reason: "explain_ddl requires a DDL statement",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
+		}
+		// Inner stmt is DDL, so it modifies schema. read_only mode
+		// forbids all schema modification, including planning.
+		// Surface the escalation path in the reason so the rejection
+		// is actionable.
+		return &Violation{
+			Tag:    tag,
+			Reason: "explain_ddl modifies schema; rerun with --mode=safe_write or --mode=full_access",
+			Mode:   ModeReadOnly,
+			Op:     op,
+		}
+	default:
+		return &Violation{
+			Tag:    tag,
+			Reason: fmt.Sprintf("unknown operation %v", op),
+			Mode:   ModeReadOnly,
+			Op:     op,
+		}
+	}
+}

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+func TestCheckReadOnlyExplain(t *testing.T) {
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedTag    string
+	}{
+		// Read-only allowlist accepts.
+		{name: "select", sql: "SELECT * FROM t"},
+		{name: "select with where", sql: "SELECT id FROM t WHERE id = 1"},
+		{name: "show", sql: "SHOW TABLES"},
+		{name: "show create", sql: "SHOW CREATE TABLE t"},
+		{name: "values", sql: "VALUES (1), (2)"},
+		{name: "with cte", sql: "WITH cte AS (SELECT 1) SELECT * FROM cte"},
+
+		// Read-only allowlist rejects DML writes.
+		{name: "insert", sql: "INSERT INTO t VALUES (1)", expectedReject: true, expectedTag: "INSERT"},
+		{name: "update", sql: "UPDATE t SET x = 1 WHERE id = 1", expectedReject: true, expectedTag: "UPDATE"},
+		{name: "delete", sql: "DELETE FROM t WHERE id = 1", expectedReject: true, expectedTag: "DELETE"},
+		{name: "truncate", sql: "TRUNCATE TABLE t", expectedReject: true, expectedTag: "TRUNCATE"},
+
+		// Read-only allowlist rejects DDL.
+		{name: "drop table", sql: "DROP TABLE users", expectedReject: true, expectedTag: "DROP TABLE"},
+		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)", expectedReject: true, expectedTag: "CREATE TABLE"},
+		{name: "alter table", sql: "ALTER TABLE x ADD COLUMN y INT", expectedReject: true, expectedTag: "ALTER TABLE"},
+
+		// Read-only allowlist rejects DCL writes.
+		{name: "grant", sql: "GRANT SELECT ON t TO bob", expectedReject: true, expectedTag: "GRANT"},
+		{name: "revoke", sql: "REVOKE SELECT ON t FROM bob", expectedReject: true, expectedTag: "REVOKE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain, tc.sql)
+			require.NoError(t, err)
+
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v, "expected statement to be rejected")
+			require.Equal(t, tc.expectedTag, v.Tag)
+			require.Equal(t, safety.ModeReadOnly, v.Mode)
+			require.Equal(t, safety.OpExplain, v.Op)
+			require.NotEmpty(t, v.Reason)
+		})
+	}
+}
+
+func TestCheckReadOnlyExplainDDL(t *testing.T) {
+	// In read_only mode, OpExplainDDL rejects everything: DDL because
+	// it modifies schema, non-DDL because explain-ddl requires a DDL
+	// inner stmt. The two reject reasons differ — that distinction is
+	// the load-bearing assertion below.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReason string
+	}{
+		{
+			name:           "ddl rejected with escalation hint",
+			sql:            "ALTER TABLE x ADD COLUMN y INT",
+			expectedReason: "rerun with --mode=safe_write or --mode=full_access",
+		},
+		{
+			name:           "create table rejected with escalation hint",
+			sql:            "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedReason: "rerun with --mode=safe_write or --mode=full_access",
+		},
+		{
+			name:           "select rejected as non-ddl",
+			sql:            "SELECT 1",
+			expectedReason: "explain_ddl requires a DDL statement",
+		},
+		{
+			name:           "insert rejected as non-ddl",
+			sql:            "INSERT INTO t VALUES (1)",
+			expectedReason: "explain_ddl requires a DDL statement",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpExplainDDL, tc.sql)
+			require.NoError(t, err)
+			require.NotNil(t, v)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
+func TestCheckRejectsUnimplementedModes(t *testing.T) {
+	// safe_write and full_access parse successfully (per ParseMode)
+	// but Check rejects them until issues #28/#29. The rejection
+	// reason names the mode so an agent can recognise the
+	// "not implemented" condition vs a real classification miss.
+	tests := []struct {
+		name string
+		mode safety.Mode
+	}{
+		{name: "safe_write not yet implemented", mode: safety.ModeSafeWrite},
+		{name: "full_access not yet implemented", mode: safety.ModeFullAccess},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(tc.mode, safety.OpExplain, "SELECT 1")
+			require.NoError(t, err)
+			require.NotNil(t, v, "non-read_only modes are not admitted yet")
+			require.Contains(t, v.Reason, "not yet implemented")
+			require.Equal(t, tc.mode, v.Mode)
+		})
+	}
+}
+
+func TestCheckMultiStatementShortCircuits(t *testing.T) {
+	// First statement is fine, second is a write — Check must reject
+	// at the first violation and report the offending tag, not the
+	// last admitted one.
+	v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain,
+		"SELECT 1; DELETE FROM t WHERE id = 1; SELECT 2")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.Equal(t, "DELETE", v.Tag)
+}
+
+func TestCheckParseErrorPropagates(t *testing.T) {
+	// A malformed input must surface as a parse error, not a safety
+	// violation: the user gets a real syntax diagnostic and not a
+	// misleading "rejected by allowlist" message.
+	v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain, "SELEKT broken")
+	require.Error(t, err)
+	require.Nil(t, v)
+}
+
+func TestCheckRejectsEmptyInput(t *testing.T) {
+	// parser.Parse("") returns zero stmts and no error, which without
+	// an explicit empty-batch guard would be (nil, nil) — i.e.
+	// "permitted". Pin the defensive rejection so a regression that
+	// removes the guard is loud.
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "empty string", sql: ""},
+		{name: "whitespace only", sql: "   \n\t  "},
+		{name: "comment only", sql: "-- nothing here"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain, tc.sql)
+			require.NoError(t, err)
+			require.NotNil(t, v, "empty input must not bypass the gate")
+			require.Contains(t, v.Reason, "no statements parsed")
+		})
+	}
+}
+
+func TestCheckRejectsNestedExplain(t *testing.T) {
+	// tree.CanWriteData/CanModifySchema do not descend into
+	// *Explain/*ExplainAnalyze AST nodes, so a caller wrapping their
+	// write in EXPLAIN ANALYZE would otherwise sneak through the AST
+	// allowlist (the cluster's BEGIN READ ONLY catches it at runtime,
+	// but defense-in-depth says reject before any cluster contact).
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "explain analyze write", sql: "EXPLAIN ANALYZE INSERT INTO t VALUES (1)"},
+		{name: "explain analyze ddl", sql: "EXPLAIN ANALYZE ALTER TABLE t ADD COLUMN x INT"},
+		{name: "explain select", sql: "EXPLAIN SELECT 1"},
+		{name: "explain analyze select", sql: "EXPLAIN ANALYZE SELECT 1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain, tc.sql)
+			require.NoError(t, err)
+			require.NotNil(t, v, "nested EXPLAIN must be rejected at the AST layer")
+			require.Contains(t, v.Reason, "nested EXPLAIN")
+		})
+	}
+}

--- a/internal/safety/envelope.go
+++ b/internal/safety/envelope.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety
+
+import (
+	"fmt"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// Envelope converts a Violation into the structured output.Error that
+// CLI and MCP surfaces emit. Centralising the conversion guarantees
+// that the two surfaces produce byte-identical error shapes for the
+// same rejection — agents can rely on the Code, Severity, and Context
+// keys regardless of how they invoked the tool.
+//
+// Context keys: tag, mode, operation, reason. These mirror Violation's
+// fields but use the same lowercase wire tokens already used elsewhere
+// in the envelope.
+//
+// Suggestions: when the violation can be unblocked by escalating the
+// safety mode (read_only on either op), a single Suggestion entry
+// points the agent at the higher-mode escape hatch. The Range is zero
+// because the suggestion is a flag value, not a SQL edit; agents that
+// only know how to apply byte-range edits will skip it harmlessly.
+func Envelope(v *Violation) output.Error {
+	return output.Error{
+		Code:        output.CodeSafetyViolation,
+		Severity:    output.SeverityError,
+		Message:     formatMessage(v),
+		Category:    "safety",
+		Context:     contextMap(v),
+		Suggestions: suggestionsFor(v),
+	}
+}
+
+// formatMessage builds the human-readable Message embedded in the
+// envelope. Format: "<reason> (<tag>, mode=<mode>, op=<op>)" so a
+// single line carries the salient facts in CLI text mode where the
+// Context map is not rendered.
+func formatMessage(v *Violation) string {
+	return fmt.Sprintf("safety violation: %s (%s, mode=%s, op=%s)",
+		v.Reason, v.Tag, v.Mode, v.Op)
+}
+
+// contextMap returns the Context payload for the envelope error. Keys
+// are lowercase, matching the convention used by
+// CodeFeatureNotYetIntroduced (see internal/output/envelope.go).
+func contextMap(v *Violation) map[string]any {
+	return map[string]any{
+		"tag":       v.Tag,
+		"mode":      string(v.Mode),
+		"operation": v.Op.String(),
+		"reason":    v.Reason,
+	}
+}
+
+// suggestionsFor proposes the higher-mode escape hatch when the
+// violation is mode-driven. We always suggest the lowest-privilege
+// mode that would admit the call — safe_write per design doc §Safety
+// Model — rather than jumping straight to full_access, so agents
+// follow the principle of least privilege.
+func suggestionsFor(v *Violation) []output.Suggestion {
+	if v.Mode != ModeReadOnly {
+		return nil
+	}
+	switch v.Op {
+	case OpExplain, OpExplainDDL:
+		return []output.Suggestion{{
+			Replacement: string(ModeSafeWrite),
+			Reason:      "safety_mode_escalation",
+		}}
+	default:
+		return nil
+	}
+}

--- a/internal/safety/envelope_test.go
+++ b/internal/safety/envelope_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+func TestEnvelope(t *testing.T) {
+	v := &safety.Violation{
+		Tag:    "DROP TABLE",
+		Reason: "statement modifies schema; read_only mode forbids it",
+		Mode:   safety.ModeReadOnly,
+		Op:     safety.OpExplain,
+	}
+
+	e := safety.Envelope(v)
+
+	require.Equal(t, output.CodeSafetyViolation, e.Code)
+	require.Equal(t, output.SeverityError, e.Severity)
+	require.Equal(t, "safety", e.Category)
+	require.Contains(t, e.Message, "DROP TABLE")
+	require.Contains(t, e.Message, "read_only")
+	require.Contains(t, e.Message, "explain")
+
+	require.Equal(t, "DROP TABLE", e.Context["tag"])
+	require.Equal(t, "read_only", e.Context["mode"])
+	require.Equal(t, "explain", e.Context["operation"])
+	require.NotEmpty(t, e.Context["reason"])
+}
+
+func TestEnvelopeSuggestionsByOp(t *testing.T) {
+	// Both OpExplain and OpExplainDDL escalation suggestions point at
+	// safe_write — the lowest-privilege mode that admits the call per
+	// design doc §Safety Model. Jumping to full_access would violate
+	// principle of least privilege, and the test pins the symmetry so
+	// a future change can't accidentally regress only one op.
+	tests := []struct {
+		name string
+		op   safety.Operation
+	}{
+		{name: "explain", op: safety.OpExplain},
+		{name: "explain_ddl", op: safety.OpExplainDDL},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := safety.Envelope(&safety.Violation{
+				Tag:  "ANY",
+				Mode: safety.ModeReadOnly,
+				Op:   tc.op,
+			})
+			require.Len(t, e.Suggestions, 1)
+			require.Equal(t, string(safety.ModeSafeWrite), e.Suggestions[0].Replacement)
+			require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
+		})
+	}
+}
+
+func TestEnvelopeNoSuggestionForUnimplementedModes(t *testing.T) {
+	// safe_write/full_access violations are "not implemented" — the
+	// fix is to wait for issues #28/#29, not to escalate. So no
+	// suggestion is offered.
+	e := safety.Envelope(&safety.Violation{
+		Tag:  "SELECT",
+		Mode: safety.ModeSafeWrite,
+		Op:   safety.OpExplain,
+	})
+	require.Empty(t, e.Suggestions)
+}

--- a/internal/safety/mode.go
+++ b/internal/safety/mode.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package safety implements the Tier 3 statement allowlist that gates
+// every cluster-bound command in crdb-sql (today: explain,
+// explain-ddl). Defense-in-depth at the MCP/CLI layer: even if the
+// downstream cluster's role would permit a write, a SELECT-only Mode
+// rejects the statement before any pgwire round-trip.
+//
+// The package is split into three concerns:
+//
+//	mode.go      — the Mode enum (read_only, safe_write, full_access)
+//	               and ParseMode for flag/parameter validation.
+//	allowlist.go — Check, the pure AST classifier that decides whether
+//	               a statement is permitted under a given Mode and
+//	               Operation.
+//	envelope.go  — Envelope, the helper that converts a Violation into
+//	               the structured output.Error agents consume.
+//
+// allowlist.go has no dependency on internal/output, so the
+// classification logic stays unit-testable without dragging in the CLI
+// envelope. envelope.go is the single bridge between the two.
+//
+// Design doc reference: §Safety Model (read_only is the default,
+// safe_write and full_access are opt-in escalations). Issue #21 wires
+// read_only end-to-end; safe_write and full_access enforcement land in
+// follow-up issues #28 and #29.
+package safety
+
+import "fmt"
+
+// Mode names the safety policy applied to a Tier 3 command. Values are
+// the lowercase strings agents pass on the wire so the same token works
+// across the CLI --mode flag and the MCP tool parameter.
+type Mode string
+
+// Mode values. ModeReadOnly is the default for every Tier 3 command;
+// the other two are recognised by ParseMode but rejected by Check
+// until issues #28 and #29 land.
+const (
+	ModeReadOnly   Mode = "read_only"
+	ModeSafeWrite  Mode = "safe_write"
+	ModeFullAccess Mode = "full_access"
+)
+
+// DefaultMode is the safety mode applied when a caller does not set
+// one. Every Tier 3 surface (CLI flag, MCP parameter) defaults to
+// ModeReadOnly — explicit opt-in is required for any path that could
+// reach a write.
+const DefaultMode = ModeReadOnly
+
+// ParseMode validates a user-supplied mode token and returns the
+// canonical Mode. The empty string maps to DefaultMode so callers can
+// pass a flag value through unconditionally without needing to
+// special-case "unset". Any other unrecognised value produces an error
+// that names the valid choices, so the message a user sees on a typo
+// is actionable on its own.
+//
+// safe_write and full_access parse successfully even though Check
+// currently rejects them — the split keeps the flag-parsing layer
+// stable across issues #28/#29 so the only churn when those modes land
+// is inside Check.
+func ParseMode(s string) (Mode, error) {
+	switch Mode(s) {
+	case "":
+		return DefaultMode, nil
+	case ModeReadOnly:
+		return ModeReadOnly, nil
+	case ModeSafeWrite:
+		return ModeSafeWrite, nil
+	case ModeFullAccess:
+		return ModeFullAccess, nil
+	default:
+		return "", fmt.Errorf("invalid safety mode %q: valid choices are %q, %q, %q",
+			s, ModeReadOnly, ModeSafeWrite, ModeFullAccess)
+	}
+}

--- a/internal/safety/mode_test.go
+++ b/internal/safety/mode_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedMode safety.Mode
+		expectedErr  string
+	}{
+		{name: "empty defaults to read_only", input: "", expectedMode: safety.DefaultMode},
+		{name: "read_only", input: "read_only", expectedMode: safety.ModeReadOnly},
+		{name: "safe_write", input: "safe_write", expectedMode: safety.ModeSafeWrite},
+		{name: "full_access", input: "full_access", expectedMode: safety.ModeFullAccess},
+		{name: "unknown rejected", input: "yolo", expectedErr: "invalid safety mode"},
+		{name: "case-sensitive", input: "Read_Only", expectedErr: "invalid safety mode"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := safety.ParseMode(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				require.Contains(t, err.Error(), "read_only",
+					"error message should list valid choices")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedMode, m)
+		})
+	}
+}


### PR DESCRIPTION

Defense-in-depth at the MCP/CLI layer for `explain` and `explain-ddl`.
Before this change both surfaces handed user SQL straight to
`Manager.Explain` / `Manager.ExplainDDL`, which prepended `EXPLAIN ` /
`EXPLAIN (DDL, SHAPE) ` and shipped it to the cluster with no AST
classification, no transactional sandbox, and no statement timeout. An
agent could request `crdb-sql explain --dsn ... -e "DROP TABLE users"`
and the only line of defense was the cluster role.

The new `internal/safety` package owns the allowlist as a single,
pure decision point: `Check(mode, op, sql)` parses with the existing
cockroachdb-parser entry point and uses `tree.CanModifySchema` /
`tree.CanWriteData` to classify each statement under a (mode,
operation) pair. The first violation short-circuits the batch. A
`Mode` enum (read_only / safe_write / full_access) gates flag and
parameter parsing now so issues #28 and #29 can land their per-mode
rules without touching call sites; safe_write and full_access parse
successfully but Check rejects them with "not yet implemented" until
those issues land. `Envelope` converts a `Violation` into the
structured `output.Error` agents consume, with a new
`output.CodeSafetyViolation` constant and a Context map keyed by tag,
mode, operation, and reason.

`conn.Manager` grows a Functional-Options API with
`WithStatementTimeout` (default 30s, exposed as
`DefaultStatementTimeout`). `runExplain` now wraps the cluster call in
`BEGIN READ ONLY` + `SET LOCAL statement_timeout`; `runExplainDDL`
wraps in a default (read-write) txn + `SET LOCAL statement_timeout`,
because the cluster rejects `EXPLAIN (DDL, SHAPE) <ddl>` inside a
read-only txn with SQLSTATE 25006 — the txn-mode check fires on the
inner DDL stmt before the SHAPE-only flag is consulted, so the
allowlist remains the load-bearing safety check for that surface.

The CLI gains `--mode` (default read_only) and `--timeout` (default
30s) on both `explain` and `explain-ddl`. The MCP `explain_sql` and
`explain_schema_change` tools gain optional `mode` (string) and
`statement_timeout_ms` (number) parameters, with shared `tools.go`
resolver helpers that mirror the existing `target_version` pattern.
Safety check runs before `conn.NewManager` on every surface, so
rejected calls never open a cluster connection: the envelope reports
`connection_status: disconnected` and exit 1.

Three pre-existing tests in `cmd/explain_ddl_test.go` (and one in
`internal/mcp/tools/tools_test.go`) asserted "reaches connect step"
with a DDL input. With the safety gate in front, DDL inputs in the
default read_only mode now stop earlier; the assertions were
re-anchored on `CodeSafetyViolation` (the new earlier stop point),
preserving the original test intent (input plumbing reaches a
downstream step) while pinning the new contract.

Demo from the issue, working as specified:

  $ bin/crdb-sql explain --dsn ... --output json -e "DROP TABLE users"
  {"connection_status":"disconnected","errors":[{"code":"safety_violation",
   "context":{"tag":"DROP TABLE","mode":"read_only","operation":"explain",...}}]}

Out of scope (called out in the plan):
- safe_write / full_access mode rules — issues #28, #29.
- LIMIT injection on unbounded SELECTs — issue #29 (execute_sql).
- Standalone `crdb-sql exec` subcommand — issue #29.

Resolves: #21

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
