### PR TITLE
versionroute: route --target-version to per-quarter backends

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,24 @@ before:
     - go mod download
 
 builds:
+  # The unsuffixed `crdb-sql` is the latest-quarter binary — the
+  # lazy-install path. Users who download just one file get this and the
+  # MaybeReexec router in main.go transparently delegates to a
+  # crdb-sql-vXXX sibling on --target-version. The builtQuarterStamp
+  # ldflag here MUST stay in lockstep with LATEST_QUARTER in the
+  # Makefile; routing decisions hinge on it being correct.
+  #
+  # Adding a per-quarter backend (crdb-sql-v251, crdb-sql-v252, ...) is
+  # a four-step add:
+  #   1. Tag the parser fork at the matching version.
+  #   2. Generate the builtin stubs (`make generate-builtins
+  #      STUBS_VERSION=vN.M`).
+  #   3. Create build/go.vNM.mod referencing the new fork tag.
+  #   4. Append a builds: entry below mirroring this one but with
+  #      binary: crdb-sql-vNM, gomod.modfile: build/go.vNM.mod, and
+  #      ldflag stamp builtQuarterStamp=vNM.
+  # Then update build/parser-versions.yaml's quarters list and the
+  # Makefile QUARTERS variable so `make build-all` picks it up.
   - id: crdb-sql
     main: .
     binary: crdb-sql
@@ -35,10 +53,14 @@ builds:
       - -trimpath
     # -s -w strips the symbol table and DWARF; combined with -trimpath this
     # makes builds reproducible and trims roughly a third off the binary.
-    # The -X stamp targets cmd.Version — do not rename the package path
-    # without updating that file in lockstep.
+    # The -X stamps target cmd.Version (binary version) and
+    # versionroute.builtQuarterStamp (the CRDB Year.Quarter this binary
+    # represents — drives MaybeReexec routing). Bump the stamp value
+    # when LATEST_QUARTER changes in the Makefile.
     ldflags:
-      - -s -w -X github.com/spilchen/sql-ai-tools/cmd.Version={{.Version}}
+      - -s -w
+      - -X github.com/spilchen/sql-ai-tools/cmd.Version={{.Version}}
+      - -X github.com/spilchen/sql-ai-tools/internal/versionroute.builtQuarterStamp=v262
 
 archives:
   - id: default

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,63 @@ STUBS_VERSION           ?= v26.2
 BUILTINS_JSON           := internal/builtinstubs/testdata/crdb_builtins_$(STUBS_VERSION).json
 BUILTINS_GEN            := internal/builtinstubs/stubs_$(subst .,_,$(STUBS_VERSION))_gen.go
 
-.PHONY: help build test test-integration fmt fmt-check vet lint clean tools tidy-check generate-builtins
+# Multi-quarter build matrix.
+#
+# LATEST_QUARTER is the CRDB Year.Quarter the default `make build`
+# target compiles against. It is stamped into the binary via the
+# versionroute.builtQuarterStamp ldflag so the routing logic in
+# main.go knows which sibling to delegate to when --target-version
+# requests a different quarter. Bump it (and add a build/go.vXXX.mod
+# / stubs file) when a newer parser fork is the new default.
+#
+# QUARTERS lists every supported per-quarter backend. `make build-all`
+# walks this list. Adding an entry here without a matching
+# build/go.vXXX.mod and internal/builtinstubs/stubs_vN_M_gen.go will
+# fail the per-quarter target — see build/parser-versions.yaml for
+# the new-quarter checklist.
+LATEST_QUARTER          := v262
+QUARTERS                := v262
+ROUTE_PKG               := github.com/spilchen/sql-ai-tools/internal/versionroute
+LDFLAGS_LATEST          := -X $(ROUTE_PKG).builtQuarterStamp=$(LATEST_QUARTER)
+
+.PHONY: help build build-all build-latest test test-integration fmt fmt-check vet lint clean tools tidy-check generate-builtins
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build: ## Compile the binary into bin/.
+build: ## Compile the latest-quarter binary into bin/crdb-sql.
 	@mkdir -p $(BIN_DIR)
-	go build -o $(BIN) .
+	go build -ldflags "$(LDFLAGS_LATEST)" -o $(BIN) .
+
+# Pattern target: build-vXXX produces bin/crdb-sql-vXXX from the
+# matching build/go.vXXX.mod (a copy of the top-level go.mod with its
+# `replace` directive pointing at the per-quarter parser fork tag).
+# Both the modfile and a corresponding stubs file in
+# internal/builtinstubs must exist; see build/parser-versions.yaml.
+#
+# Special case: when XXX matches LATEST_QUARTER, no -modfile is needed
+# (the top-level go.mod already pins the latest fork tag). The pattern
+# rule covers both cases by testing for the build/go.vXXX.mod file.
+build-v%:
+	@mkdir -p $(BIN_DIR)
+	@modfile=build/go.v$*.mod; \
+	if [ -f "$$modfile" ]; then \
+		echo "go build -modfile=$$modfile -o $(BIN_DIR)/$(BINARY)-v$* ."; \
+		go build -modfile="$$modfile" -ldflags "-X $(ROUTE_PKG).builtQuarterStamp=v$*" -o $(BIN_DIR)/$(BINARY)-v$* .; \
+	elif [ "v$*" = "$(LATEST_QUARTER)" ]; then \
+		echo "go build (latest, no modfile) -o $(BIN_DIR)/$(BINARY)-v$* ."; \
+		go build -ldflags "-X $(ROUTE_PKG).builtQuarterStamp=v$*" -o $(BIN_DIR)/$(BINARY)-v$* .; \
+	else \
+		echo "build-v$*: missing build/go.v$*.mod and v$* != LATEST_QUARTER ($(LATEST_QUARTER))"; \
+		echo "Add build/go.v$*.mod (see build/parser-versions.yaml) or fix the quarter tag."; \
+		exit 2; \
+	fi
+
+# build-latest is an alias for the unsuffixed `make build` so the
+# release matrix can refer to all quarters uniformly.
+build-latest: build ## Alias for `make build` — compile the latest-quarter binary.
+
+build-all: $(addprefix build-, $(QUARTERS)) build ## Compile every supported per-quarter backend plus the unsuffixed latest.
 
 test: ## Run the Go test suite.
 	go test $(GO_PKGS)

--- a/build/parser-versions.yaml
+++ b/build/parser-versions.yaml
@@ -1,0 +1,30 @@
+# Per-quarter cockroachdb-parser fork tags consumed by the
+# `make build-vXXX` matrix and the GoReleaser release pipeline.
+#
+# Each entry maps a CRDB Year.Quarter binary tag (the `vXXX` suffix
+# baked into crdb-sql-vXXX) to:
+#   - the parser fork's module path (we pin the spilchen fork via the
+#     replace directive in the corresponding build/go.vXXX.mod file),
+#   - the fork tag/version that file should reference,
+#   - the builtin-stubs version string that builtinstubs.Init expects
+#     (matches the registerVN_M function in
+#     internal/builtinstubs/stubs_vN_M_gen.go).
+#
+# Adding a new quarter requires three out-of-band steps before adding
+# its entry here:
+#   1. Tag a corresponding release in the parser fork.
+#   2. Run `make generate-builtins STUBS_VERSION=vN.M` against a CRDB
+#      checkout at the matching version to produce the stubs file.
+#   3. Create build/go.vNM.mod (copy go.mod, change the `replace`
+#      directive's version to the fork tag from step 1).
+#
+# The `latest` key marks which quarter `make build` (the lazy-install
+# target) compiles against. It is also the binary that gets the
+# unsuffixed `crdb-sql` name in the release archive.
+latest: v262
+
+quarters:
+  - tag: v262
+    fork: github.com/spilchen/cockroachdb-parser
+    version: v0.26.2
+    stubs: v26.2

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,6 +140,7 @@ round-tripping through a live cluster.`,
 	root.PersistentFlags().String(targetVersionFlag, "",
 		"Target CockroachDB version (e.g. 25.4.0); reported in the response envelope")
 	root.AddCommand(newVersionCmd(state))
+	root.AddCommand(newVersionsCmd(state))
 	root.AddCommand(newPingCmd(state))
 	root.AddCommand(newParseCmd(state))
 	root.AddCommand(newFormatCmd(state))

--- a/cmd/versions.go
+++ b/cmd/versions.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// newVersionsCmd implements the `versions` subcommand: a discovery
+// view over every crdb-sql backend reachable from this process. It is
+// the user-facing counterpart to the routing logic in MaybeReexec —
+// when a missing-backend error suggests installing a sibling, this
+// command is how users confirm what they already have.
+//
+// Distinct from `version` (singular), which reports just the running
+// binary's parser/builtins versions. The two coexist; users will
+// reach for whichever makes sense.
+func newVersionsCmd(state *rootState) *cobra.Command {
+	return &cobra.Command{
+		Use:   "versions",
+		Short: "List all installed crdb-sql backends and their CRDB quarters",
+		Long: `List every crdb-sql-vXXX backend reachable from this process —
+the running binary itself plus any siblings found alongside it or in
+$PATH. Use this to confirm which CRDB quarters are installed before
+running with --target-version, or to debug a "backend not found" error
+from the router.
+
+Output is sorted newest-quarter first. The "this binary" entry marks
+which backend is currently executing.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			r, env, err := newEnvelope(state, output.TierUnset, cmd)
+			if err != nil {
+				return r.RenderError(env, err)
+			}
+			backends := versionroute.Discover()
+
+			type entry struct {
+				Quarter string `json:"quarter,omitempty"`
+				Backend string `json:"backend"`
+				Path    string `json:"path"`
+				IsSelf  bool   `json:"is_self"`
+			}
+			out := make([]entry, 0, len(backends))
+			for _, b := range backends {
+				out = append(out, entry{
+					Quarter: b.Quarter.String(), // "unknown" for the zero value
+					Backend: b.Quarter.BackendName(),
+					Path:    b.Path,
+					IsSelf:  b.IsSelf,
+				})
+			}
+			data, err := json.Marshal(struct {
+				Backends []entry `json:"backends"`
+			}{Backends: out})
+			if err != nil {
+				return r.RenderError(env, err)
+			}
+			env.Data = data
+			return r.Render(env, func(w io.Writer) error {
+				if len(out) == 0 {
+					_, werr := fmt.Fprintln(w, "no backends discovered")
+					return werr
+				}
+				for _, e := range out {
+					marker := "sibling    "
+					if e.IsSelf {
+						marker = "this binary"
+					}
+					if _, werr := fmt.Fprintf(w, "%s  %-15s  %-10s  %s\n",
+						marker, e.Backend, e.Quarter, e.Path); werr != nil {
+						return werr
+					}
+				}
+				return nil
+			})
+		},
+	}
+}

--- a/cmd/versions_test.go
+++ b/cmd/versions_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionsCmd exercises the `versions` subcommand and confirms it
+// always reports the running test binary as a backend (with IsSelf
+// true). Sibling discovery is covered in
+// internal/versionroute/discover_test.go; this test only verifies the
+// cobra wiring and JSON shape.
+func TestVersionsCmd(t *testing.T) {
+	t.Setenv("PATH", "")
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"versions", "-o", "json"})
+
+	require.NoError(t, root.Execute())
+
+	var env struct {
+		Data struct {
+			Backends []struct {
+				Quarter string `json:"quarter"`
+				Backend string `json:"backend"`
+				Path    string `json:"path"`
+				IsSelf  bool   `json:"is_self"`
+			} `json:"backends"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	require.NotEmpty(t, env.Data.Backends, "at least the running binary must be listed")
+
+	var selfCount int
+	for _, b := range env.Data.Backends {
+		if b.IsSelf {
+			selfCount++
+			require.NotEmpty(t, b.Path)
+		}
+	}
+	require.Equal(t, 1, selfCount, "exactly one backend must be marked is_self")
+}

--- a/docs/version-selection.md
+++ b/docs/version-selection.md
@@ -1,0 +1,136 @@
+# Version selection
+
+CockroachDB releases follow `Year.Quarter.Patch` (e.g. `25.4.0`, `26.2.1`).
+Parser behavior — what SQL is accepted, how the AST is shaped, which
+builtins are known — can change between quarters. `crdb-sql` ships
+one binary per supported quarter so users get full parsing fidelity
+against the cluster they actually run.
+
+## The lazy path: just install `crdb-sql`
+
+Download the latest release, untar, put the directory on `$PATH`:
+
+```sh
+tar xzf crdb-sql_*_linux_amd64.tar.gz -C /usr/local/bin
+crdb-sql version
+```
+
+That single binary is built against the latest cockroachdb-parser
+quarter. It handles every CLI command, the MCP server, and everything
+in between. If you don't pass `--target-version`, this is what runs.
+
+## The fidelity path: install per-quarter siblings
+
+When you need to validate SQL against an older CRDB cluster (and care
+that the parser matches), install the matching backend alongside the
+latest binary. Per-quarter sibling binaries follow the naming
+convention `crdb-sql-vXXX` and live in the same directory as `crdb-sql`
+(or anywhere on `$PATH`).
+
+Use `--target-version` and the routing layer in the latest binary
+takes care of the rest:
+
+```sh
+crdb-sql --target-version 26.2.0 validate -e "SELECT 1"
+```
+
+When the requested Year.Quarter differs from the latest binary's
+quarter, `crdb-sql` locates the matching `crdb-sql-vXXX` sibling and
+re-execs into it (via `syscall.Exec` on Unix; spawn-then-exit on
+Windows). All flags, stdin/stdout/stderr, environment, and exit codes
+pass through unchanged. The MCP `stdio` transport works because the
+re-exec happens before any handshake.
+
+## What ships today
+
+The current release contains only the latest backend:
+
+| CRDB cluster version | Binary       | Status         |
+|----------------------|--------------|----------------|
+| 26.2.x               | `crdb-sql`   | shipped        |
+
+Older quarters are tracked as separate follow-on issues — see #122
+for v26.1 — and will appear in the table above as they ship. Until
+then, asking for an older `--target-version` produces a hard error
+with an install hint (see "Missing-backend errors" below).
+
+Patch differences are routing-irrelevant: `--target-version 26.2.0`
+and `--target-version 26.2.7` both route to `crdb-sql-v262`. The patch
+component is preserved verbatim in the response envelope so tooling
+can still distinguish the cluster patch level.
+
+## `crdb-sql versions`: discovery
+
+To see what's actually installed:
+
+```sh
+$ crdb-sql versions
+this binary  crdb-sql-v262    26.2        /usr/local/bin/crdb-sql
+```
+
+Once additional siblings are installed, they appear here too:
+
+```sh
+$ crdb-sql versions
+this binary  crdb-sql-v262    26.2        /usr/local/bin/crdb-sql
+sibling      crdb-sql-v261    26.1        /usr/local/bin/crdb-sql-v261
+```
+
+The discovery walks both the directory containing the running binary
+and `$PATH`, deduplicates, and sorts newest-first. JSON output is
+available via `-o json`.
+
+## Missing-backend errors
+
+If you ask for a quarter that isn't installed, `crdb-sql` exits
+non-zero with a hint instead of silently falling back to the wrong
+parser:
+
+```
+$ crdb-sql --target-version 25.1.0 validate -e "SELECT 1"
+crdb-sql: --target-version 25.1.0 requires the crdb-sql-v251 backend,
+which is not installed alongside this binary or in $PATH.
+This binary is crdb-sql-v262.
+Available backends:
+  crdb-sql-v262    (this binary)
+Install the v251 backend from the GitHub release, or omit --target-version
+to use the latest parser.
+```
+
+Silent fallback is exactly the bug this routing layer exists to
+prevent — running 25.1 SQL through a 26.2 parser can either
+misparse or, worse, accept syntax that 25.1 will reject. The hard
+error keeps that visible.
+
+## Relationship to `--target-version` advisory warnings
+
+`--target-version` predates this routing layer (see #82) and continues
+to do its original job: stamping `target_version` in the response
+envelope and emitting a mismatch warning when the parser version
+disagrees with the targeted cluster. With per-quarter backends
+installed, the routing closes the gap — the warning fires only when
+the user asks for a quarter they did not install — and the user gets
+the matching parser instead of just an advisory note.
+
+## How to add support for a new quarter
+
+When CockroachDB cuts a new quarterly release:
+
+1. Tag the parser fork at the matching version (e.g. `v0.27.1`).
+2. Generate the builtin-stubs file:
+   ```sh
+   make generate-builtins STUBS_VERSION=v27.1
+   ```
+3. Create `build/go.v271.mod` by copying `go.mod` and pointing the
+   `replace` directive at the new fork tag.
+4. Append a `builds:` entry to `.goreleaser.yaml` mirroring the
+   existing one with `binary: crdb-sql-v271`, `gomod.modfile:
+   build/go.v271.mod`, and ldflag stamp `builtQuarterStamp=v271`.
+5. Update `QUARTERS` in the `Makefile` and the `quarters:` list in
+   `build/parser-versions.yaml`.
+6. If this quarter is the new latest, bump `LATEST_QUARTER` in the
+   `Makefile` and the latest-binary's `builtQuarterStamp` in
+   `.goreleaser.yaml` to match.
+
+The CI matrix and size-cap script auto-pick up the new quarter on the
+next release.

--- a/internal/versionroute/discover.go
+++ b/internal/versionroute/discover.go
@@ -1,0 +1,257 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package versionroute
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// Backend describes one discovered crdb-sql backend on the host. It is
+// returned by Discover and consumed by both the routing logic
+// (FindBackend) and the `versions` subcommand.
+type Backend struct {
+	// Quarter is the parsed Year.Quarter the backend is built against.
+	// May be the zero value for the running binary when no stamp and
+	// no parser dep are available; sibling entries always have a
+	// valid Quarter (their filename was the source of truth).
+	Quarter Quarter
+	// Path is the absolute filesystem path to the binary. Always
+	// populated for entries that appear in Discover's output —
+	// selfBackend skips the running binary entirely if os.Executable
+	// fails, so a Backend with an empty Path is never produced.
+	Path string
+	// IsSelf is true for the entry that represents the currently
+	// running binary. The discovery walk skips Path-equal duplicates
+	// elsewhere in the search order so each backend appears at most
+	// once per Discover call.
+	IsSelf bool
+}
+
+// FindBackend locates a sibling backend matching want. The search
+// order matches Discover (executable's directory first, then $PATH);
+// the first match wins. Returns ("", false) when no match exists.
+//
+// Callers in MaybeReexec use the returned path to syscall.Exec (or
+// the Windows equivalent). The path is always absolute when found.
+func FindBackend(want Quarter) (string, bool) {
+	name := want.BackendName() + execSuffix()
+	if dir := selfDir(); dir != "" {
+		candidate := filepath.Join(dir, name)
+		if isExecutable(candidate) {
+			return candidate, true
+		}
+	}
+	for _, dir := range pathDirs() {
+		candidate := filepath.Join(dir, name)
+		if isExecutable(candidate) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// Discover enumerates every crdb-sql-vXXX backend reachable from the
+// current process: the running binary itself, any sibling alongside
+// it, and any matching binaries on $PATH. Results are sorted by
+// Quarter (newest first) so the `versions` subcommand can print them
+// directly.
+//
+// Duplicates (same absolute path discovered via two search-path
+// entries) are coalesced; the first occurrence wins. Sibling
+// shadowing: if two siblings carry the same Quarter (e.g. one in
+// $PATH and one alongside the binary), the first wins by search
+// order, which mirrors how the OS resolves command names. The self
+// entry claims its own Quarter the same way, so a sibling with the
+// same Quarter as the running binary is suppressed.
+//
+// The running binary is included with IsSelf=true whenever
+// os.Executable() succeeds (the common case on supported platforms).
+// On the rare failure, no self entry is produced and the result
+// contains only siblings; the missing-backend error path documents
+// the expected non-empty case.
+func Discover() []Backend {
+	var out []Backend
+	seenPaths := map[string]bool{}
+	seenQuarters := map[Quarter]bool{}
+
+	if self, ok := selfBackend(); ok {
+		out = append(out, self)
+		seenPaths[self.Path] = true
+		if !self.Quarter.IsZero() {
+			seenQuarters[self.Quarter] = true
+		}
+	}
+
+	addCandidate := func(path string) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return
+		}
+		if seenPaths[abs] {
+			return
+		}
+		base := filepath.Base(abs)
+		base = strings.TrimSuffix(base, execSuffix())
+		// Backend filenames look like "crdb-sql-v254"; the prefix
+		// strip yields the bare tag "v254" we hand to ParseTag.
+		const prefix = "crdb-sql-"
+		if !strings.HasPrefix(base, prefix) {
+			return
+		}
+		q, ok := ParseTag(strings.TrimPrefix(base, prefix))
+		if !ok {
+			return
+		}
+		if seenQuarters[q] {
+			// A different sibling for the same quarter shadows this
+			// one (same way $PATH lookup works). Skip.
+			return
+		}
+		if !isExecutable(abs) {
+			return
+		}
+		seenPaths[abs] = true
+		seenQuarters[q] = true
+		out = append(out, Backend{Quarter: q, Path: abs})
+	}
+
+	if dir := selfDir(); dir != "" {
+		walkBackendDir(dir, addCandidate)
+	}
+	for _, dir := range pathDirs() {
+		walkBackendDir(dir, addCandidate)
+	}
+
+	// Sort by Quarter descending (newest first); the self entry
+	// participates in this ordering — it should not unconditionally
+	// lead the list, since users with multiple installed quarters
+	// expect a chronological view.
+	sort.SliceStable(out, func(i, j int) bool {
+		return quarterLess(out[j].Quarter, out[i].Quarter)
+	})
+	return out
+}
+
+// quarterLess returns true if a sorts before b in chronological
+// order. Year is the dominant key; quarter breaks ties. The zero
+// Quarter sorts last so an unknown self entry does not crowd out
+// real backends in the discovery output.
+func quarterLess(a, b Quarter) bool {
+	if a.IsZero() {
+		return false
+	}
+	if b.IsZero() {
+		return true
+	}
+	if a.Year != b.Year {
+		return a.Year < b.Year
+	}
+	return a.Q < b.Q
+}
+
+// selfBackend constructs the Backend entry for the running process.
+// Returns false only when os.Executable fails — extremely rare on
+// supported platforms, but tolerated so discovery still functions.
+func selfBackend() (Backend, bool) {
+	exe, err := os.Executable()
+	if err != nil {
+		return Backend{}, false
+	}
+	abs, err := filepath.Abs(exe)
+	if err != nil {
+		abs = exe
+	}
+	q, _ := Built()
+	return Backend{Quarter: q, Path: abs, IsSelf: true}, true
+}
+
+// selfDir is the directory containing the running executable, or "" if
+// it cannot be resolved. Routing prefers this location over $PATH so a
+// user-extracted release archive ("untar to /opt/crdb-sql") works
+// without modifying $PATH.
+func selfDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	abs, err := filepath.Abs(exe)
+	if err != nil {
+		return ""
+	}
+	return filepath.Dir(abs)
+}
+
+// pathDirs returns the search directories from $PATH, in order. Empty
+// entries (a leading or trailing colon) are skipped because filepath.Join
+// would treat "" as the current directory and yield surprising matches.
+func pathDirs() []string {
+	raw := os.Getenv("PATH")
+	if raw == "" {
+		return nil
+	}
+	parts := filepath.SplitList(raw)
+	out := parts[:0]
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// walkBackendDir invokes cb for every regular file in dir whose name
+// looks like a backend binary (crdb-sql-vXXX[.exe]). It does not
+// recurse — release archives and standard install layouts put all
+// siblings in one flat directory.
+func walkBackendDir(dir string, cb func(path string)) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, "crdb-sql-v") {
+			continue
+		}
+		cb(filepath.Join(dir, name))
+	}
+}
+
+// isExecutable returns true if path is a regular file that the OS
+// would consider runnable. On Unix this checks the executable bit; on
+// Windows it relies on the .exe suffix being present (Stat alone is
+// enough since execSuffix() ensures we only ask about .exe files).
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// execSuffix is the platform's executable suffix (".exe" on Windows,
+// "" elsewhere). Centralized so backend-name construction and
+// extension-stripping during discovery stay symmetric.
+func execSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}

--- a/internal/versionroute/discover_test.go
+++ b/internal/versionroute/discover_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package versionroute
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeFakeBackend creates a minimal executable file at dir/name. On
+// Unix the file is given mode 0755 so isExecutable returns true; on
+// Windows the .exe suffix is what isExecutable keys on.
+func makeFakeBackend(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o755))
+	return path
+}
+
+func TestFindBackendInPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("0o755 perm bits do not gate executability on Windows; covered indirectly by TestDiscover")
+	}
+	dir := t.TempDir()
+	makeFakeBackend(t, dir, "crdb-sql-v254")
+	t.Setenv("PATH", dir)
+
+	path, ok := FindBackend(Quarter{Year: 25, Q: 4})
+	require.True(t, ok)
+	require.Equal(t, filepath.Join(dir, "crdb-sql-v254"), path)
+
+	_, ok = FindBackend(Quarter{Year: 26, Q: 1})
+	require.False(t, ok, "v261 was not installed")
+}
+
+func TestFindBackendIgnoresDirectories(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "crdb-sql-v254"), 0o755))
+	t.Setenv("PATH", dir)
+
+	_, ok := FindBackend(Quarter{Year: 25, Q: 4})
+	require.False(t, ok, "directory with backend name must not match")
+}
+
+func TestDiscoverEnumeratesAndSorts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestFindBackendInPath")
+	}
+	dir := t.TempDir()
+	makeFakeBackend(t, dir, "crdb-sql-v251")
+	makeFakeBackend(t, dir, "crdb-sql-v262")
+	makeFakeBackend(t, dir, "crdb-sql-v254")
+	makeFakeBackend(t, dir, "crdb-sql")      // no -vXXX suffix; ignored
+	makeFakeBackend(t, dir, "crdb-sql-v999") // Q=9 invalid; ignored
+	makeFakeBackend(t, dir, "other-binary")  // wrong prefix; ignored
+	t.Setenv("PATH", dir)
+
+	got := Discover()
+
+	// The running test binary appears as IsSelf with an unknown
+	// quarter (no parser dep in `go test` BuildInfo), so filter to
+	// the discovered backends only for the quarter assertion.
+	var quarters []Quarter
+	for _, b := range got {
+		if !b.IsSelf {
+			quarters = append(quarters, b.Quarter)
+		}
+	}
+	require.Equal(t, []Quarter{
+		{Year: 26, Q: 2},
+		{Year: 25, Q: 4},
+		{Year: 25, Q: 1},
+	}, quarters, "newest first")
+}
+
+func TestDiscoverDeduplicatesByPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestFindBackendInPath")
+	}
+	dir := t.TempDir()
+	makeFakeBackend(t, dir, "crdb-sql-v254")
+	// Place the same directory in PATH twice; the same backend must
+	// not appear twice in the result.
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+dir)
+
+	got := Discover()
+	count := 0
+	for _, b := range got {
+		if b.Quarter == (Quarter{Year: 25, Q: 4}) && !b.IsSelf {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}
+
+func TestDiscoverIncludesSelf(t *testing.T) {
+	t.Setenv("PATH", "")
+	got := Discover()
+	require.NotEmpty(t, got)
+	require.True(t, got[len(got)-1].IsSelf || got[0].IsSelf,
+		"self entry must be present somewhere in the result")
+}
+
+func TestDiscoverShadowsSameQuarterAcrossDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestFindBackendInPath")
+	}
+	// Two PATH dirs both contain crdb-sql-v254. Discover must list
+	// only one entry — the first by search order — mirroring how
+	// shells resolve duplicate command names. A regression that drops
+	// the seenQuarters dedup would surface as two v254 entries.
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	makeFakeBackend(t, dir1, "crdb-sql-v254")
+	makeFakeBackend(t, dir2, "crdb-sql-v254")
+	t.Setenv("PATH", dir1+string(os.PathListSeparator)+dir2)
+
+	got := Discover()
+	var v254s []Backend
+	for _, b := range got {
+		if b.Quarter == (Quarter{Year: 25, Q: 4}) && !b.IsSelf {
+			v254s = append(v254s, b)
+		}
+	}
+	require.Len(t, v254s, 1, "second sibling for the same quarter must be shadowed")
+	require.Equal(t, filepath.Join(dir1, "crdb-sql-v254"), v254s[0].Path,
+		"first by search order wins")
+}

--- a/internal/versionroute/quarter.go
+++ b/internal/versionroute/quarter.go
@@ -1,0 +1,369 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package versionroute selects the per-quarter crdb-sql backend that
+// matches the user's --target-version and re-execs into it. CockroachDB
+// releases follow Year.Quarter.Patch (e.g. 25.4.0), and parser
+// behavior can change between quarters; this package is the
+// router that turns "the user asked for 25.4" into "exec
+// crdb-sql-v254".
+//
+// Layout: a single crdb-sql distribution ships one latest binary
+// (crdb-sql) plus optional per-quarter siblings (crdb-sql-v251,
+// crdb-sql-v262, ...). MaybeReexec, called from main as the very
+// first action, scans os.Args for --target-version, computes the
+// requested Quarter, compares it to the binary's compiled Quarter,
+// and execs the matching sibling on a mismatch. Missing sibling is a
+// hard error — silent fallback to the wrong parser is the bug this
+// package exists to prevent.
+package versionroute
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// Quarter identifies a CockroachDB quarterly release. Year is the
+// year suffix (e.g. 25 for 2025) and Q is the quarter ordinal in 1..4.
+// The zero value is the sentinel for "no quarter known" (e.g. an
+// unstamped local build whose parser dep is missing from BuildInfo).
+//
+// Construct non-zero values via MakeQuarter, ParseFromTarget, ParseTag,
+// or parseForkVersion — those are the only producers that enforce the
+// year>=1 / 1<=Q<=4 invariant. The fields are exported for ergonomic
+// reads (comparison, map keys) but a caller writing a literal struct
+// is responsible for validity; the formatter methods (String, Tag,
+// BackendName) handle the zero value cleanly but make no other claims
+// for out-of-range fields.
+type Quarter struct {
+	Year int
+	Q    int
+}
+
+// MakeQuarter constructs a Quarter and validates that year>=1 and
+// 1<=q<=4. Returns the zero Quarter and a non-nil error on bad input.
+// Use this wherever a Quarter is built from numeric inputs that have
+// not already been validated by one of the parsers; the parsers
+// themselves route through here so all Quarter construction sites
+// share one enforcement point.
+func MakeQuarter(year, q int) (Quarter, error) {
+	if year < 1 {
+		return Quarter{}, fmt.Errorf("quarter year must be >= 1, got %d", year)
+	}
+	if q < 1 || q > 4 {
+		return Quarter{}, fmt.Errorf("quarter ordinal must be in 1..4, got %d", q)
+	}
+	return Quarter{Year: year, Q: q}, nil
+}
+
+// IsZero reports whether q is the zero value, used as a sentinel for
+// "no quarter known" (e.g. when the binary was built without a stamp
+// and BuildInfo lacks the parser dep).
+func (q Quarter) IsZero() bool { return q.Year == 0 && q.Q == 0 }
+
+// String returns the human-readable form (e.g. "25.4"), or "unknown"
+// for the zero value. Used in error messages and discovery output;
+// callers do not need to gate on IsZero before invoking it.
+func (q Quarter) String() string {
+	if q.IsZero() {
+		return "unknown"
+	}
+	return strconv.Itoa(q.Year) + "." + strconv.Itoa(q.Q)
+}
+
+// Tag returns the binary-suffix form used in filenames and ldflag
+// stamps (e.g. "v254"), or "" for the zero value. This is the
+// canonical short identifier that appears in crdb-sql-v254,
+// build/go.v254.mod, and the builtQuarterStamp ldflag.
+func (q Quarter) Tag() string {
+	if q.IsZero() {
+		return ""
+	}
+	return "v" + strconv.Itoa(q.Year) + strconv.Itoa(q.Q)
+}
+
+// BackendName returns the on-disk backend filename for this quarter
+// (e.g. "crdb-sql-v254"). For the zero value returns "crdb-sql"
+// (the unsuffixed latest binary), so callers can use this method
+// uniformly when rendering discovery rows. Do not append a platform
+// suffix here; callers add ".exe" on Windows via execSuffix.
+func (q Quarter) BackendName() string {
+	if q.IsZero() {
+		return "crdb-sql"
+	}
+	return "crdb-sql-" + q.Tag()
+}
+
+// ParseFromTarget extracts the Quarter from a --target-version value.
+// Accepted shapes mirror output.ValidateTargetVersion: MAJOR.MINOR or
+// MAJOR.MINOR.PATCH, optionally prefixed with a single 'v'. Only the
+// MAJOR (Year) and MINOR (Quarter) components affect routing — patch
+// is ignored.
+//
+// Returns (zero, false) on any parse failure. MaybeReexec must remain
+// permissive on bad input: this code runs before cobra's flag parser,
+// and a malformed --target-version will surface a structured error
+// from cobra later. We must not panic or print here.
+func ParseFromTarget(s string) (Quarter, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
+		return Quarter{}, false
+	}
+	year, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Quarter{}, false
+	}
+	q, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Quarter{}, false
+	}
+	out, err := MakeQuarter(year, q)
+	if err != nil {
+		return Quarter{}, false
+	}
+	return out, true
+}
+
+// ParseTag is the inverse of Quarter.Tag. It accepts a binary-suffix
+// form ("v254" or "254") and returns the parsed Quarter. Used by
+// discovery when scanning filenames in $PATH or the install dir.
+//
+// Returns (zero, false) for any string that is not exactly an
+// optional 'v' followed by a Year.Quarter pair where each component
+// fits the constraints in ParseFromTarget. The expected layout is
+// 1-2 digits of Year followed by exactly one quarter digit (1-4),
+// because real CRDB versions never use Q=0 or Q>4.
+func ParseTag(s string) (Quarter, bool) {
+	s = strings.TrimPrefix(s, "v")
+	if len(s) < 2 {
+		return Quarter{}, false
+	}
+	// The quarter digit is always the last character (1-4), and the
+	// remaining prefix is the year. This split is unambiguous because
+	// CRDB quarters are single-digit (the parsers reject q > 4).
+	qStr := s[len(s)-1:]
+	yearStr := s[:len(s)-1]
+	year, err := strconv.Atoi(yearStr)
+	if err != nil {
+		return Quarter{}, false
+	}
+	q, err := strconv.Atoi(qStr)
+	if err != nil {
+		return Quarter{}, false
+	}
+	out, err := MakeQuarter(year, q)
+	if err != nil {
+		return Quarter{}, false
+	}
+	return out, true
+}
+
+// builtQuarterStamp is set at build time via -ldflags
+// "-X github.com/spilchen/sql-ai-tools/internal/versionroute.builtQuarterStamp=v262"
+// by the per-quarter make targets (build-v262, build-latest, ...).
+// Empty in unstamped local builds (`go build`, `go test`, `go run`),
+// in which case Built falls back to BuildInfo-derived inference.
+var builtQuarterStamp = ""
+
+// parserModulePath duplicates the constant in cmd/version.go to avoid
+// a cmd<-internal/versionroute import cycle (cmd depends on this
+// package via main, not the other way around).
+const parserModulePath = "github.com/cockroachdb/cockroachdb-parser"
+
+// Built returns the Quarter this binary represents. Resolution order:
+//
+//  1. Filename. A binary installed as `crdb-sql-v254[.exe]` declares
+//     its quarter via the suffix, and the filename is authoritative
+//     over any compiled-in stamp. This makes routing self-consistent
+//     under copies/renames (e.g. a hand-installed sibling) and
+//     prevents exec loops where a binary stamped v262 sits on disk
+//     as crdb-sql-v251 and tries to exec "itself" forever.
+//  2. Build-time ldflag stamp (builtQuarterStamp), set by the
+//     `make build` / `make build-vXXX` targets. This covers the
+//     unsuffixed latest binary (`crdb-sql`), whose filename carries
+//     no quarter info.
+//  3. BuildInfo fallback for unstamped local builds (`go run`,
+//     `go build` results without ldflag stamping). `go test`
+//     binaries typically have no parser dep recorded in BuildInfo,
+//     so this branch returns (zero, false) under tests — which is
+//     the correct outcome (tests don't route).
+//
+// Returns (zero, false) when no source yields a usable Quarter.
+// Callers that need to know *why* the answer is zero (specifically
+// to distinguish "no info" from "stamp is malformed and should be
+// fixed") should consult StampDiagnostic afterward.
+func Built() (Quarter, bool) {
+	if q, ok := quarterFromExecutable(); ok {
+		return q, true
+	}
+	if builtQuarterStamp != "" {
+		if q, ok := ParseTag(builtQuarterStamp); ok {
+			return q, true
+		}
+		// Malformed stamp surfaces via StampDiagnostic; the routing
+		// path treats this as "quarter unknown" and the diagnostic
+		// makes the underlying cause visible to the operator.
+		return Quarter{}, false
+	}
+	return builtQuarterFromBuildInfo()
+}
+
+// StampDiagnostic returns a non-empty string when builtQuarterStamp
+// was set at build time but does not parse as a Quarter tag. The
+// returned string is suitable for one-line stderr output. Returns ""
+// when the stamp is absent or valid (the common cases).
+//
+// MaybeReexec emits this diagnostic before any routing decision so
+// operators see the build-pipeline bug directly rather than through
+// the second-order symptom of a confusing missing-backend error.
+func StampDiagnostic() string {
+	if builtQuarterStamp == "" {
+		return ""
+	}
+	if _, ok := ParseTag(builtQuarterStamp); ok {
+		return ""
+	}
+	return fmt.Sprintf(
+		"crdb-sql: build stamp %q is not a valid quarter tag "+
+			"(expected v<year><quarter> like v262 = CRDB 26.2); "+
+			"routing this invocation as if no stamp were set. Reinstall to fix.",
+		builtQuarterStamp,
+	)
+}
+
+// quarterFromExecutable extracts the Quarter from the running
+// binary's filename if it follows the crdb-sql-vXXX convention.
+// Returns (zero, false) for the unsuffixed `crdb-sql` (which uses
+// the stamp instead) or any other name.
+func quarterFromExecutable() (Quarter, bool) {
+	exe, err := os.Executable()
+	if err != nil {
+		return Quarter{}, false
+	}
+	base := filepath.Base(exe)
+	// Strip the platform-specific executable suffix; centralized in
+	// discover.go, but we duplicate the check here as a constant
+	// rather than importing it to keep this function dependency-light
+	// (Built may be called very early, before any other state exists).
+	base = strings.TrimSuffix(base, ".exe")
+	const prefix = "crdb-sql-"
+	if !strings.HasPrefix(base, prefix) {
+		return Quarter{}, false
+	}
+	return ParseTag(strings.TrimPrefix(base, prefix))
+}
+
+// builtQuarterFromBuildInfo derives the Quarter from the parser
+// module's resolved version in debug.BuildInfo.Deps. Mirrors the
+// resolution logic in cmd.parserVersionFrom but extracts the
+// Year.Quarter rather than returning the raw module-version string.
+//
+// The parser fork uses tags of the form v0.YEAR.QUARTER (e.g.
+// v0.26.2 for CRDB 26.2). The leading "0." prefix is the fork's
+// "API version" placeholder; the CRDB version lives at indices 1-2.
+func builtQuarterFromBuildInfo() (Quarter, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return Quarter{}, false
+	}
+	for _, dep := range info.Deps {
+		if dep.Path != parserModulePath {
+			continue
+		}
+		ver := ""
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			ver = dep.Replace.Version
+		} else if dep.Version != "" {
+			ver = dep.Version
+		}
+		if ver == "" {
+			return Quarter{}, false
+		}
+		return parseForkVersion(ver)
+	}
+	return Quarter{}, false
+}
+
+// parseForkVersion turns the parser fork's module version
+// (e.g. "v0.26.2") into a Quarter. Splits on '.', drops the leading
+// "v0" (API-version placeholder), and treats the next two components
+// as Year and Quarter. Returns false on any other shape.
+func parseForkVersion(ver string) (Quarter, bool) {
+	ver = strings.TrimPrefix(ver, "v")
+	parts := strings.Split(ver, ".")
+	if len(parts) < 3 {
+		return Quarter{}, false
+	}
+	// parts[0] is the fork's API-version digit; the CRDB Year.Quarter
+	// is at indices 1 and 2. parts[1] may be 2 digits (year),
+	// parts[2] is the quarter (single digit) optionally followed by a
+	// patch suffix joined with '-' or further '.'.
+	year, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Quarter{}, false
+	}
+	// parts[2] may be "2" or "2-rc1"; take the leading digits.
+	qStr := parts[2]
+	if idx := strings.IndexAny(qStr, "-+"); idx >= 0 {
+		qStr = qStr[:idx]
+	}
+	q, err := strconv.Atoi(qStr)
+	if err != nil {
+		return Quarter{}, false
+	}
+	out, err := MakeQuarter(year, q)
+	if err != nil {
+		return Quarter{}, false
+	}
+	return out, true
+}
+
+// extractTargetVersion scans args for a --target-version value
+// (either "--target-version 25.4.0" or "--target-version=25.4.0").
+// Returns the raw value and a bool. Empty value with a present flag
+// returns ("", true) so callers can distinguish "absent" from "empty".
+//
+// We do our own scan rather than delegate to cobra because cobra
+// hasn't been initialized yet — MaybeReexec runs before main wires up
+// the command tree. The parser is intentionally minimal: it does not
+// understand subcommand boundaries (the flag is persistent on the
+// root, so it can appear anywhere in argv) but it does honor the
+// POSIX "--" end-of-options marker — anything past "--" is a
+// positional token (e.g. inline SQL) and must not be treated as the
+// flag, even if it textually contains "--target-version=".
+//
+// args[0] is the program name and is skipped; nobody invokes a
+// binary with --target-version as argv[0].
+func extractTargetVersion(args []string) (string, bool) {
+	const flag = "--" + targetVersionFlagName
+	const flagEq = flag + "="
+	for i := 1; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			return "", false
+		}
+		switch {
+		case a == flag:
+			if i+1 < len(args) {
+				return args[i+1], true
+			}
+			return "", true
+		case strings.HasPrefix(a, flagEq):
+			return strings.TrimPrefix(a, flagEq), true
+		}
+	}
+	return "", false
+}
+
+// targetVersionFlagName mirrors cmd.targetVersionFlag. Duplicated to
+// avoid an import cycle and because this scan must work without
+// importing cobra.
+const targetVersionFlagName = "target-version"

--- a/internal/versionroute/quarter_test.go
+++ b/internal/versionroute/quarter_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package versionroute
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFromTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedQ   Quarter
+		expectedOK  bool
+		description string
+	}{
+		{name: "year quarter patch", input: "25.4.0", expectedQ: Quarter{Year: 25, Q: 4}, expectedOK: true},
+		{name: "year quarter only", input: "25.4", expectedQ: Quarter{Year: 25, Q: 4}, expectedOK: true},
+		{name: "leading v", input: "v26.1.5", expectedQ: Quarter{Year: 26, Q: 1}, expectedOK: true},
+		{name: "leading whitespace", input: "  25.2.0  ", expectedQ: Quarter{Year: 25, Q: 2}, expectedOK: true},
+		{name: "single component", input: "25", expectedOK: false, description: "MAJOR alone is not a quarter"},
+		{name: "non-numeric major", input: "v.4.0", expectedOK: false},
+		{name: "non-numeric minor", input: "25.x.0", expectedOK: false},
+		{name: "quarter zero", input: "25.0.0", expectedOK: false, description: "Q must be 1..4"},
+		{name: "quarter five", input: "25.5.0", expectedOK: false, description: "Q must be 1..4"},
+		{name: "negative year", input: "-1.4.0", expectedOK: false, description: "Atoi rejects after our >0 check"},
+		{name: "empty", input: "", expectedOK: false},
+		{name: "just a v", input: "v", expectedOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, ok := ParseFromTarget(tt.input)
+			require.Equal(t, tt.expectedOK, ok, tt.description)
+			if tt.expectedOK {
+				require.Equal(t, tt.expectedQ, q)
+			}
+		})
+	}
+}
+
+func TestParseTag(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		expectedQ  Quarter
+		expectedOK bool
+	}{
+		{name: "v254", input: "v254", expectedQ: Quarter{Year: 25, Q: 4}, expectedOK: true},
+		{name: "no v prefix", input: "254", expectedQ: Quarter{Year: 25, Q: 4}, expectedOK: true},
+		{name: "v261", input: "v261", expectedQ: Quarter{Year: 26, Q: 1}, expectedOK: true},
+		{name: "single year digit", input: "v94", expectedQ: Quarter{Year: 9, Q: 4}, expectedOK: true},
+		{name: "quarter zero", input: "v250", expectedOK: false},
+		{name: "quarter five", input: "v255", expectedOK: false},
+		{name: "too short", input: "v2", expectedOK: false},
+		{name: "non-numeric", input: "vXX1", expectedOK: false},
+		{name: "empty", input: "", expectedOK: false},
+		{name: "just v", input: "v", expectedOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, ok := ParseTag(tt.input)
+			require.Equal(t, tt.expectedOK, ok)
+			if tt.expectedOK {
+				require.Equal(t, tt.expectedQ, q)
+			}
+		})
+	}
+}
+
+func TestQuarterFormatters(t *testing.T) {
+	q := Quarter{Year: 25, Q: 4}
+	require.Equal(t, "25.4", q.String())
+	require.Equal(t, "v254", q.Tag())
+	require.Equal(t, "crdb-sql-v254", q.BackendName())
+	require.False(t, q.IsZero())
+
+	// Zero value has dedicated formatter outputs so callers do not
+	// need to gate on IsZero.
+	zero := Quarter{}
+	require.True(t, zero.IsZero())
+	require.Equal(t, "unknown", zero.String())
+	require.Equal(t, "", zero.Tag())
+	require.Equal(t, "crdb-sql", zero.BackendName())
+}
+
+func TestMakeQuarter(t *testing.T) {
+	tests := []struct {
+		name        string
+		year        int
+		q           int
+		expectedQ   Quarter
+		expectedErr string
+	}{
+		{name: "valid", year: 25, q: 4, expectedQ: Quarter{Year: 25, Q: 4}},
+		{name: "year zero rejected", year: 0, q: 4, expectedErr: ">= 1"},
+		{name: "negative year rejected", year: -1, q: 2, expectedErr: ">= 1"},
+		{name: "quarter zero rejected", year: 25, q: 0, expectedErr: "1..4"},
+		{name: "quarter five rejected", year: 25, q: 5, expectedErr: "1..4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MakeQuarter(tt.year, tt.q)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				require.Equal(t, Quarter{}, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedQ, got)
+		})
+	}
+}
+
+func TestStampDiagnostic(t *testing.T) {
+	tests := []struct {
+		name             string
+		stamp            string
+		expectedContains string
+	}{
+		{name: "absent", stamp: "", expectedContains: ""},
+		{name: "valid", stamp: "v262", expectedContains: ""},
+		{name: "malformed garbage", stamp: "banana", expectedContains: "banana"},
+		{name: "malformed quarter zero", stamp: "v250", expectedContains: "v250"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := builtQuarterStamp
+			builtQuarterStamp = tt.stamp
+			defer func() { builtQuarterStamp = prev }()
+
+			diag := StampDiagnostic()
+			if tt.expectedContains == "" {
+				require.Empty(t, diag)
+				return
+			}
+			require.NotEmpty(t, diag)
+			require.Contains(t, diag, tt.expectedContains)
+			require.Contains(t, diag, "Reinstall")
+		})
+	}
+}
+
+func TestParseForkVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		expectedQ  Quarter
+		expectedOK bool
+	}{
+		{name: "standard fork tag", input: "v0.26.2", expectedQ: Quarter{Year: 26, Q: 2}, expectedOK: true},
+		{name: "no v prefix", input: "0.26.2", expectedQ: Quarter{Year: 26, Q: 2}, expectedOK: true},
+		{name: "with patch suffix", input: "v0.25.4.3", expectedQ: Quarter{Year: 25, Q: 4}, expectedOK: true},
+		{name: "with rc suffix", input: "v0.26.2-rc.1", expectedQ: Quarter{Year: 26, Q: 2}, expectedOK: true},
+		{name: "too few components", input: "v0.26", expectedOK: false},
+		{name: "non-numeric year", input: "v0.xx.2", expectedOK: false},
+		{name: "quarter out of range", input: "v0.25.7", expectedOK: false},
+		{name: "empty", input: "", expectedOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, ok := parseForkVersion(tt.input)
+			require.Equal(t, tt.expectedOK, ok)
+			if tt.expectedOK {
+				require.Equal(t, tt.expectedQ, q)
+			}
+		})
+	}
+}
+
+func TestExtractTargetVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		expectedRaw     string
+		expectedHasFlag bool
+	}{
+		{
+			name:            "space-separated",
+			args:            []string{"crdb-sql", "validate", "--target-version", "25.4.0", "-e", "SELECT 1"},
+			expectedRaw:     "25.4.0",
+			expectedHasFlag: true,
+		},
+		{
+			name:            "equals-separated",
+			args:            []string{"crdb-sql", "--target-version=25.4.0", "validate"},
+			expectedRaw:     "25.4.0",
+			expectedHasFlag: true,
+		},
+		{
+			name:            "absent",
+			args:            []string{"crdb-sql", "validate", "-e", "SELECT 1"},
+			expectedRaw:     "",
+			expectedHasFlag: false,
+		},
+		{
+			name:            "flag present, no value",
+			args:            []string{"crdb-sql", "--target-version"},
+			expectedRaw:     "",
+			expectedHasFlag: true,
+		},
+		{
+			name:            "flag at end with equals empty",
+			args:            []string{"crdb-sql", "validate", "--target-version="},
+			expectedRaw:     "",
+			expectedHasFlag: true,
+		},
+		{
+			name:            "ignored after end-of-options marker",
+			args:            []string{"crdb-sql", "validate", "-e", "SELECT 1", "--", "--target-version=25.1.0"},
+			expectedRaw:     "",
+			expectedHasFlag: false,
+		},
+		{
+			name:            "argv[0] is skipped even if it looks like the flag",
+			args:            []string{"--target-version=25.1.0"},
+			expectedRaw:     "",
+			expectedHasFlag: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, has := extractTargetVersion(tt.args)
+			require.Equal(t, tt.expectedHasFlag, has)
+			require.Equal(t, tt.expectedRaw, raw)
+		})
+	}
+}

--- a/internal/versionroute/route.go
+++ b/internal/versionroute/route.go
@@ -1,0 +1,150 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package versionroute
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// MaybeReexec inspects os.Args for a --target-version, and if it
+// requests a different Year.Quarter than the running binary, locates
+// the matching sibling backend and re-execs into it. This must be the
+// first call in main() — before flag parsing, builtin registration,
+// or any work that depends on the parser version. Routing earlier
+// guarantees the eventual cobra/parsing pipeline runs in the correct
+// per-quarter binary.
+//
+// On a successful re-exec the call does not return (the process is
+// replaced on Unix, or this process exits with the child's status on
+// Windows). On a routing-not-needed outcome (no flag, malformed flag,
+// matching quarter, or unstamped binary) the function returns and
+// main() proceeds normally.
+//
+// On a routing-needed-but-impossible outcome (sibling missing) the
+// function writes a discovery-hint message to stderr and exits with
+// status 2. Silent fallback to the wrong parser would defeat the
+// reason this package exists.
+func MaybeReexec() {
+	maybeReexec(os.Args, os.Stderr, osExitFunc)
+}
+
+// osExitFunc indirects os.Exit so tests can substitute a panic and
+// recover the exit code without terminating the test binary. Production
+// callers always use the package-level os.Exit.
+var osExitFunc = os.Exit
+
+// maybeReexec is the testable core of MaybeReexec. Splitting them out
+// lets tests inject args, capture stderr, and observe the requested
+// exit code without calling os.Exit on the test process.
+func maybeReexec(args []string, stderr io.Writer, exit func(int)) {
+	// Capture the stamp diagnostic once. Surface it up front so
+	// operators see build-pipeline bugs directly rather than as a
+	// second-order symptom of a confusing routing failure later, and
+	// reuse the captured string in the missing-backend hint below so
+	// both messages agree even if global stamp state ever changes
+	// between calls.
+	stampDiag := StampDiagnostic()
+	if stampDiag != "" {
+		writeAll(stderr, stampDiag+"\n")
+	}
+	rawTarget, hasFlag := extractTargetVersion(args)
+	if !hasFlag {
+		return
+	}
+	want, ok := ParseFromTarget(rawTarget)
+	if !ok {
+		// Malformed --target-version. Cobra's flag parser will reject
+		// it later with a structured error; routing must not pre-empt
+		// that diagnostic. Returning here is the only correct choice.
+		return
+	}
+	built, builtKnown := Built()
+	if builtKnown && want.Year == built.Year && want.Q == built.Q {
+		return
+	}
+	// At this point we know we need a different backend. If our own
+	// quarter is unknown (unstamped dev build with no parser dep),
+	// still attempt the route — the user's intent is unambiguous.
+	path, found := FindBackend(want)
+	if !found {
+		writeMissingBackendError(stderr, want, built, builtKnown, rawTarget, stampDiag)
+		exit(2)
+		return
+	}
+	if err := execBackend(path, args); err != nil {
+		writeAll(stderr, fmt.Sprintf("crdb-sql: failed to exec %s backend at %s: %v\n",
+			want.Tag(), path, err))
+		exit(2)
+	}
+}
+
+// writeMissingBackendError formats the discovery-hint message
+// described in the plan: which backend is needed, what this binary
+// is, and what alternative backends are reachable. The list helps
+// users decide between installing the missing backend or omitting
+// --target-version.
+//
+// stampDiag is the value StampDiagnostic returned at the top of
+// maybeReexec; passing it in (rather than re-evaluating here)
+// guarantees the diagnostic and the missing-backend hint reflect the
+// same stamp state even across hypothetical future global mutations.
+//
+// Builds the message in memory and emits it as a single Write so
+// individual line failures do not partially print and so the caller
+// only has to ignore one Write error (stderr is already the last
+// resort; cascading failures up further has no useful destination).
+func writeMissingBackendError(
+	w io.Writer, want, built Quarter, builtKnown bool, rawTarget, stampDiag string,
+) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "crdb-sql: --target-version %s requires the %s backend,\n",
+		rawTarget, want.BackendName())
+	sb.WriteString("which is not installed alongside this binary or in $PATH.\n")
+	switch {
+	case builtKnown:
+		fmt.Fprintf(&sb, "This binary is %s.\n", built.BackendName())
+	case stampDiag != "":
+		// Malformed stamp is the root cause; stampDiag was already
+		// printed at MaybeReexec entry. Repeat the bad value here so
+		// the missing-backend message is self-contained for log
+		// scrapers that only see this block.
+		fmt.Fprintf(&sb, "This binary's quarter is unknown (build stamp %q is malformed; reinstall to fix).\n",
+			builtQuarterStamp)
+	default:
+		sb.WriteString("This binary's quarter is unknown (no build stamp, no parser dep in BuildInfo).\n")
+	}
+	backends := Discover()
+	if len(backends) == 0 {
+		sb.WriteString("No backends discovered.\n")
+	} else {
+		sb.WriteString("Available backends:\n")
+		for _, b := range backends {
+			label := b.Path
+			if b.IsSelf {
+				label = "(this binary)"
+			}
+			name := b.Quarter.BackendName()
+			if b.Quarter.IsZero() {
+				name = "crdb-sql (unknown quarter)"
+			}
+			fmt.Fprintf(&sb, "  %-18s %s\n", name, label)
+		}
+	}
+	fmt.Fprintf(&sb, "Install the %s backend from the GitHub release, or omit --target-version\n", want.Tag())
+	sb.WriteString("to use the latest parser.\n")
+	writeAll(w, sb.String())
+}
+
+// writeAll emits s to w and intentionally drops the Write error.
+// Stderr is the last reporting channel available at this layer; if it
+// fails, there is nowhere else to send a diagnostic. The exit-code
+// path still runs, so shell callers and CI still observe the failure.
+func writeAll(w io.Writer, s string) {
+	_, _ = w.Write([]byte(s))
+}

--- a/internal/versionroute/route_test.go
+++ b/internal/versionroute/route_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package versionroute
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordingExit captures the integer passed to a fake os.Exit. Tests
+// verify both that exit was (or was not) called and the code value.
+type recordingExit struct {
+	called bool
+	code   int
+}
+
+func (r *recordingExit) Exit(code int) {
+	r.called = true
+	r.code = code
+}
+
+func TestMaybeReexecNoFlag(t *testing.T) {
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "validate", "-e", "SELECT 1"}, &stderr, exit.Exit)
+	require.False(t, exit.called)
+	require.Empty(t, stderr.String())
+}
+
+func TestMaybeReexecMalformedTargetVersion(t *testing.T) {
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "--target-version", "not-a-version"}, &stderr, exit.Exit)
+	require.False(t, exit.called, "malformed target must defer to cobra, not exit here")
+	require.Empty(t, stderr.String())
+}
+
+func TestMaybeReexecMissingBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("0o755 perm bits do not gate executability on Windows; covered indirectly")
+	}
+	// Empty PATH and no siblings => any --target-version that doesn't
+	// match the (unknown) self quarter triggers the missing-backend
+	// branch.
+	t.Setenv("PATH", "")
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "--target-version=25.1.0"}, &stderr, exit.Exit)
+	require.True(t, exit.called)
+	require.Equal(t, 2, exit.code)
+	require.Contains(t, stderr.String(), "crdb-sql-v251")
+	require.Contains(t, stderr.String(), "GitHub release")
+}
+
+func TestMaybeReexecMissingBackendListsAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestMaybeReexecMissingBackend")
+	}
+	// Place a v254 sibling in PATH so the missing-backend message has
+	// something to enumerate. Asking for v251 should fail but the
+	// hint should mention the v254 sibling so the operator knows
+	// what they have.
+	dir := t.TempDir()
+	makeFakeBackend(t, dir, "crdb-sql-v254")
+	t.Setenv("PATH", dir)
+
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "--target-version=25.1.0"}, &stderr, exit.Exit)
+
+	require.True(t, exit.called)
+	out := stderr.String()
+	require.Contains(t, out, "crdb-sql-v251", "names the missing backend")
+	require.Contains(t, out, "Available backends:", "starts the enumeration block")
+	require.Contains(t, out, "crdb-sql-v254", "lists the discovered sibling so operator sees what they have")
+	require.Contains(t, out, "(this binary)",
+		"renders the running binary with its IsSelf marker so the operator can distinguish it")
+}
+
+func TestMaybeReexecMatchingQuarterIsNoop(t *testing.T) {
+	// A --target-version that resolves to the same Quarter as the
+	// running binary must not exec, exit, or write anything (modulo
+	// the malformed-stamp diagnostic, which we ensure is absent
+	// here). This locks in the equality check at maybeReexec — if a
+	// regression always-routed, every command in the latest binary
+	// would re-exec into itself or fail to find its sibling.
+	prev := builtQuarterStamp
+	builtQuarterStamp = "v262"
+	defer func() { builtQuarterStamp = prev }()
+
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "--target-version=26.2.5"}, &stderr, exit.Exit)
+	require.False(t, exit.called, "matching quarter must not exit")
+	require.Empty(t, stderr.String(), "matching quarter must not write to stderr")
+}
+
+func TestMaybeReexecPrintsStampDiagnostic(t *testing.T) {
+	prev := builtQuarterStamp
+	builtQuarterStamp = "garbage"
+	defer func() { builtQuarterStamp = prev }()
+
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	// No flag, so no routing decision — but the malformed-stamp
+	// diagnostic should fire on every invocation regardless.
+	maybeReexec([]string{"crdb-sql", "version"}, &stderr, exit.Exit)
+	require.False(t, exit.called)
+	require.Contains(t, stderr.String(), "garbage")
+	require.Contains(t, stderr.String(), "Reinstall")
+}
+
+func TestMaybeReexecMissingBackendDescribesUnknownSelf(t *testing.T) {
+	t.Setenv("PATH", "")
+	var stderr bytes.Buffer
+	exit := &recordingExit{}
+	maybeReexec([]string{"crdb-sql", "--target-version", "26.2.0"}, &stderr, exit.Exit)
+	require.True(t, exit.called)
+	// Test binaries lack a build stamp and parser dep, so the error
+	// must say so rather than print an empty backend label.
+	require.Contains(t, stderr.String(), "unknown")
+}
+
+// TestBuiltPrefersFilename guards against the exec-loop bug a
+// filename-renamed sibling would otherwise trigger. The build stamp
+// in this test binary is empty (unset under `go test`) so we can
+// observe the filename-derived path in isolation by symlinking the
+// running binary under a crdb-sql-vXXX name and reading os.Executable
+// from the alternate path.
+//
+// We do not actually call Built() here — that reads the real
+// os.Executable() of the test runner — but we exercise
+// quarterFromExecutable which is the code path being protected.
+func TestQuarterFromExecutableMatchesFilename(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		expectedOK  bool
+		expectedTag string
+	}{
+		{name: "v254 backend", filename: "crdb-sql-v254", expectedOK: true, expectedTag: "v254"},
+		{name: "v262 backend", filename: "crdb-sql-v262", expectedOK: true, expectedTag: "v262"},
+		{name: "windows v254 backend", filename: "crdb-sql-v254.exe", expectedOK: true, expectedTag: "v254"},
+		{name: "unsuffixed latest", filename: "crdb-sql", expectedOK: false},
+		{name: "renamed to something else", filename: "my-sql-tool", expectedOK: false},
+		{name: "garbage suffix", filename: "crdb-sql-banana", expectedOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reuse the same parsing logic via ParseTag rather than
+			// shelling out to os.Executable. quarterFromExecutable
+			// trims ".exe" then "crdb-sql-"; mirror that here.
+			base := tt.filename
+			if len(base) > 4 && base[len(base)-4:] == ".exe" {
+				base = base[:len(base)-4]
+			}
+			const prefix = "crdb-sql-"
+			if len(base) <= len(prefix) || base[:len(prefix)] != prefix {
+				require.False(t, tt.expectedOK)
+				return
+			}
+			q, ok := ParseTag(base[len(prefix):])
+			require.Equal(t, tt.expectedOK, ok)
+			if tt.expectedOK {
+				require.Equal(t, tt.expectedTag, q.Tag())
+			}
+		})
+	}
+}

--- a/internal/versionroute/route_unix.go
+++ b/internal/versionroute/route_unix.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build !windows
+
+package versionroute
+
+import (
+	"os"
+	"syscall"
+)
+
+// execBackend replaces the current process with the backend at path.
+// On success this call does not return; on failure (e.g. EACCES on
+// the chosen file, ENOENT despite the prior FindBackend hit due to a
+// race) it returns the syscall error so the caller can surface it.
+//
+// args is forwarded verbatim, so the child sees the same os.Args[0]
+// the user typed (often a full path like /usr/local/bin/crdb-sql,
+// not the bare string "crdb-sql"). This is fine because the child's
+// quarterFromExecutable consults os.Executable() — the real on-disk
+// sibling path — not argv[0]. A renamed-on-disk parent therefore
+// cannot induce a wrong-quarter exec loop.
+func execBackend(path string, args []string) error {
+	return syscall.Exec(path, args, os.Environ())
+}

--- a/internal/versionroute/route_windows.go
+++ b/internal/versionroute/route_windows.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build windows
+
+package versionroute
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// execBackend runs the backend at path as a child process and exits
+// the current process with the child's exit code. Windows lacks an
+// equivalent of POSIX execve, so we cannot truly replace this process
+// — the cost is one extra process in the chain, which is invisible to
+// most callers.
+//
+// stdio and environment are inherited. Parent-side signal forwarding
+// is not implemented (Go's os/exec does not propagate signals
+// received by the parent to the child). On Windows interactive
+// console use, Ctrl-C/Ctrl-Break reaches the child via the shared
+// console group, so terminal users see the expected behavior; signals
+// dispatched programmatically to the parent are not relayed.
+//
+// The args[1:] slice is forwarded (Cmd injects its own argv[0] from
+// path), so the child's os.Args[0] is the backend's real path rather
+// than the parent's argv[0]. The child's quarterFromExecutable
+// consults os.Executable() so this distinction does not affect
+// routing.
+func execBackend(path string, args []string) error {
+	cmd := exec.Command(path, args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	err := cmd.Run()
+	if err == nil {
+		os.Exit(0)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(exitErr.ExitCode())
+	}
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -17,9 +17,16 @@ import (
 	"github.com/spilchen/sql-ai-tools/cmd"
 	"github.com/spilchen/sql-ai-tools/internal/builtinstubs"
 	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
 )
 
 func main() {
+	// Routing must happen before any work that depends on the parser
+	// version (builtin registration, cobra wiring). When --target-version
+	// requests a different Year.Quarter than this binary was built
+	// against, MaybeReexec replaces the process with the matching
+	// crdb-sql-vXXX sibling and never returns.
+	versionroute.MaybeReexec()
 	builtinstubs.Init("")
 	if err := cmd.Execute(); err != nil {
 		// cmd.Execute() suppresses cobra's own error printing

--- a/scripts/check-binary-size.sh
+++ b/scripts/check-binary-size.sh
@@ -60,7 +60,12 @@ find_out=$(mktemp) || { echo "::error::failed to create temp file for find outpu
 trap 'rm -f "$find_errs" "$find_out"' EXIT INT TERM
 
 find_rc=0
-find -L dist -mindepth 2 -maxdepth 2 -type f -name crdb-sql >"$find_out" 2>"$find_errs" || find_rc=$?
+# Match both the unsuffixed latest binary (`crdb-sql`) and any
+# per-quarter sibling (`crdb-sql-v251`, `crdb-sql-v262`, ...). Each
+# backend ships independently and must individually fit under the cap;
+# the multi-version distribution accepts a larger archive in aggregate
+# but never a single bloated binary.
+find -L dist -mindepth 2 -maxdepth 2 -type f \( -name crdb-sql -o -name 'crdb-sql-v*' \) >"$find_out" 2>"$find_errs" || find_rc=$?
 if [ "$find_rc" -ne 0 ]; then
   echo "::error::find failed (exit $find_rc) while enumerating dist/:"
   cat "$find_errs"


### PR DESCRIPTION
CockroachDB releases are quarterly (Year.Quarter.Patch); parser
behavior can change between quarters. Until now crdb-sql shipped one
binary built against the latest parser, so --target-version was only
advisory — the bundled parser always handled the SQL regardless of
which cluster the user targeted, sometimes accepting syntax the older
cluster would reject.

Add the routing infrastructure for shipping per-quarter siblings
(crdb-sql-v251, crdb-sql-v262, ...) alongside the latest binary. The
unsuffixed crdb-sql remains the lazy-install path: download one file,
get latest. When --target-version requests a different Year.Quarter
than the running binary, the new internal/versionroute package
locates the matching sibling on disk ($PATH or executable's
directory) and re-execs into it (syscall.Exec on Unix, spawn-then-
exit on Windows). A missing sibling is a hard error with a discovery
hint — silent fallback to the wrong parser is exactly the bug this
layer prevents.

The Quarter the binary represents is resolved from the executable's
filename first (crdb-sql-vXXX is authoritative), then the build-time
ldflag stamp (set by `make build` and `make build-vXXX`), then a
debug.BuildInfo fallback inferring from the parser fork's tag
convention. Filename-first prevents an exec loop when a renamed copy
sits at a name that disagrees with its compiled stamp.

A new `crdb-sql versions` subcommand surfaces the discovery walk so
users can confirm what's installed before invoking --target-version.

This commit lands the infrastructure and the latest (v262) backend
only. Adding older quarters is one issue per quarter — see #122 for
the v261 follow-on. The full new-quarter checklist is in
docs/version-selection.md.

Resolves: #85