### PR TITLE
simulate: add EXPLAIN-based simulate_sql for side-effect-free what-if

### DIFF
--- a/cmd/explain_ddl.go
+++ b/cmd/explain_ddl.go
@@ -36,7 +36,7 @@ import (
 // declarative schema changer to compile a plan — and the safety
 // allowlist still gates the call: in the default read_only mode every
 // DDL is rejected (since DDL modifies schema), so users must escalate
-// to --mode=safe_write or --mode=full_access (issues #28/#29) to
+// to --mode=safe_write or --mode=full_access (issue #29) to
 // exercise this command.
 func newExplainDDLCmd(state *rootState) *cobra.Command {
 	var (
@@ -57,7 +57,7 @@ connection string is read from --dsn or CRDB_DSN (flag wins).
 The --mode flag selects the safety policy applied before the cluster
 call. The default "read_only" rejects every DDL (since DDL modifies
 schema), so this command requires --mode=safe_write or
---mode=full_access — both reserved for follow-up issues #28 and #29
+--mode=full_access — both reserved for follow-up issue #29
 and currently rejected with a "not yet implemented" violation.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,6 +151,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newSummarizeCmd(state))
 	root.AddCommand(newExplainCmd(state))
 	root.AddCommand(newExplainDDLCmd(state))
+	root.AddCommand(newSimulateCmd(state))
 	root.AddCommand(newMCPCmd(state))
 	return root
 }

--- a/cmd/simulate.go
+++ b/cmd/simulate.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// newSimulateCmd builds the `crdb-sql simulate` subcommand. It
+// dispatches each parsed statement to the appropriate non-executing
+// EXPLAIN flavor and renders the per-statement outcomes:
+//
+//   - SELECT (and other read-only DML) → EXPLAIN ANALYZE; runtime
+//     stats are real because SELECT has no side effects.
+//   - INSERT/UPDATE/DELETE/UPSERT → plain EXPLAIN; planner estimates
+//     only, no execution, no leaked writes.
+//   - DDL → EXPLAIN (DDL, SHAPE) plus a SHOW STATISTICS row-count
+//     annotation per affected table; the schema changer compiles a
+//     plan but does not apply it.
+//
+// Tier 3 (connected). The safety allowlist (internal/safety) admits
+// every dispatchable statement under the default read_only mode —
+// the dispatcher itself is the safety boundary, since none of the
+// chosen EXPLAIN flavors execute the inner write or DDL at the
+// cluster level. Statement classes the dispatcher has no route for
+// (TCL, DCL, nested EXPLAIN) are rejected by the allowlist before
+// any cluster contact.
+func newSimulateCmd(state *rootState) *cobra.Command {
+	var (
+		expr    string
+		mode    string
+		timeout time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "simulate [file]",
+		Short: "Simulate one or more SQL statements via EXPLAIN flavors that do not execute",
+		Long: `Connect to a CockroachDB cluster and simulate the supplied SQL by
+dispatching each statement to a non-executing EXPLAIN flavor:
+
+  - SELECT runs through EXPLAIN ANALYZE (real runtime stats; reads
+    have no side effects).
+  - INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN (planner
+    estimates only — the write is never applied).
+  - DDL runs through EXPLAIN (DDL, SHAPE) plus SHOW STATISTICS for
+    each affected table (the schema change is planned but not
+    applied).
+
+Input is read from the -e flag (inline SQL), a positional file
+argument, or stdin. Multi-statement input returns one entry per
+statement in the order parsed. The connection string is read from
+--dsn or CRDB_DSN (flag wins).
+
+Because no flavor executes the inner write or DDL at the cluster
+level, the default --mode=read_only admits every dispatched class.
+Statement types with no EXPLAIN form (BEGIN/COMMIT, GRANT/REVOKE)
+are rejected before any cluster contact.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			sql = strings.TrimSpace(sql)
+
+			if state.dsn == "" {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
+			}
+
+			parsedMode, err := safety.ParseMode(mode)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			// Safety check runs before any cluster contact: a
+			// rejection produces a structured envelope with
+			// connection_status=disconnected, exactly as if --dsn
+			// were missing. Parse errors propagate as parse
+			// diagnostics so the agent sees the SQLSTATE-tagged
+			// syntax message rather than a misleading safety
+			// violation.
+			violation, err := safety.Check(parsedMode, safety.OpSimulate, sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+			}
+			if violation != nil {
+				return r.RenderErrorEntry(baseEnv,
+					fmt.Errorf("safety violation: %s", violation.Reason),
+					safety.Envelope(violation))
+			}
+
+			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
+			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
+
+			result, err := mgr.Simulate(cmd.Context(), sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
+			}
+
+			baseEnv.ConnectionStatus = output.ConnectionConnected
+
+			data, err := json.Marshal(result)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			// Surface step-level failures (plan errors and stats
+			// errors alike) as a single envelope warning so JSON
+			// consumers that read only the top-level errors[] see
+			// the partial failure, and so the CLI returns a non-zero
+			// exit. The text/JSON body must still render the per-step
+			// data — we want the agent to see WHICH step failed and
+			// which steps succeeded, not just a summary. Following
+			// the renderValidateFailure pattern in cmd/validate.go:
+			// append to env.Errors, render the body normally, then
+			// return ErrRendered so main.go signals failure without
+			// reprinting the error.
+			if entry, ok := simulateStepWarning(result); ok {
+				baseEnv.Errors = append(baseEnv.Errors, entry)
+				if err := r.Render(baseEnv, func(w io.Writer) error {
+					return renderSimulateText(w, result)
+				}); err != nil {
+					return err
+				}
+				return output.ErrRendered
+			}
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				return renderSimulateText(w, result)
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to simulate")
+	cmd.Flags().StringVar(&mode, "mode", string(safety.DefaultMode),
+		"safety mode: read_only (default), safe_write, full_access")
+	cmd.Flags().DurationVar(&timeout, "timeout", conn.DefaultStatementTimeout,
+		"statement timeout for each wrapped EXPLAIN call")
+
+	return cmd
+}
+
+// renderSimulateText renders a SimulateResult for --output=text.
+// Each step is preceded by a one-line header naming the strategy
+// and statement tag so a multi-statement output stays
+// human-readable; the body reuses the EXPLAIN/EXPLAIN (DDL, SHAPE)
+// raw text the cluster returned, matching what `cockroach sql`
+// would print. Plan errors short-circuit the body. Stats errors
+// (DDL plan succeeded but SHOW STATISTICS failed for one or more
+// targets) are surfaced after the plan so the operator still sees
+// the schema-change steps the simulation produced.
+func renderSimulateText(w io.Writer, result conn.SimulateResult) error {
+	for i, step := range result.Steps {
+		if i > 0 {
+			if _, err := io.WriteString(w, "\n"); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "-- step %d: %s (%s)\n",
+			step.StatementIndex, step.Tag, step.Strategy); err != nil {
+			return err
+		}
+		if step.Error != "" {
+			if _, err := fmt.Fprintf(w, "error: %s\n", step.Error); err != nil {
+				return err
+			}
+			continue
+		}
+		switch step.Strategy {
+		case conn.StrategyExplainDDL:
+			if step.DDLPlan != nil {
+				if _, err := io.WriteString(w, step.DDLPlan.RawText); err != nil {
+					return err
+				}
+				if !strings.HasSuffix(step.DDLPlan.RawText, "\n") {
+					if _, err := io.WriteString(w, "\n"); err != nil {
+						return err
+					}
+				}
+			}
+			for _, ts := range step.TableStats {
+				if ts.CollectedAt == "" {
+					// No stats have been collected for this target
+					// yet (typically a freshly created table). The
+					// row_count field is the zero value; render it
+					// as "unavailable" rather than "0" so a fresh
+					// table is not mistaken for an empty one.
+					if _, err := fmt.Fprintf(w,
+						"-- table stats: %s.%s row_count=unavailable\n",
+						ts.Schema, ts.Table); err != nil {
+						return err
+					}
+					continue
+				}
+				if _, err := fmt.Fprintf(w,
+					"-- table stats: %s.%s row_count=%d (collected %s)\n",
+					ts.Schema, ts.Table, ts.RowCount, ts.CollectedAt); err != nil {
+					return err
+				}
+			}
+			if step.StatsError != "" {
+				if _, err := fmt.Fprintf(w,
+					"-- table stats error: %s\n", step.StatsError); err != nil {
+					return err
+				}
+			}
+		default:
+			if step.Plan != nil {
+				for _, row := range step.Plan.RawRows {
+					if _, err := fmt.Fprintln(w, row); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// simulateStepWarning summarises per-step failures into a single
+// envelope error entry. Returns ok=false when every step succeeded;
+// otherwise builds a `simulate_step_failure` entry whose message
+// names which step indices failed and how, and whose Context carries
+// the index slices as machine-readable lists. Used by both the CLI
+// (to drive a non-zero exit) and the MCP handler (to populate
+// env.Errors so agents reading the standard envelope contract see
+// the failure).
+//
+// The Context fields let an agent retry only the failed steps
+// without parsing the human-readable message — important because
+// the message format can shift across versions, but the field
+// names ("plan_failed_steps", "stats_failed_steps") are part of
+// the wire contract.
+func simulateStepWarning(result conn.SimulateResult) (output.Error, bool) {
+	msg, planFails, statsFails, ok := result.StepFailureSummary()
+	if !ok {
+		return output.Error{}, false
+	}
+	ctx := make(map[string]any, 2)
+	if len(planFails) > 0 {
+		ctx["plan_failed_steps"] = planFails
+	}
+	if len(statsFails) > 0 {
+		ctx["stats_failed_steps"] = statsFails
+	}
+	return output.Error{
+		Code:     "simulate_step_failure",
+		Severity: output.SeverityError,
+		Message:  msg,
+		Category: "simulate",
+		Context:  ctx,
+	}, true
+}

--- a/cmd/simulate_test.go
+++ b/cmd/simulate_test.go
@@ -1,0 +1,382 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// runSimulate executes `crdb-sql simulate` with the supplied args and
+// stdin, returning the captured stdout buffer and the Execute error.
+func runSimulate(t *testing.T, stdin string, args ...string) (*bytes.Buffer, error) {
+	t.Helper()
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(append([]string{"simulate"}, args...))
+	return &stdout, root.Execute()
+}
+
+// TestSimulateCmdNoDSN verifies the same DSN-required contract the
+// other Tier 3 commands honour: missing --dsn / CRDB_DSN fails
+// before any cluster contact.
+func TestSimulateCmdNoDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	_, err := runSimulate(t, "", "-e", "SELECT 1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no connection string")
+}
+
+// TestSimulateCmdSafetyRejectionTCL pins that the OpSimulate
+// allowlist rejects TCL/DCL/nested EXPLAIN before any cluster
+// contact. A nonworking DSN guarantees that any regression which
+// stops short-circuiting will surface as a connect error rather
+// than the safety_violation we expect.
+func TestSimulateCmdSafetyRejectionTCL(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		expectedTag string
+	}{
+		{name: "begin rejected", sql: "BEGIN", expectedTag: "BEGIN"},
+		{name: "commit rejected", sql: "COMMIT", expectedTag: "COMMIT"},
+		{name: "grant rejected", sql: "GRANT SELECT ON t TO bob", expectedTag: "GRANT"},
+		{name: "nested explain rejected", sql: "EXPLAIN SELECT 1", expectedTag: "EXPLAIN"},
+		{name: "nested explain analyze rejected", sql: "EXPLAIN ANALYZE INSERT INTO t VALUES (1)", expectedTag: "EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRDB_DSN", "")
+			stdout, err := runSimulate(t, "", "--output", "json",
+				"--dsn", "postgres://nope:1/db?connect_timeout=1",
+				"-e", tc.sql)
+			require.ErrorIs(t, err, output.ErrRendered)
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+				"safety rejection must short-circuit before any cluster contact")
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, "read_only", env.Errors[0].Context["mode"])
+			require.Equal(t, "simulate", env.Errors[0].Context["operation"])
+		})
+	}
+}
+
+// TestSimulateCmdAdmitsDispatchableShapes pins the inverse of the
+// rejection test: SELECT, DML writes, and DDL all pass the safety
+// gate and reach the connect step, even under the default
+// read_only mode. A regression that tightens the OpSimulate rule
+// would surface here as a safety_violation rather than the
+// expected connect error.
+func TestSimulateCmdAdmitsDispatchableShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "select admitted", sql: "SELECT 1"},
+		{name: "insert admitted", sql: "INSERT INTO t VALUES (1)"},
+		{name: "update admitted", sql: "UPDATE t SET x = 1 WHERE id = 1"},
+		{name: "delete admitted", sql: "DELETE FROM t WHERE id = 1"},
+		{name: "alter table admitted", sql: "ALTER TABLE t ADD COLUMN x INT"},
+		{name: "create index admitted", sql: "CREATE INDEX i ON t (c)"},
+		{name: "drop table admitted", sql: "DROP TABLE t"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRDB_DSN", "")
+			stdout, err := runSimulate(t, "", "--output", "json",
+				"--dsn", "postgres://flaghost:26257/defaultdb?connect_timeout=1",
+				"-e", tc.sql)
+			require.ErrorIs(t, err, output.ErrRendered)
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+			require.Len(t, env.Errors, 1)
+			require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+				"dispatchable shape must reach the connect step under read_only mode")
+		})
+	}
+}
+
+// TestSimulateCmdInvalidMode mirrors TestExplainCmdInvalidMode: an
+// unknown --mode value must be rejected with the actionable
+// "invalid safety mode" message before any input reading or
+// cluster contact.
+func TestSimulateCmdInvalidMode(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runSimulate(t, "", "--output", "json",
+		"--mode", "yolo",
+		"-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "invalid safety mode")
+}
+
+// TestSimulateCmdRejectsExtraArgs verifies the cobra arg ceiling.
+func TestSimulateCmdRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"simulate", "file1.sql", "file2.sql"})
+
+	err := root.Execute()
+	require.Error(t, err)
+}
+
+// TestRenderSimulateTextDDLWithStatsError pins the renderer's
+// load-bearing partial-failure contract: when a DDL plan succeeded
+// but stats lookup failed, the plan body and table-stats line for
+// successful targets must still appear, followed by a clearly
+// labelled "table stats error" line. Earlier behaviour set
+// step.Error on stats failure, which made the renderer suppress
+// the plan entirely — directly contradicting the documented
+// "best-effort, plan stays visible" contract.
+func TestRenderSimulateTextDDLWithStatsError(t *testing.T) {
+	var buf bytes.Buffer
+	result := conn.SimulateResult{Steps: []conn.SimulateStep{{
+		StatementIndex: 0,
+		Tag:            "ALTER TABLE",
+		Strategy:       conn.StrategyExplainDDL,
+		SQL:            "ALTER TABLE users ADD COLUMN x INT",
+		DDLPlan: &conn.DDLExplainResult{
+			Statement: "ALTER TABLE users ADD COLUMN x INT",
+			RawText:   "Schema change plan:\n  ├── BackfillIndex\n",
+		},
+		TableStats: []conn.TableStat{{
+			Schema: "public", Table: "users",
+			RowCount: 1234, Source: "show_statistics",
+			CollectedAt: "2026-04-22 12:00:00",
+		}},
+		StatsError: "public.other: connection reset",
+	}}}
+
+	require.NoError(t, renderSimulateText(&buf, result))
+	out := buf.String()
+	require.Contains(t, out, "BackfillIndex", "DDL plan body must survive a stats failure")
+	require.Contains(t, out, "row_count=1234", "successful stats line must still render")
+	require.Contains(t, out, "table stats error: public.other: connection reset")
+}
+
+// TestRenderSimulateTextNoStatsRendersUnavailable pins the
+// "RowCount=0 from a no-stats sentinel must not look like a real
+// zero" contract. A freshly created table returns
+// CollectedAt=="" — the renderer must show "unavailable" rather
+// than printing row_count=0 indistinguishable from an empty table.
+func TestRenderSimulateTextNoStatsRendersUnavailable(t *testing.T) {
+	var buf bytes.Buffer
+	result := conn.SimulateResult{Steps: []conn.SimulateStep{{
+		StatementIndex: 0,
+		Tag:            "ALTER TABLE",
+		Strategy:       conn.StrategyExplainDDL,
+		DDLPlan:        &conn.DDLExplainResult{RawText: "ok\n"},
+		TableStats: []conn.TableStat{{
+			Schema: "public", Table: "fresh",
+			Source: "show_statistics",
+			// CollectedAt deliberately empty.
+		}},
+	}}}
+
+	require.NoError(t, renderSimulateText(&buf, result))
+	require.Contains(t, buf.String(), "row_count=unavailable")
+	require.NotContains(t, buf.String(), "row_count=0",
+		"no-stats sentinel must not be rendered as a real zero")
+}
+
+// TestRenderSimulateTextPlanError verifies the plan-error path
+// short-circuits the body but still emits the per-step header so
+// multi-statement output stays readable.
+func TestRenderSimulateTextPlanError(t *testing.T) {
+	var buf bytes.Buffer
+	result := conn.SimulateResult{Steps: []conn.SimulateStep{
+		{
+			StatementIndex: 0, Tag: "SELECT", Strategy: conn.StrategyExplainAnalyze,
+			Plan: &conn.ExplainResult{RawRows: []string{"distribution: full", "scan", "  table: t@primary"}},
+		},
+		{
+			StatementIndex: 1, Tag: "INSERT", Strategy: conn.StrategyExplain,
+			Error: "table \"missing\" does not exist",
+		},
+	}}
+
+	require.NoError(t, renderSimulateText(&buf, result))
+	out := buf.String()
+	require.Contains(t, out, "step 0: SELECT (explain_analyze)")
+	require.Contains(t, out, "step 1: INSERT (explain)")
+	require.Contains(t, out, "error: table \"missing\" does not exist")
+	require.Contains(t, out, "table: t@primary", "successful step body must still render")
+}
+
+// TestSimulateStepWarningSurfacesEnvelopeError pins that
+// per-step failures are promoted to an envelope-level error so
+// JSON consumers reading only top-level errors[] see the partial
+// failure. Without this aggregation, an agent would have to walk
+// data.steps manually to detect "this simulation partly failed."
+// The Context fields carry index slices so an agent can retry only
+// the failed steps without parsing the human-readable message.
+func TestSimulateStepWarningSurfacesEnvelopeError(t *testing.T) {
+	tests := []struct {
+		name              string
+		steps             []conn.SimulateStep
+		expectedOK        bool
+		expectedMsg       string
+		expectedPlanIdx   []int
+		expectedStatsIdx  []int
+		expectPlanCtxKey  bool
+		expectStatsCtxKey bool
+	}{
+		{
+			name: "all success returns no warning",
+			steps: []conn.SimulateStep{
+				{StatementIndex: 0, Tag: "SELECT", Strategy: conn.StrategyExplainAnalyze},
+			},
+			expectedOK: false,
+		},
+		{
+			name: "plan failure stamps plan_failed_steps context",
+			steps: []conn.SimulateStep{
+				{StatementIndex: 0, Tag: "INSERT", Strategy: conn.StrategyExplain, Error: "boom"},
+			},
+			expectedOK:       true,
+			expectedMsg:      "1 plan error(s)",
+			expectedPlanIdx:  []int{0},
+			expectPlanCtxKey: true,
+		},
+		{
+			name: "stats failure stamps stats_failed_steps context",
+			steps: []conn.SimulateStep{
+				{StatementIndex: 0, Tag: "ALTER TABLE", Strategy: conn.StrategyExplainDDL, StatsError: "x"},
+			},
+			expectedOK:        true,
+			expectedMsg:       "1 stats error(s)",
+			expectedStatsIdx:  []int{0},
+			expectStatsCtxKey: true,
+		},
+		{
+			name: "mixed failures stamp both context keys",
+			steps: []conn.SimulateStep{
+				{StatementIndex: 0, Tag: "INSERT", Strategy: conn.StrategyExplain, Error: "boom"},
+				{StatementIndex: 1, Tag: "ALTER TABLE", Strategy: conn.StrategyExplainDDL, StatsError: "x"},
+			},
+			expectedOK:        true,
+			expectedPlanIdx:   []int{0},
+			expectedStatsIdx:  []int{1},
+			expectPlanCtxKey:  true,
+			expectStatsCtxKey: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry, ok := simulateStepWarning(conn.SimulateResult{Steps: tc.steps})
+			require.Equal(t, tc.expectedOK, ok)
+			if !tc.expectedOK {
+				return
+			}
+			require.Equal(t, "simulate_step_failure", entry.Code)
+			require.Equal(t, "simulate", entry.Category)
+			if tc.expectedMsg != "" {
+				require.Contains(t, entry.Message, tc.expectedMsg)
+			}
+			if tc.expectPlanCtxKey {
+				require.Equal(t, tc.expectedPlanIdx, entry.Context["plan_failed_steps"])
+			} else {
+				require.NotContains(t, entry.Context, "plan_failed_steps")
+			}
+			if tc.expectStatsCtxKey {
+				require.Equal(t, tc.expectedStatsIdx, entry.Context["stats_failed_steps"])
+			} else {
+				require.NotContains(t, entry.Context, "stats_failed_steps")
+			}
+		})
+	}
+}
+
+// TestSimulateCmdPartialFailurePreservesData pins the load-bearing
+// data-preservation contract for the CLI: when a multi-statement
+// simulation has one failed step among several successes, the JSON
+// envelope MUST keep data.steps populated so the agent can see
+// every plan that did succeed and the per-step error for the one
+// that didn't. Earlier behaviour routed through RenderErrorEntry,
+// which nils env.Data — wiping exactly the data we asked the agent
+// to inspect. The fix follows the renderValidateFailure pattern in
+// cmd/validate.go.
+//
+// We exercise this via the dispatcher's "no route" branch (TCL),
+// which reaches the connect step and produces a per-step error
+// without needing a real cluster. With a multi-statement input
+// where step 0 reaches connect (which fails fast on the unreachable
+// DSN), this path doesn't actually exercise the no-route branch
+// alone — so we use a unit-level test by constructing a stub
+// SimulateResult and rendering directly via renderSimulateText
+// plus the simulateStepWarning helper, mirroring what RunE does.
+func TestSimulateCmdPartialFailurePreservesData(t *testing.T) {
+	// Stub a SimulateResult that includes both a successful step
+	// and a failed step — exactly the shape RunE produces in
+	// production for a real multi-statement batch with one mid-
+	// failure. The assertion below verifies env.Data survives
+	// alongside the simulate_step_failure entry.
+	result := conn.SimulateResult{Steps: []conn.SimulateStep{
+		{
+			StatementIndex: 0, Tag: "SELECT", Strategy: conn.StrategyExplainAnalyze,
+			Plan: &conn.ExplainResult{RawRows: []string{"distribution: full", "scan"}},
+		},
+		{
+			StatementIndex: 1, Tag: "INSERT", Strategy: conn.StrategyExplain,
+			Error: "table \"missing\" does not exist",
+		},
+	}}
+
+	// Reproduce the RunE flow shape: marshal data, then surface
+	// step warnings without calling RenderErrorEntry (which would
+	// nil env.Data).
+	data, err := json.Marshal(result)
+	require.NoError(t, err)
+
+	env := output.Envelope{
+		Tier:             output.TierConnected,
+		ConnectionStatus: output.ConnectionConnected,
+		Data:             data,
+	}
+	if entry, ok := simulateStepWarning(result); ok {
+		env.Errors = append(env.Errors, entry)
+	}
+
+	// The envelope MUST carry both the per-step data and the
+	// aggregated failure entry. Either being missing is a
+	// regression of the iter-2 critical fix.
+	require.NotEmpty(t, env.Data, "data must survive partial failure")
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "simulate_step_failure", env.Errors[0].Code)
+	require.Equal(t, []int{1}, env.Errors[0].Context["plan_failed_steps"])
+
+	// Round-trip the envelope through JSON and confirm steps[]
+	// remains parseable on the wire.
+	body, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"steps"`)
+	require.Contains(t, string(body), `"distribution: full"`,
+		"successful step's plan body must survive in the JSON envelope")
+}

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -111,7 +111,7 @@ simulate → execute.
 | `explain_sql` | SQL string | EXPLAIN output as structured JSON | 3 |
 | `explain_schema_change` | DDL string | Schema changer plan with phases, elements, operations | 3 |
 | `detect_risky_query` | SQL string | Risk assessment with reason codes, severity, fix hints | 1-3 |
-| `simulate_sql` | SQL string | Query results without side effects (txn+rollback) | 3 |
+| `simulate_sql` | SQL string | Per-statement EXPLAIN-based simulation (ANALYZE for SELECT, plain EXPLAIN for DML writes, EXPLAIN (DDL, SHAPE) + table stats for DDL); no inner statement is executed at the cluster level | 3 |
 | `execute_sql` | SQL string | Query results with safety guardrails | 3 |
 
 **CLI** (mirrors MCP tools):
@@ -627,17 +627,37 @@ the pragmatic alternative.
 
 ### Simulation Layer
 
-EXPLAIN ANALYZE (NO_WRITE) for execute-without-side-effects. Two
-implementation paths:
+`simulate_sql` (issue #28, shipped) takes a per-statement
+EXPLAIN-based dispatcher rather than the txn+rollback wrapper that
+issue #28 originally proposed. The dispatcher routes each parsed
+statement to a non-executing EXPLAIN flavor:
 
-- **(A) Transaction+rollback wrapper**: Execute the query in a transaction,
-  capture results, then ROLLBACK. Simple to implement. Leaks: sequence
-  increments, volatile function side effects, audit triggers.
-- **(B) No-commit execution mode**: A new CRDB execution mode that runs the
-  query with full semantics but never commits. Cleaner, but requires CRDB
-  server changes.
+- SELECT (and other read-only DML) → `EXPLAIN ANALYZE` inside a
+  read-only txn. ANALYZE physically executes the inner statement, but
+  SELECT has no side effects, so the runtime stats (rows read,
+  network bytes, time) come back without persisting anything.
+- INSERT/UPDATE/DELETE/UPSERT → plain `EXPLAIN`. Returns the
+  optimizer's estimated plan only — the write is never applied. We
+  trade measured stats for honest safety here.
+- DDL → `EXPLAIN (DDL, SHAPE)` plus `SHOW STATISTICS` for each
+  affected table. The declarative schema changer compiles a plan
+  without applying it; the row-count annotation gives the agent a
+  rough handle on backfill cost.
 
-Option A is sufficient for the near term. Option B is cleaner for production.
+This sidesteps the side-effect leaks the txn+rollback approach
+cannot prevent (sequence increments, volatile function side effects,
+audit triggers, INSERT-into-CDC) because none of the EXPLAIN flavors
+execute the inner write at the cluster level.
+
+For the cases where measured stats on a write would be valuable, two
+longer-term options remain on the table:
+
+- **Transaction+rollback wrapper for writes**: revisit only if a
+  user explicitly asks for ANALYZE-quality stats on DML and accepts
+  the leak surface.
+- **No-commit execution mode**: a new CRDB execution mode that runs
+  the query with full semantics but never commits. Cleanest answer,
+  but requires CRDB server changes.
 
 ### Schema Change Simulation
 

--- a/internal/conn/simulate.go
+++ b/internal/conn/simulate.go
@@ -1,0 +1,506 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/jackc/pgx/v5"
+)
+
+// Strategy names the EXPLAIN flavor a SimulateStep used to render its
+// no-execute view of a single statement. The values are wire-stable
+// tokens — agents branch on them to decide which payload field to
+// read (Plan vs DDLPlan) and how to interpret the numbers (estimates
+// vs measured stats).
+type Strategy string
+
+// Strategy values.
+const (
+	// StrategyExplainAnalyze runs `EXPLAIN ANALYZE <stmt>`. Used for
+	// SELECT, where actual execution is harmless and the runtime
+	// stats (rows read, network bytes, time) are far more useful
+	// than the optimizer's estimates.
+	StrategyExplainAnalyze Strategy = "explain_analyze"
+
+	// StrategyExplain runs plain `EXPLAIN <stmt>`. Used for DML
+	// writes (INSERT/UPDATE/DELETE/UPSERT) where ANALYZE would
+	// persist data. Returns the optimizer's estimated plan only —
+	// no execution, no side effects.
+	StrategyExplain Strategy = "explain"
+
+	// StrategyExplainDDL runs `EXPLAIN (DDL, SHAPE) <stmt>`. Used
+	// for DDL. Returns the declarative schema changer's compiled
+	// plan; the cluster does not execute the schema change.
+	StrategyExplainDDL Strategy = "explain_ddl"
+)
+
+// SimulateResult is the JSON-serialisable payload returned by
+// Manager.Simulate. One Steps entry per parsed statement, in
+// statement order. Errors that scope to a single statement live on
+// the step (Step.Error / Step.StatsError); any failure that aborts
+// the whole simulation (parse error, connect error) is returned as
+// the method-level error instead.
+type SimulateResult struct {
+	Steps []SimulateStep `json:"steps"`
+}
+
+// StepFailureSummary scans every Step and returns a one-line
+// summary of any per-step failures plus the indices that carried
+// each failure class. Returns ok=false when every step succeeded
+// — both surfaces (CLI and MCP) use that to decide whether to
+// promote the failure into an envelope-level entry. Keeping the
+// summary close to the data types means new step-level error
+// classes can be added in one place rather than duplicated across
+// surfaces.
+func (r SimulateResult) StepFailureSummary() (msg string, planFails, statsFails []int, ok bool) {
+	for _, step := range r.Steps {
+		if step.Error != "" {
+			planFails = append(planFails, step.StatementIndex)
+		}
+		if step.StatsError != "" {
+			statsFails = append(statsFails, step.StatementIndex)
+		}
+	}
+	if len(planFails) == 0 && len(statsFails) == 0 {
+		return "", nil, nil, false
+	}
+	parts := make([]string, 0, 2)
+	if len(planFails) > 0 {
+		parts = append(parts, fmt.Sprintf("%d plan error(s) at step(s) %v", len(planFails), planFails))
+	}
+	if len(statsFails) > 0 {
+		parts = append(parts, fmt.Sprintf("%d stats error(s) at step(s) %v", len(statsFails), statsFails))
+	}
+	return strings.Join(parts, "; ") + " (see data.steps for per-step detail)",
+		planFails, statsFails, true
+}
+
+// SimulateStep records the simulated outcome for a single statement.
+// Exactly one of Plan / DDLPlan is non-nil on success, selected by
+// Strategy:
+//
+//	explain_analyze | explain → Plan is set, DDLPlan is nil.
+//	explain_ddl              → DDLPlan is set, Plan is nil.
+//
+// On a plan failure (cluster rejected EXPLAIN, statement timeout,
+// connection drop after the dispatch began), Plan and DDLPlan are
+// both nil and Error carries the message. On a stats-only failure
+// (DDL plan succeeded but SHOW STATISTICS errored for one of the
+// affected tables), DDLPlan stays populated and StatsError carries
+// the lookup failure — keeping Error reserved for plan-blocking
+// problems lets renderers surface the plan and the stats failure
+// independently. Subsequent steps still run regardless of which
+// field is set; failures do not abort the simulation.
+type SimulateStep struct {
+	StatementIndex int      `json:"statement_index"`
+	Tag            string   `json:"tag"`
+	Strategy       Strategy `json:"strategy"`
+	SQL            string   `json:"sql"`
+
+	Plan       *ExplainResult    `json:"plan,omitempty"`
+	DDLPlan    *DDLExplainResult `json:"ddl_plan,omitempty"`
+	TableStats []TableStat       `json:"table_stats,omitempty"`
+
+	Error      string `json:"error,omitempty"`
+	StatsError string `json:"stats_error,omitempty"`
+}
+
+// TableStat is a row-count estimate for a table touched by a
+// simulated DDL. Sourced from `SHOW STATISTICS` (auto-collected by
+// CRDB), so the numbers reflect the most recent stats refresh rather
+// than a live count. CollectedAt lets callers reason about
+// staleness; an empty CollectedAt means stats have never been
+// collected for this table — RowCount in that case is the zero
+// value and is not meaningful.
+//
+// The slice on SimulateStep is omitted from the JSON payload (via
+// `omitempty`) when the DDL has no extractable target table or when
+// stats lookup failed for every target. Callers should treat both
+// "absent slice" and "non-empty slice with empty CollectedAt" as
+// "no information available," not as "row count = 0".
+type TableStat struct {
+	Schema      string `json:"schema"`
+	Table       string `json:"table"`
+	RowCount    int64  `json:"row_count"`
+	Source      string `json:"source"`
+	CollectedAt string `json:"collected_at,omitempty"`
+}
+
+// Simulate parses sql, dispatches each statement to the appropriate
+// non-executing EXPLAIN flavor, and returns the per-statement
+// outcomes. The dispatcher is what makes simulate side-effect free
+// at the cluster level: SELECT runs through EXPLAIN ANALYZE (read
+// only by construction), DML writes through plain EXPLAIN (no
+// execution), and DDL through EXPLAIN (DDL, SHAPE) (no execution
+// plus an optional row-count annotation from SHOW STATISTICS).
+//
+// Per-statement errors land on the step rather than the method:
+// plan failures populate step.Error, stats-only failures populate
+// step.StatsError. Subsequent steps still run regardless. Errors
+// that abort the whole call (parse failure, initial connect) are
+// returned as the method-level error.
+//
+// Caller contract: safety.Check(safety.OpSimulate, ...) must have
+// been called before Simulate. Simulate does not re-validate
+// statement classes. nested EXPLAIN must be rejected upstream
+// because tree.CanWriteData does not descend into Explain wrappers
+// — the dispatcher would misclassify a wrapped write as a SELECT
+// and route it to EXPLAIN ANALYZE. TCL and DCL would surface as a
+// per-step "no route" error in the default branch, which is
+// actionable but not the intended path. Callers must walk Steps for
+// per-step Error/StatsError values; a nil method-level error does
+// not mean every statement succeeded.
+func (m *Manager) Simulate(ctx context.Context, sql string) (SimulateResult, error) {
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return SimulateResult{}, fmt.Errorf("parse simulate input: %w", err)
+	}
+	if len(stmts) == 0 {
+		return SimulateResult{}, errors.New("no statements parsed")
+	}
+	// Fail fast on connect: a per-statement loop that re-dials on
+	// every step would record the same connect error N times. The
+	// caller wants one method-level error, rendered the same way as
+	// any other Tier 3 connect failure.
+	if err := m.connect(ctx); err != nil {
+		return SimulateResult{}, err
+	}
+
+	steps := make([]SimulateStep, 0, len(stmts))
+	for i, s := range stmts {
+		step := SimulateStep{
+			StatementIndex: i,
+			Tag:            s.AST.StatementTag(),
+			SQL:            s.SQL,
+		}
+		m.dispatchSimulateStep(ctx, s.AST, s.SQL, &step)
+		steps = append(steps, step)
+	}
+	return SimulateResult{Steps: steps}, nil
+}
+
+// dispatchSimulateStep picks the EXPLAIN flavor for ast, runs it,
+// and populates step in place. The dispatcher branches on the AST,
+// not on the SQL text, so wrapper noise (comments, whitespace) does
+// not affect routing. Any error is recorded on step.Error rather
+// than returned, so the caller can keep iterating over remaining
+// statements.
+func (m *Manager) dispatchSimulateStep(
+	ctx context.Context, ast tree.Statement, sql string, step *SimulateStep,
+) {
+	switch ast.StatementType() {
+	case tree.TypeDDL:
+		step.Strategy = StrategyExplainDDL
+		ddl, err := m.ExplainDDL(ctx, sql)
+		if err != nil {
+			step.Error = err.Error()
+			return
+		}
+		step.DDLPlan = &ddl
+		// Stats lookup is best-effort: a missing table or absent
+		// stats should not blank the plan we already have, nor
+		// should a single bad target wipe the partial successes.
+		// collectDDLTableStats returns whatever it managed to
+		// collect plus any failure message; both fields land on
+		// the step independently, so renderers can surface the
+		// plan, the partial stats, and the lookup error all at
+		// once.
+		step.TableStats, step.StatsError = m.collectDDLTableStats(ctx, ast)
+	case tree.TypeDML:
+		if tree.CanWriteData(ast) {
+			step.Strategy = StrategyExplain
+			plan, err := m.Explain(ctx, sql)
+			if err != nil {
+				step.Error = err.Error()
+				return
+			}
+			step.Plan = &plan
+			return
+		}
+		step.Strategy = StrategyExplainAnalyze
+		plan, err := m.ExplainAnalyze(ctx, sql)
+		if err != nil {
+			step.Error = err.Error()
+			return
+		}
+		step.Plan = &plan
+	default:
+		// safety.Check(OpSimulate) is supposed to reject TCL and
+		// DCL before we get here (nested EXPLAIN reports as
+		// TypeDML and so would not land in this branch — that's
+		// the case the safety gate must catch upstream because the
+		// dispatcher cannot detect a wrapped write). This branch
+		// exists so a bypass of the TCL/DCL rule surfaces as an
+		// actionable per-step error instead of a panic or a
+		// misleading cluster reject.
+		step.Error = fmt.Sprintf("simulate has no route for statement type %s", ast.StatementTag())
+	}
+}
+
+// ExplainAnalyze runs `EXPLAIN ANALYZE <sql>` against the cluster
+// and returns the parsed plan tree alongside the raw tabular output.
+// EXPLAIN ANALYZE physically executes the wrapped statement, so the
+// returned Plan carries measured runtime stats (rows read, network
+// bytes, execution time) rather than the optimizer's estimates.
+//
+// Caller contract: sql must be a SELECT (or other read-only DML
+// shape — VALUES, WITH, SHOW). The dispatcher in Simulate enforces
+// this by routing CanWriteData statements to plain Explain instead.
+// As defense in depth, the call still runs inside BEGIN READ ONLY
+// with a SET LOCAL statement_timeout, so any write that reaches
+// this method is rejected by the cluster with SQLSTATE 25006 and
+// the timeout caps slow plans.
+//
+// On any begin/exec/query/scan/parse failure after a successful
+// connect, the underlying connection is closed and the Manager
+// reverts to its pre-connect state, mirroring Explain's recovery
+// contract.
+func (m *Manager) ExplainAnalyze(ctx context.Context, sql string) (ExplainResult, error) {
+	if err := m.connect(ctx); err != nil {
+		return ExplainResult{}, err
+	}
+
+	result, err := m.runExplainAnalyze(ctx, sql)
+	if err != nil {
+		m.conn.Close(ctx) //nolint:errcheck // best-effort cleanup
+		m.conn = nil
+		return ExplainResult{}, err
+	}
+	return result, nil
+}
+
+// runExplainAnalyze owns the txn/query/scan/parse pipeline for
+// ExplainAnalyze. Splitting it out lets ExplainAnalyze centralize
+// the connection-recovery sequence so the failure modes (BeginTx,
+// Exec timeout, Query, Scan, rows.Err, parse, Commit) cannot drift
+// apart from the runExplain twin.
+func (m *Manager) runExplainAnalyze(ctx context.Context, sql string) (ExplainResult, error) {
+	tx, err := m.conn.BeginTx(ctx, pgx.TxOptions{AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("begin read-only txn: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup
+
+	if _, err := tx.Exec(ctx,
+		fmt.Sprintf("SET LOCAL statement_timeout = '%dms'", m.stmtTimeout.Milliseconds())); err != nil {
+		return ExplainResult{}, fmt.Errorf("set statement_timeout: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, "EXPLAIN ANALYZE "+sql)
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("run EXPLAIN ANALYZE: %w", err)
+	}
+	defer rows.Close()
+
+	var raw []string
+	for rows.Next() {
+		var info string
+		if err := rows.Scan(&info); err != nil {
+			return ExplainResult{}, fmt.Errorf("scan EXPLAIN ANALYZE row: %w", err)
+		}
+		raw = append(raw, info)
+	}
+	if err := rows.Err(); err != nil {
+		return ExplainResult{}, fmt.Errorf("read EXPLAIN ANALYZE rows: %w", err)
+	}
+	rows.Close() //nolint:errcheck // pgx requires release before commit; idempotent
+
+	if err := tx.Commit(ctx); err != nil {
+		return ExplainResult{}, fmt.Errorf("commit read-only txn: %w", err)
+	}
+
+	header, plan, err := parseExplainTree(raw)
+	if err != nil {
+		return ExplainResult{}, fmt.Errorf("parse EXPLAIN ANALYZE output: %w", err)
+	}
+	return ExplainResult{Header: header, Plan: plan, RawRows: raw}, nil
+}
+
+// GetTableStats returns the most recent row-count statistic for the
+// table at (schema, table). The source is SHOW STATISTICS, which
+// CRDB auto-collects: typically there is one row per (schema,
+// table, column-set) and the row with the latest `created`
+// timestamp wins. We pick the highest row_count across all column
+// sets — every column set's stats sample the same physical table,
+// so they should agree, and picking the max is a forgiving choice
+// when a single set is briefly stale.
+//
+// An empty schema is allowed and means "resolve against the
+// connection's search_path." That matches how the same SQL would
+// behave if the user ran the DDL in this connection, which is the
+// resolution the simulation should report against. Callers that
+// need a deterministic schema should pass it explicitly.
+//
+// Returns a zero TableStat (no error) when stats have not been
+// collected yet — that is the common case for freshly created
+// tables and is not an error condition the caller needs to
+// distinguish from a missing table. A non-nil error is reserved
+// for actual cluster failures.
+func (m *Manager) GetTableStats(ctx context.Context, schema, table string) (TableStat, error) {
+	if err := m.connect(ctx); err != nil {
+		return TableStat{}, err
+	}
+
+	stat, err := m.runGetTableStats(ctx, schema, table)
+	if err != nil {
+		m.conn.Close(ctx) //nolint:errcheck // best-effort cleanup
+		m.conn = nil
+		return TableStat{}, err
+	}
+	return stat, nil
+}
+
+// runGetTableStats is the inner half of GetTableStats. SHOW
+// STATISTICS does not accept placeholders for the table identifier,
+// so the table (and optional schema) are escaped via
+// pgx.Identifier.Sanitize to prevent injection.
+func (m *Manager) runGetTableStats(ctx context.Context, schema, table string) (TableStat, error) {
+	if table == "" {
+		return TableStat{}, fmt.Errorf("table must not be empty")
+	}
+	var qualified string
+	if schema == "" {
+		qualified = pgx.Identifier{table}.Sanitize()
+	} else {
+		qualified = pgx.Identifier{schema, table}.Sanitize()
+	}
+	// `created` ordering picks the most recent stat collection;
+	// `row_count DESC` breaks ties by preferring the higher number
+	// (every column set samples the same table, so equality is the
+	// expected case but not guaranteed across collection windows).
+	query := "SELECT row_count, created::STRING FROM [SHOW STATISTICS FOR TABLE " + qualified +
+		"] ORDER BY created DESC, row_count DESC LIMIT 1"
+
+	var (
+		rowCount    int64
+		collectedAt string
+	)
+	err := m.conn.QueryRow(ctx, query).Scan(&rowCount, &collectedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// No stats have been collected yet — return zero.
+			return TableStat{Schema: schema, Table: table, Source: "show_statistics"}, nil
+		}
+		return TableStat{}, fmt.Errorf("SHOW STATISTICS FOR TABLE %s: %w", qualified, err)
+	}
+	return TableStat{
+		Schema:      schema,
+		Table:       table,
+		RowCount:    rowCount,
+		Source:      "show_statistics",
+		CollectedAt: collectedAt,
+	}, nil
+}
+
+// collectDDLTableStats walks ast for table targets and returns one
+// TableStat per successfully looked-up target plus a non-empty
+// error string when at least one target failed. Statements with no
+// extractable target (e.g. CREATE SCHEMA, CREATE DATABASE) yield a
+// nil slice and an empty error — "nothing to annotate" is the
+// correct answer.
+//
+// Partial successes are preserved: a DROP TABLE a, b, c where the
+// stats lookup for `b` errors still returns the stats for `a` (and
+// `c`), with the StatsError message listing every failed target.
+// We deliberately accumulate ALL per-target errors rather than
+// keeping only the first — different targets can hit different
+// failure classes (permission denied on one, undefined relation on
+// another) and an operator debugging the simulation needs to see
+// each one to act on it.
+func (m *Manager) collectDDLTableStats(ctx context.Context, ast tree.Statement) ([]TableStat, string) {
+	targets := ddlTargets(ast)
+	if len(targets) == 0 {
+		return nil, ""
+	}
+	stats := make([]TableStat, 0, len(targets))
+	var failures []string
+	for _, t := range targets {
+		stat, err := m.GetTableStats(ctx, t.Schema, t.Table)
+		if err != nil {
+			label := t.Table
+			if t.Schema != "" {
+				label = t.Schema + "." + t.Table
+			}
+			failures = append(failures, fmt.Sprintf("%s: %v", label, err))
+			continue
+		}
+		stats = append(stats, stat)
+	}
+	if len(stats) == 0 {
+		stats = nil
+	}
+	return stats, strings.Join(failures, "; ")
+}
+
+// ddlTarget identifies a (schema, table) pair touched by a DDL
+// statement. Schema is the parser-supplied qualifier and may be
+// empty when the user wrote an unqualified name (e.g.
+// `ALTER TABLE users ...`); GetTableStats handles the empty case
+// by letting SHOW STATISTICS resolve against the connection's
+// search_path, which is the same resolution the eventual DDL would
+// see on this connection.
+type ddlTarget struct {
+	Schema string
+	Table  string
+}
+
+// ddlTargets extracts table targets from the DDL forms simulate
+// supports today: ALTER TABLE, CREATE INDEX, DROP INDEX, DROP
+// TABLE. Other forms (CREATE TABLE on a brand-new name, CREATE
+// SCHEMA, CREATE DATABASE, etc.) yield no targets — there is no
+// pre-existing table whose row count would inform the simulation.
+//
+// Adding a new DDL form is a one-case extension here. We chose
+// case-by-case extraction over a generic AST walker so the cost of
+// each new form is explicit and the helper stays auditable.
+func ddlTargets(stmt tree.Statement) []ddlTarget {
+	switch s := stmt.(type) {
+	case *tree.AlterTable:
+		tn := s.Table.ToTableName()
+		return []ddlTarget{{Schema: tn.Schema(), Table: tn.Table()}}
+	case *tree.CreateIndex:
+		return []ddlTarget{{Schema: s.Table.Schema(), Table: s.Table.Table()}}
+	case *tree.DropTable:
+		out := make([]ddlTarget, 0, len(s.Names))
+		for i := range s.Names {
+			out = append(out, ddlTarget{Schema: s.Names[i].Schema(), Table: s.Names[i].Table()})
+		}
+		return out
+	case *tree.DropIndex:
+		out := make([]ddlTarget, 0, len(s.IndexList))
+		for _, idx := range s.IndexList {
+			out = append(out, ddlTarget{Schema: idx.Table.Schema(), Table: idx.Table.Table()})
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// simulateStrategyForAST is a package-private helper so tests can
+// verify dispatch decisions without round-tripping through Simulate
+// (which would require a live cluster). Returns the strategy a real
+// Simulate call would pick for ast, plus a boolean indicating
+// whether the dispatcher has any route at all.
+func simulateStrategyForAST(ast tree.Statement) (Strategy, bool) {
+	switch ast.StatementType() {
+	case tree.TypeDDL:
+		return StrategyExplainDDL, true
+	case tree.TypeDML:
+		if tree.CanWriteData(ast) {
+			return StrategyExplain, true
+		}
+		return StrategyExplainAnalyze, true
+	default:
+		return "", false
+	}
+}

--- a/internal/conn/simulate_integration_test.go
+++ b/internal/conn/simulate_integration_test.go
@@ -1,0 +1,350 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// Integration tests for Manager.Simulate / ExplainAnalyze /
+// GetTableStats against a real CockroachDB cluster. Build-tagged so
+// `make test` stays fast; run via `make test-integration`.
+
+package conn_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// TestIntegrationManagerExplainAnalyzeSelect covers the happy path:
+// EXPLAIN ANALYZE on a SELECT returns a populated plan tree plus the
+// "execution time" / "rows read" header lines that distinguish it
+// from plain EXPLAIN. The explicit assertions are kept loose enough
+// to tolerate CRDB version drift while still failing if a future
+// regression silently routes through plain EXPLAIN (which would
+// strip the runtime stats).
+func TestIntegrationManagerExplainAnalyzeSelect(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := mgr.ExplainAnalyze(ctx, "SELECT 1")
+	require.NoError(t, err)
+	require.NotEmpty(t, result.RawRows, "EXPLAIN ANALYZE must return raw output")
+	require.NotEmpty(t, result.Plan, "EXPLAIN ANALYZE must parse into a plan tree")
+}
+
+// TestIntegrationManagerExplainAnalyzeRejectsWritesViaReadOnlyTxn
+// pins the load-bearing safety property of ExplainAnalyze: even if
+// a caller bypasses the dispatcher (which routes writes to plain
+// Explain), the cluster's BEGIN READ ONLY wrapper rejects the
+// inner write with SQLSTATE 25006. Without this guard, ANALYZE
+// would persist the write — exactly the side effect the simulate
+// design avoids.
+func TestIntegrationManagerExplainAnalyzeRejectsWritesViaReadOnlyTxn(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE IF NOT EXISTS explain_analyze_probe (id INT PRIMARY KEY)")
+
+	_, err := mgr.ExplainAnalyze(ctx, "INSERT INTO explain_analyze_probe VALUES (1)")
+	require.Error(t, err, "ExplainAnalyze of an INSERT must be rejected by the read-only txn")
+	require.Contains(t, err.Error(), "25006",
+		"rejection must carry SQLSTATE 25006 (read_only_sql_transaction)")
+}
+
+// TestIntegrationManagerSimulateSelect verifies the dispatcher
+// routes a SELECT through StrategyExplainAnalyze and populates Plan
+// (not DDLPlan). Single-statement happy path.
+func TestIntegrationManagerSimulateSelect(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := mgr.Simulate(ctx, "SELECT 1")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	step := result.Steps[0]
+	require.Equal(t, conn.StrategyExplainAnalyze, step.Strategy)
+	require.Empty(t, step.Error)
+	require.NotNil(t, step.Plan, "SELECT step must carry a Plan")
+	require.Nil(t, step.DDLPlan, "SELECT step must not carry a DDLPlan")
+	require.Empty(t, step.TableStats, "SELECT step has no DDL targets")
+}
+
+// TestIntegrationManagerSimulateDMLWriteUsesPlainExplain pins the
+// dispatcher's safety choice for writes: route to plain EXPLAIN so
+// no row is persisted, even though ANALYZE would give richer stats.
+// We verify the row count of the target table is unchanged
+// after the simulation.
+func TestIntegrationManagerSimulateDMLWriteUsesPlainExplain(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "simulate_write")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	result, err := mgr.Simulate(ctx, "INSERT INTO t VALUES (42)")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	step := result.Steps[0]
+	require.Equal(t, conn.StrategyExplain, step.Strategy)
+	require.Empty(t, step.Error)
+	require.NotNil(t, step.Plan)
+
+	// Verify the INSERT was not persisted: the table must be empty.
+	var count int
+	require.NoError(t,
+		queryScalar(t, ctx, dsnWithDatabase(t, cluster.DSN, dbName),
+			"SELECT count(*) FROM t", &count))
+	require.Equal(t, 0, count,
+		"plain EXPLAIN of an INSERT must not persist the row")
+}
+
+// TestIntegrationManagerSimulateDDL verifies the DDL path: the
+// dispatcher routes ALTER TABLE through EXPLAIN (DDL, SHAPE), and
+// the table referenced by the ALTER survives unchanged (no schema
+// modification). TableStats are populated when SHOW STATISTICS has
+// data; we assert the slice has one entry naming the right table
+// rather than a row-count value (auto-collection timing varies).
+func TestIntegrationManagerSimulateDDL(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "simulate_ddl")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.users (id INT PRIMARY KEY, name STRING)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	result, err := mgr.Simulate(ctx, "ALTER TABLE public.users ADD COLUMN age INT")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	step := result.Steps[0]
+	require.Equal(t, conn.StrategyExplainDDL, step.Strategy)
+	require.NotNil(t, step.DDLPlan)
+	require.Nil(t, step.Plan)
+	require.Len(t, step.TableStats, 1, "ALTER TABLE has one extracted target")
+	require.Equal(t, "public", step.TableStats[0].Schema)
+	require.Equal(t, "users", step.TableStats[0].Table)
+	require.Equal(t, "show_statistics", step.TableStats[0].Source)
+
+	// Verify the schema was not modified — `age` must still be absent.
+	var colCount int
+	require.NoError(t, queryScalar(t, ctx, dsnWithDatabase(t, cluster.DSN, dbName),
+		"SELECT count(*) FROM information_schema.columns "+
+			"WHERE table_schema='public' AND table_name='users' AND column_name='age'",
+		&colCount))
+	require.Equal(t, 0, colCount,
+		"EXPLAIN (DDL, SHAPE) must not actually add the column")
+}
+
+// TestIntegrationManagerSimulateUnqualifiedDDLPreservesPlan pins
+// the load-bearing partial-failure contract: an unqualified DDL
+// (the common form `ALTER TABLE users ...`) must produce a DDL
+// plan even if the stats lookup against the empty schema yields
+// nothing useful. Earlier behaviour rejected the empty schema
+// inside runGetTableStats and surfaced the failure as step.Error,
+// which the renderer suppressed — so unqualified DDL appeared
+// blank to operators. Now stats lookup against an empty schema
+// resolves via search_path; the plan is always preserved.
+func TestIntegrationManagerSimulateUnqualifiedDDLPreservesPlan(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "simulate_unqual")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.users (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	// Unqualified target — parser leaves Schema="".
+	result, err := mgr.Simulate(ctx, "ALTER TABLE users ADD COLUMN x INT")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 1)
+	step := result.Steps[0]
+	require.Empty(t, step.Error, "plan must succeed for unqualified target")
+	require.NotNil(t, step.DDLPlan, "DDL plan must be preserved for unqualified target")
+	require.Len(t, step.TableStats, 1)
+	// Schema came back empty from the parser; the stat carries the
+	// same empty schema since we did not resolve it client-side.
+	require.Equal(t, "users", step.TableStats[0].Table)
+}
+
+// TestIntegrationManagerSimulateMultiStatement verifies the
+// per-statement contract: a mixed batch returns one Step per
+// parsed statement, with each step independently routed.
+func TestIntegrationManagerSimulateMultiStatement(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "simulate_multi")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	result, err := mgr.Simulate(ctx,
+		"SELECT 1; INSERT INTO t VALUES (1); ALTER TABLE t ADD COLUMN c INT")
+	require.NoError(t, err)
+	require.Len(t, result.Steps, 3)
+
+	require.Equal(t, conn.StrategyExplainAnalyze, result.Steps[0].Strategy)
+	require.Equal(t, 0, result.Steps[0].StatementIndex)
+
+	require.Equal(t, conn.StrategyExplain, result.Steps[1].Strategy)
+	require.Equal(t, 1, result.Steps[1].StatementIndex)
+
+	require.Equal(t, conn.StrategyExplainDDL, result.Steps[2].Strategy)
+	require.Equal(t, 2, result.Steps[2].StatementIndex)
+}
+
+// TestIntegrationManagerSimulateMultiStatementMidFailure pins
+// the per-step error-isolation contract: a mid-batch failure
+// (here, a query against a non-existent table) does not abort the
+// remaining steps, the StatementIndex stays correctly aligned, and
+// the failed step carries its cluster error in step.Error while
+// neighbouring steps complete normally.
+func TestIntegrationManagerSimulateMultiStatementMidFailure(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "simulate_mid")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	result, err := mgr.Simulate(ctx,
+		"SELECT 1; SELECT * FROM does_not_exist; SELECT 2")
+	require.NoError(t, err, "method-level call should succeed even when one step fails")
+	require.Len(t, result.Steps, 3)
+
+	require.Empty(t, result.Steps[0].Error, "step 0 (SELECT 1) should succeed")
+	require.NotNil(t, result.Steps[0].Plan)
+
+	require.NotEmpty(t, result.Steps[1].Error, "step 1 must carry the cluster error")
+	require.Equal(t, 1, result.Steps[1].StatementIndex,
+		"failed step must keep its position in the batch")
+
+	require.Empty(t, result.Steps[2].Error, "step 2 (SELECT 2) must run after step 1 failed")
+	require.NotNil(t, result.Steps[2].Plan)
+
+	// The aggregate summary must mark the partial failure so the
+	// CLI/MCP layers can surface it at the envelope level.
+	msg, planFails, _, ok := result.StepFailureSummary()
+	require.True(t, ok)
+	require.Equal(t, []int{1}, planFails)
+	require.Contains(t, msg, "1 plan error(s)")
+}
+
+// TestIntegrationManagerGetTableStatsFreshTable pins the
+// "no stats yet" contract: a table that was just created (so
+// auto-stats has not run) returns a zero TableStat without an
+// error. The dispatcher relies on this so a freshly created
+// target does not turn the simulation into an error case.
+func TestIntegrationManagerGetTableStatsFreshTable(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "stats_fresh")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.fresh (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	stat, err := mgr.GetTableStats(ctx, "public", "fresh")
+	require.NoError(t, err, "missing stats must not be an error")
+	require.Equal(t, "public", stat.Schema)
+	require.Equal(t, "fresh", stat.Table)
+	require.Equal(t, "show_statistics", stat.Source)
+}
+
+// queryScalar opens a one-off pgx connection, runs the given SQL,
+// and scans a single scalar column into dest. Used in the simulate
+// integration tests to verify side-effect absence (e.g. row counts
+// before/after a simulated DML).
+func queryScalar(t *testing.T, ctx context.Context, dsn, sql string, dest any) error {
+	t.Helper()
+	c, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return err
+	}
+	defer c.Close(ctx) //nolint:errcheck // best-effort cleanup
+	return c.QueryRow(ctx, sql).Scan(dest)
+}

--- a/internal/conn/simulate_test.go
+++ b/internal/conn/simulate_test.go
@@ -1,0 +1,401 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSimulateStrategyForAST pins the dispatcher's routing table.
+// Since the routing decision determines whether the inner statement
+// executes (StrategyExplainAnalyze) or not (StrategyExplain /
+// StrategyExplainDDL), a regression here would be the difference
+// between "simulated" and "actually wrote data" — exactly the
+// safety property the EXPLAIN-based dispatcher exists to provide.
+func TestSimulateStrategyForAST(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		expectedStrategy Strategy
+		expectedRouted   bool
+	}{
+		{
+			name:             "select goes to explain analyze",
+			sql:              "SELECT * FROM t",
+			expectedStrategy: StrategyExplainAnalyze,
+			expectedRouted:   true,
+		},
+		{
+			name:             "values goes to explain analyze",
+			sql:              "VALUES (1), (2)",
+			expectedStrategy: StrategyExplainAnalyze,
+			expectedRouted:   true,
+		},
+		{
+			name:             "with cte select goes to explain analyze",
+			sql:              "WITH cte AS (SELECT 1) SELECT * FROM cte",
+			expectedStrategy: StrategyExplainAnalyze,
+			expectedRouted:   true,
+		},
+		{
+			name:             "insert goes to plain explain",
+			sql:              "INSERT INTO t VALUES (1)",
+			expectedStrategy: StrategyExplain,
+			expectedRouted:   true,
+		},
+		{
+			name:             "update goes to plain explain",
+			sql:              "UPDATE t SET x = 1 WHERE id = 1",
+			expectedStrategy: StrategyExplain,
+			expectedRouted:   true,
+		},
+		{
+			name:             "delete goes to plain explain",
+			sql:              "DELETE FROM t WHERE id = 1",
+			expectedStrategy: StrategyExplain,
+			expectedRouted:   true,
+		},
+		{
+			name:             "upsert goes to plain explain",
+			sql:              "UPSERT INTO t VALUES (1)",
+			expectedStrategy: StrategyExplain,
+			expectedRouted:   true,
+		},
+		{
+			name:             "alter table goes to explain ddl",
+			sql:              "ALTER TABLE t ADD COLUMN x INT",
+			expectedStrategy: StrategyExplainDDL,
+			expectedRouted:   true,
+		},
+		{
+			name:             "create index goes to explain ddl",
+			sql:              "CREATE INDEX i ON t (c)",
+			expectedStrategy: StrategyExplainDDL,
+			expectedRouted:   true,
+		},
+		{
+			name:             "drop table goes to explain ddl",
+			sql:              "DROP TABLE t",
+			expectedStrategy: StrategyExplainDDL,
+			expectedRouted:   true,
+		},
+		{
+			name:           "begin has no route",
+			sql:            "BEGIN",
+			expectedRouted: false,
+		},
+		{
+			name:           "commit has no route",
+			sql:            "COMMIT",
+			expectedRouted: false,
+		},
+		{
+			name:           "grant has no route",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedRouted: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			strategy, routed := simulateStrategyForAST(stmts[0].AST)
+			require.Equal(t, tc.expectedRouted, routed)
+			if tc.expectedRouted {
+				require.Equal(t, tc.expectedStrategy, strategy)
+			}
+		})
+	}
+}
+
+// TestDDLTargets pins the AST-target extraction used to drive the
+// SHOW STATISTICS lookup. The dispatcher relies on this to label
+// per-step TableStats, so a missed extraction would silently drop
+// the row-count annotation rather than fail loudly.
+func TestDDLTargets(t *testing.T) {
+	tests := []struct {
+		name            string
+		sql             string
+		expectedTargets []ddlTarget
+	}{
+		{
+			name:            "alter table unqualified",
+			sql:             "ALTER TABLE users ADD COLUMN x INT",
+			expectedTargets: []ddlTarget{{Schema: "", Table: "users"}},
+		},
+		{
+			name:            "alter table qualified",
+			sql:             "ALTER TABLE public.users ADD COLUMN x INT",
+			expectedTargets: []ddlTarget{{Schema: "public", Table: "users"}},
+		},
+		{
+			name:            "create index qualified",
+			sql:             "CREATE INDEX i ON public.users (email)",
+			expectedTargets: []ddlTarget{{Schema: "public", Table: "users"}},
+		},
+		{
+			name: "drop table multiple",
+			sql:  "DROP TABLE public.a, public.b",
+			expectedTargets: []ddlTarget{
+				{Schema: "public", Table: "a"},
+				{Schema: "public", Table: "b"},
+			},
+		},
+		{
+			name:            "drop index single",
+			sql:             "DROP INDEX public.users@users_email_idx",
+			expectedTargets: []ddlTarget{{Schema: "public", Table: "users"}},
+		},
+		{
+			name:            "create table has no extractable target",
+			sql:             "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedTargets: nil,
+		},
+		{
+			name:            "create schema has no extractable target",
+			sql:             "CREATE SCHEMA app",
+			expectedTargets: nil,
+		},
+		{
+			name:            "select is not a DDL target",
+			sql:             "SELECT 1",
+			expectedTargets: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			targets := ddlTargets(stmts[0].AST)
+			require.Equal(t, tc.expectedTargets, targets)
+		})
+	}
+}
+
+// TestSimulateRejectsBadInput pins the input-validation surface of
+// Simulate that runs before any cluster contact. A parse failure or
+// empty input must return without dialing — otherwise a malformed
+// agent request would burn a connection per call.
+func TestSimulateRejectsBadInput(t *testing.T) {
+	mgr := NewManager("postgres://localhost:1/defaultdb")
+	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
+
+	tests := []struct {
+		name        string
+		sql         string
+		expectedErr string
+	}{
+		{
+			name:        "parse error surfaces with prefix",
+			sql:         "SELEKT broken",
+			expectedErr: "parse simulate input",
+		},
+		{
+			name:        "empty input rejected",
+			sql:         "",
+			expectedErr: "no statements parsed",
+		},
+		{
+			name:        "whitespace only rejected",
+			sql:         "   \n\t",
+			expectedErr: "no statements parsed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := mgr.Simulate(t.Context(), tc.sql)
+			require.ErrorContains(t, err, tc.expectedErr)
+			require.Nil(t, mgr.conn, "Simulate must not dial on input rejection")
+		})
+	}
+}
+
+// TestStrategyConstantsAreStable pins the wire values for the
+// Strategy enum. Agents branch on these tokens to decide which
+// payload field to read; a rename here would silently break every
+// downstream consumer.
+func TestStrategyConstantsAreStable(t *testing.T) {
+	require.Equal(t, Strategy("explain_analyze"), StrategyExplainAnalyze)
+	require.Equal(t, Strategy("explain"), StrategyExplain)
+	require.Equal(t, Strategy("explain_ddl"), StrategyExplainDDL)
+}
+
+// TestStepFailureSummary pins the per-step failure aggregation that
+// drives the CLI's exit code and the MCP envelope's Errors entry.
+// Without this aggregation, a multi-statement simulation where one
+// step failed would render as fully successful to any consumer
+// reading only the top-level errors[] array.
+func TestStepFailureSummary(t *testing.T) {
+	tests := []struct {
+		name             string
+		steps            []SimulateStep
+		expectedOK       bool
+		expectedMsgPart  string
+		expectedPlanIdx  []int
+		expectedStatsIdx []int
+	}{
+		{
+			name: "all success",
+			steps: []SimulateStep{
+				{StatementIndex: 0, Tag: "SELECT", Strategy: StrategyExplainAnalyze},
+				{StatementIndex: 1, Tag: "INSERT", Strategy: StrategyExplain},
+			},
+			expectedOK: false,
+		},
+		{
+			name: "single plan failure",
+			steps: []SimulateStep{
+				{StatementIndex: 0, Tag: "SELECT", Strategy: StrategyExplainAnalyze, Error: "boom"},
+			},
+			expectedOK:      true,
+			expectedMsgPart: "1 plan error(s) at step(s) [0]",
+			expectedPlanIdx: []int{0},
+		},
+		{
+			name: "stats-only failure preserves the message split",
+			steps: []SimulateStep{
+				{StatementIndex: 0, Tag: "ALTER TABLE", Strategy: StrategyExplainDDL, StatsError: "users.x: nope"},
+			},
+			expectedOK:       true,
+			expectedMsgPart:  "1 stats error(s) at step(s) [0]",
+			expectedStatsIdx: []int{0},
+		},
+		{
+			name: "mixed plan and stats failures across statements",
+			steps: []SimulateStep{
+				{StatementIndex: 0, Tag: "SELECT", Strategy: StrategyExplainAnalyze},
+				{StatementIndex: 1, Tag: "INSERT", Strategy: StrategyExplain, Error: "boom"},
+				{StatementIndex: 2, Tag: "ALTER TABLE", Strategy: StrategyExplainDDL, StatsError: "lookup failed"},
+			},
+			expectedOK:       true,
+			expectedPlanIdx:  []int{1},
+			expectedStatsIdx: []int{2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SimulateResult{Steps: tc.steps}
+			msg, planFails, statsFails, ok := result.StepFailureSummary()
+			require.Equal(t, tc.expectedOK, ok)
+			if !tc.expectedOK {
+				require.Empty(t, msg)
+				require.Empty(t, planFails)
+				require.Empty(t, statsFails)
+				return
+			}
+			require.Equal(t, tc.expectedPlanIdx, planFails)
+			require.Equal(t, tc.expectedStatsIdx, statsFails)
+			if tc.expectedMsgPart != "" {
+				require.Contains(t, msg, tc.expectedMsgPart)
+			}
+			require.Contains(t, msg, "see data.steps")
+		})
+	}
+}
+
+// TestDispatchSimulateStepNoRoute pins the defense-in-depth
+// behaviour for statement classes the safety gate is supposed to
+// reject upstream (TCL, DCL). If a future caller bypasses
+// safety.Check, the dispatcher's default arm must record an
+// actionable per-step error rather than panicking or silently
+// routing. We exercise dispatchSimulateStep directly with a nil
+// connection because the no-route branch never touches the conn.
+func TestDispatchSimulateStepNoRoute(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		expectedTag string
+	}{
+		{name: "TCL begin has no route", sql: "BEGIN", expectedTag: "BEGIN"},
+		{name: "TCL commit has no route", sql: "COMMIT", expectedTag: "COMMIT"},
+		{name: "DCL grant has no route", sql: "GRANT SELECT ON t TO bob", expectedTag: "GRANT"},
+		{name: "DCL revoke has no route", sql: "REVOKE SELECT ON t FROM bob", expectedTag: "REVOKE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			mgr := NewManager("postgres://localhost:1/defaultdb")
+			t.Cleanup(func() { _ = mgr.Close(t.Context()) })
+
+			step := SimulateStep{
+				StatementIndex: 0,
+				Tag:            stmts[0].AST.StatementTag(),
+				SQL:            stmts[0].SQL,
+			}
+			mgr.dispatchSimulateStep(t.Context(), stmts[0].AST, stmts[0].SQL, &step)
+
+			require.Equal(t, tc.expectedTag, step.Tag)
+			require.Empty(t, step.Strategy, "no route means no strategy was selected")
+			require.Nil(t, step.Plan)
+			require.Nil(t, step.DDLPlan)
+			require.Empty(t, step.StatsError)
+			require.Contains(t, step.Error, "no route for statement type")
+			require.Contains(t, step.Error, tc.expectedTag)
+		})
+	}
+}
+
+// TestCollectDDLTableStatsAggregatesEveryFailure pins the
+// "every per-target error class survives" contract. Earlier
+// behaviour kept only the first failure message ("first error
+// wins"), which silently dropped distinct error classes from later
+// targets — e.g. a permission-denied on table `a` would hide a
+// connection-refused on table `b`. The fix joins every per-target
+// error with `; ` so an operator debugging the simulation sees
+// each one.
+//
+// We exercise this with `DROP TABLE a, b` against a Manager whose
+// connect step is guaranteed to fail (unreachable DSN). Each
+// per-target GetTableStats call produces the same connect error,
+// so the joined StatsError must mention both `a` and `b`. A
+// regression that reverts to "first error wins" would fail the
+// `b` assertion.
+func TestCollectDDLTableStatsAggregatesEveryFailure(t *testing.T) {
+	mgr := NewManager("postgres://nope:1/db?connect_timeout=1")
+	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
+
+	stmts, err := parser.Parse("DROP TABLE public.a, public.b")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	stats, statsErr := mgr.collectDDLTableStats(t.Context(), stmts[0].AST)
+	require.Empty(t, stats, "every per-target lookup should fail against an unreachable DSN")
+	require.NotEmpty(t, statsErr)
+	require.Contains(t, statsErr, "public.a")
+	require.Contains(t, statsErr, "public.b",
+		"second target's failure must not be dropped — agents need every error class")
+	require.Contains(t, statsErr, ";",
+		"per-target failures must be joined with `; ` separators")
+}
+
+// TestRunGetTableStatsRejectsEmptyTable pins the load-bearing
+// validation in runGetTableStats that runs before any cluster
+// contact. An empty table name would let pgx.Identifier.Sanitize
+// produce a literal empty-quoted identifier, which the cluster
+// would reject with a confusing message; rejecting here keeps the
+// error message actionable.
+func TestRunGetTableStatsRejectsEmptyTable(t *testing.T) {
+	mgr := NewManager("postgres://localhost:1/defaultdb")
+	t.Cleanup(func() { _ = mgr.Close(t.Context()) })
+
+	_, err := mgr.runGetTableStats(t.Context(), "public", "")
+	require.ErrorContains(t, err, "table must not be empty")
+}

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -44,6 +44,7 @@ var expectedTools = []string{
 	tools.SummarizeSQLToolName,
 	tools.ExplainSQLToolName,
 	tools.ExplainSchemaChangeToolName,
+	tools.SimulateSQLToolName,
 	tools.ListTablesToolName,
 	tools.DescribeTableToolName,
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,13 +9,13 @@
 // tools (parse_sql, validate_sql, format_sql, detect_risky_query,
 // summarize_sql), two Tier 2 catalog tools (list_tables,
 // describe_table) that operate on inline CREATE TABLE schemas, and
-// two Tier 3 connected tools (explain_sql, explain_schema_change)
-// that run against a live cluster. validate_sql is dual-tier: it
-// runs Tier 1 by default and lifts to Tier 2 (name resolution) when
-// the caller supplies inline schemas. Keeping construction pure (no
-// transport, no I/O) lets the cmd layer pick a transport — currently
-// just stdio — and lets tests exercise individual tool handlers
-// directly.
+// three Tier 3 connected tools (explain_sql, explain_schema_change,
+// simulate_sql) that run against a live cluster. validate_sql is
+// dual-tier: it runs Tier 1 by default and lifts to Tier 2 (name
+// resolution) when the caller supplies inline schemas. Keeping
+// construction pure (no transport, no I/O) lets the cmd layer pick
+// a transport — currently just stdio — and lets tests exercise
+// individual tool handlers directly.
 //
 // Versions are passed in by the caller rather than read from
 // debug.ReadBuildInfo here, so this package stays free of
@@ -77,6 +77,7 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 	s.AddTool(tools.SummarizeSQLTool(), tools.SummarizeSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSchemaChangeTool(), tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.SimulateSQLTool(), tools.SimulateSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))
 	s.AddTool(tools.DescribeTableTool(), tools.DescribeTableHandler(parserVersion))
 	return s

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -86,6 +86,7 @@ func TestNewServerRegistersTools(t *testing.T) {
 		tools.DetectRiskyQueryToolName,
 		tools.ExplainSQLToolName,
 		tools.ExplainSchemaChangeToolName,
+		tools.SimulateSQLToolName,
 		tools.ListTablesToolName,
 		tools.DescribeTableToolName,
 	} {

--- a/internal/mcp/tools/simulate.go
+++ b/internal/mcp/tools/simulate.go
@@ -1,0 +1,138 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+// SimulateSQLTool returns the MCP tool definition for simulate_sql.
+// The dispatcher behind this tool routes each parsed statement to a
+// non-executing EXPLAIN flavor (EXPLAIN ANALYZE for SELECT, plain
+// EXPLAIN for DML writes, EXPLAIN (DDL, SHAPE) for DDL) and returns
+// per-statement plan + (for DDL) row-count annotations. The `dsn`
+// parameter is required because MCP sessions are stateless: the
+// server has no per-client connection to reuse, so each call carries
+// the connection string. Credentials are never logged or echoed back.
+func SimulateSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		SimulateSQLToolName,
+		mcp.WithDescription(`Simulate one or more SQL statements without applying them. Each parsed statement is dispatched to a non-executing EXPLAIN flavor: SELECT runs through EXPLAIN ANALYZE (real runtime stats; reads have no side effects), INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN (planner estimates only — the write is never applied), and DDL runs through EXPLAIN (DDL, SHAPE) plus a SHOW STATISTICS row-count annotation per affected table. Multi-statement input returns one entry per statement in parse order.`),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement(s) to simulate. Multi-statement input is split per ';' and each statement is dispatched independently.")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
+		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
+	)
+}
+
+// SimulateSQLHandler returns the handler for the simulate_sql tool.
+// The envelope's ConnectionStatus starts disconnected and flips to
+// connected only after a successful Simulate call, so partial-failure
+// envelopes report the actual reached state. Per-statement failures
+// (cluster reject, statement timeout, missing target table for stats)
+// land on the corresponding SimulateStep.Error rather than aborting
+// the whole call; method-level errors (parse failure, initial
+// connect) populate env.Errors via diag.FromClusterError.
+//
+// defaultTargetVersion is the server-level default; per-call
+// target_version arguments override it. The resolved value is
+// stamped onto the envelope (and may add a mismatch warning) per
+// the contract documented on connectedEnvelope.
+func SimulateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractRequiredString(req, "sql")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		dsn, toolErr := extractRequiredString(req, "dsn")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		mode, toolErr := resolveSafetyMode(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		timeout, toolErr := resolveStatementTimeout(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := connectedEnvelope(parserVersion, target)
+
+		// Safety check runs before any cluster contact: a rejection
+		// surfaces in env.Errors with connection_status=disconnected,
+		// matching the CLI's behaviour. Parse errors propagate via
+		// diag.FromParseError so the agent gets the SQLSTATE-tagged
+		// syntax diagnostic, not a misleading safety violation.
+		violation, err := safety.Check(mode, safety.OpSimulate, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+		if violation != nil {
+			env.Errors = []output.Error{safety.Envelope(violation)}
+			return envelopeResult(env)
+		}
+
+		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
+
+		result, err := mgr.Simulate(ctx, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
+			return envelopeResult(env)
+		}
+
+		env.ConnectionStatus = output.ConnectionConnected
+		data, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+
+		// Promote per-step failures into an envelope-level warning
+		// so agents that read only the top-level errors[] still see
+		// the partial failure. Without this, a multi-statement
+		// simulation where step 2 of 5 failed would render as a
+		// fully successful tool call with the failure buried
+		// inside data.steps. The index slices land in Context so
+		// agents can retry only the failed steps without parsing
+		// the human-readable message.
+		if msg, planFails, statsFails, ok := result.StepFailureSummary(); ok {
+			ctx := make(map[string]any, 2)
+			if len(planFails) > 0 {
+				ctx["plan_failed_steps"] = planFails
+			}
+			if len(statsFails) > 0 {
+				ctx["stats_failed_steps"] = statsFails
+			}
+			env.Errors = append(env.Errors, output.Error{
+				Code:     "simulate_step_failure",
+				Severity: output.SeverityError,
+				Message:  msg,
+				Category: "simulate",
+				Context:  ctx,
+			})
+		}
+
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/simulate_test.go
+++ b/internal/mcp/tools/simulate_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// TestSimulateSQLHandlerParameterValidation covers the tool-level
+// error path for simulate_sql. Mirrors the explain_sql parameter
+// table — a missing or wrong-typed required argument must produce a
+// tool error, not an envelope.
+func TestSimulateSQLHandlerParameterValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing both params", args: map[string]any{}},
+		{name: "missing dsn", args: map[string]any{"sql": "SELECT 1"}},
+		{name: "missing sql", args: map[string]any{"dsn": "postgres://h:26257/db"}},
+		{name: "empty sql", args: map[string]any{"sql": "", "dsn": "postgres://h:26257/db"}},
+		{name: "empty dsn", args: map[string]any{"sql": "SELECT 1", "dsn": ""}},
+		{name: "wrong type sql", args: map[string]any{"sql": 1, "dsn": "postgres://h:26257/db"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := SimulateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.True(t, res.IsError, "expected tool-level error")
+		})
+	}
+}
+
+// TestSimulateSQLHandlerSafetyRejection verifies that the OpSimulate
+// allowlist intercepts TCL/DCL/nested-EXPLAIN inputs before any
+// cluster contact, in the MCP surface. Mirror of the CLI test in
+// cmd/simulate_test.go.
+func TestSimulateSQLHandlerSafetyRejection(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		expectedTag string
+	}{
+		{name: "begin rejected", sql: "BEGIN", expectedTag: "BEGIN"},
+		{name: "grant rejected", sql: "GRANT SELECT ON t TO bob", expectedTag: "GRANT"},
+		{name: "nested explain rejected", sql: "EXPLAIN SELECT 1", expectedTag: "EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := SimulateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"sql": tc.sql,
+				// Unreachable on purpose: a regression that lets
+				// the safety check fall through would surface here
+				// as a connect error instead of safety_violation.
+				"dsn": "postgres://nope:1/db?connect_timeout=1",
+			}
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+				"safety rejection must short-circuit before any cluster contact")
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, "simulate", env.Errors[0].Context["operation"])
+		})
+	}
+}
+
+// TestSimulateSQLHandlerAdmitsDispatchableShapes is the inverse:
+// SELECT, DML writes, and DDL all pass the safety gate and reach
+// the connect step, even under the default read_only mode. The
+// connect failure (unreachable DSN) is the assertion that the
+// safety gate did not short-circuit.
+func TestSimulateSQLHandlerAdmitsDispatchableShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "select admitted", sql: "SELECT 1"},
+		{name: "insert admitted", sql: "INSERT INTO t VALUES (1)"},
+		{name: "alter table admitted", sql: "ALTER TABLE t ADD COLUMN x INT"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := SimulateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"sql": tc.sql,
+				"dsn": "postgres://flaghost:26257/db?connect_timeout=1",
+			}
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+			require.Len(t, env.Errors, 1)
+			require.Contains(t, env.Errors[0].Message, "connect to CockroachDB",
+				"dispatchable shape must reach the connect step under read_only mode")
+		})
+	}
+}
+
+// TestSimulateSQLHandlerRejectsInvalidMode covers the tool-level
+// error path for a malformed mode argument.
+func TestSimulateSQLHandlerRejectsInvalidMode(t *testing.T) {
+	handler := SimulateSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":  "SELECT 1",
+		"dsn":  "postgres://nope:1/db",
+		"mode": "yolo",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "invalid mode must produce a tool-level error, not an envelope")
+}
+
+// TestSimulateSQLToolAdvertisesParams pins the tool schema so a
+// removed parameter (e.g. the agent-facing `mode` knob) fails
+// loudly. We assert the parameter set rather than the exact
+// description text.
+func TestSimulateSQLToolAdvertisesParams(t *testing.T) {
+	tool := SimulateSQLTool()
+	require.Equal(t, SimulateSQLToolName, tool.Name)
+	require.NotEmpty(t, tool.Description)
+
+	// InputSchema.Properties carries the per-parameter schema. The
+	// required set lives at InputSchema.Required.
+	require.Contains(t, tool.InputSchema.Properties, "sql")
+	require.Contains(t, tool.InputSchema.Properties, "dsn")
+	require.Contains(t, tool.InputSchema.Properties, ModeParamName)
+	require.Contains(t, tool.InputSchema.Properties, StatementTimeoutParamName)
+	require.Contains(t, tool.InputSchema.Properties, TargetVersionParamName)
+	require.ElementsMatch(t, []string{"sql", "dsn"}, tool.InputSchema.Required)
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -44,6 +44,7 @@ const (
 	SummarizeSQLToolName        = "summarize_sql"
 	ExplainSQLToolName          = "explain_sql"
 	ExplainSchemaChangeToolName = "explain_schema_change"
+	SimulateSQLToolName         = "simulate_sql"
 	ListTablesToolName          = "list_tables"
 	DescribeTableToolName       = "describe_table"
 )

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -25,6 +25,7 @@ type Operation int
 const (
 	OpExplain Operation = iota + 1
 	OpExplainDDL
+	OpSimulate
 )
 
 // String returns the wire-stable token for op. Used in violation
@@ -35,6 +36,8 @@ func (op Operation) String() string {
 		return "explain"
 	case OpExplainDDL:
 		return "explain_ddl"
+	case OpSimulate:
+		return "simulate"
 	default:
 		return "unknown"
 	}
@@ -134,7 +137,7 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 	case ModeSafeWrite, ModeFullAccess:
 		// Modes are recognised at the flag layer (so the CLI accepts
 		// --mode=safe_write today without a "bad value" error), but
-		// no statement is admitted until issues #28/#29 wire the
+		// no statement is admitted until issue #29 wires the
 		// per-mode rules. Returning a violation here keeps the
 		// rejection path uniform with read_only.
 		return &Violation{
@@ -175,9 +178,19 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 //     user error. But because read_only mode is meant to forbid all
 //     schema modification, we reject DDL too — leaving OpExplainDDL
 //     effectively unusable in read_only mode. Users must escalate to
-//     safe_write or full_access (issues #28/#29) to use explain-ddl.
+//     safe_write or full_access (issue #29) to use explain-ddl.
 //     The reason text names the escalation path so the rejection is
 //     actionable.
+//
+//   - OpSimulate dispatches per-statement to a non-executing EXPLAIN
+//     flavor (EXPLAIN ANALYZE for SELECT, plain EXPLAIN for DML
+//     writes, EXPLAIN (DDL, SHAPE) for DDL). Because the dispatcher
+//     never executes the inner write or DDL at the cluster level,
+//     read_only mode admits every dispatched class — SELECT, DML
+//     writes, and DDL alike — and only rejects shapes the dispatcher
+//     has no route for: nested EXPLAIN (defense in depth, mirroring
+//     OpExplain), TCL (BEGIN/COMMIT/ROLLBACK have no EXPLAIN form),
+//     and DCL (GRANT/REVOKE, out of scope for the dispatcher).
 func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 	tag := stmt.StatementTag()
 	switch op {
@@ -234,6 +247,42 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 			Reason: "explain_ddl modifies schema; rerun with --mode=safe_write or --mode=full_access",
 			Mode:   ModeReadOnly,
 			Op:     op,
+		}
+	case OpSimulate:
+		// Reject nested EXPLAIN wrappers explicitly. The dispatcher
+		// classifies the inner statement to pick a route, but
+		// tree.CanWriteData/CanModifySchema do not descend into
+		// *Explain/*ExplainAnalyze AST nodes — so a wrapped write
+		// would otherwise be misclassified as a SELECT and dispatched
+		// to EXPLAIN ANALYZE, which executes. Reject the nested form
+		// before any cluster contact and tell the caller to unwrap.
+		switch stmt.(type) {
+		case *tree.Explain, *tree.ExplainAnalyze:
+			return &Violation{
+				Tag:    tag,
+				Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
+		}
+		switch stmt.StatementType() {
+		case tree.TypeDDL, tree.TypeDML:
+			// Dispatcher has a route: DDL → EXPLAIN (DDL, SHAPE),
+			// DML write → EXPLAIN, SELECT → EXPLAIN ANALYZE. None of
+			// these execute the inner write or DDL at the cluster
+			// level, so read_only mode admits them.
+			return nil
+		default:
+			// TCL (BEGIN/COMMIT/ROLLBACK/SAVEPOINT) has no EXPLAIN
+			// form. DCL (GRANT/REVOKE) is out of scope for the
+			// dispatcher today. Both surface the same actionable
+			// reason so callers can branch on Tag.
+			return &Violation{
+				Tag:    tag,
+				Reason: "simulate has no route for this statement type; only DDL, DML, and SELECT are supported",
+				Mode:   ModeReadOnly,
+				Op:     op,
+			}
 		}
 	default:
 		return &Violation{

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -106,7 +106,7 @@ func TestCheckReadOnlyExplainDDL(t *testing.T) {
 
 func TestCheckRejectsUnimplementedModes(t *testing.T) {
 	// safe_write and full_access parse successfully (per ParseMode)
-	// but Check rejects them until issues #28/#29. The rejection
+	// but Check rejects them until issue #29. The rejection
 	// reason names the mode so an agent can recognise the
 	// "not implemented" condition vs a real classification miss.
 	tests := []struct {
@@ -169,6 +169,101 @@ func TestCheckRejectsEmptyInput(t *testing.T) {
 			require.Contains(t, v.Reason, "no statements parsed")
 		})
 	}
+}
+
+func TestCheckReadOnlySimulate(t *testing.T) {
+	// OpSimulate dispatches to a non-executing EXPLAIN flavor for
+	// each supported statement class, so read_only mode admits SELECT,
+	// DML writes, and DDL alike. The rejections are scoped to shapes
+	// the dispatcher has no route for: TCL, DCL, and nested EXPLAIN.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedReason string
+	}{
+		// Dispatchable shapes are admitted.
+		{name: "select", sql: "SELECT * FROM t"},
+		{name: "select with cte", sql: "WITH cte AS (SELECT 1) SELECT * FROM cte"},
+		{name: "values", sql: "VALUES (1), (2)"},
+		{name: "insert", sql: "INSERT INTO t VALUES (1)"},
+		{name: "update", sql: "UPDATE t SET x = 1 WHERE id = 1"},
+		{name: "delete", sql: "DELETE FROM t WHERE id = 1"},
+		{name: "upsert", sql: "UPSERT INTO t VALUES (1)"},
+		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
+		{name: "alter table add column", sql: "ALTER TABLE x ADD COLUMN y INT"},
+		{name: "drop table", sql: "DROP TABLE x"},
+		{name: "create index", sql: "CREATE INDEX i ON t (c)"},
+
+		// TCL has no EXPLAIN form.
+		{
+			name:           "begin rejected",
+			sql:            "BEGIN",
+			expectedReject: true,
+			expectedReason: "no route",
+		},
+		{
+			name:           "commit rejected",
+			sql:            "COMMIT",
+			expectedReject: true,
+			expectedReason: "no route",
+		},
+
+		// DCL is out of scope for the dispatcher.
+		{
+			name:           "grant rejected",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedReject: true,
+			expectedReason: "no route",
+		},
+		{
+			name:           "revoke rejected",
+			sql:            "REVOKE SELECT ON t FROM bob",
+			expectedReject: true,
+			expectedReason: "no route",
+		},
+
+		// Nested EXPLAIN wrappers are rejected with the same reason
+		// OpExplain uses, so a caller migrating between operations
+		// gets a consistent message.
+		{
+			name:           "nested explain rejected",
+			sql:            "EXPLAIN SELECT 1",
+			expectedReject: true,
+			expectedReason: "nested EXPLAIN",
+		},
+		{
+			name:           "nested explain analyze rejected",
+			sql:            "EXPLAIN ANALYZE INSERT INTO t VALUES (1)",
+			expectedReject: true,
+			expectedReason: "nested EXPLAIN",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpSimulate, tc.sql)
+			require.NoError(t, err)
+
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted under OpSimulate")
+				return
+			}
+			require.NotNil(t, v, "expected statement to be rejected")
+			require.Equal(t, safety.ModeReadOnly, v.Mode)
+			require.Equal(t, safety.OpSimulate, v.Op)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
+func TestOperationStringIncludesSimulate(t *testing.T) {
+	// Operation.String is the wire-stable token agents branch on.
+	// Pin every value so a future enum addition that forgets to
+	// extend the switch (returning "unknown") fails loudly.
+	require.Equal(t, "explain", safety.OpExplain.String())
+	require.Equal(t, "explain_ddl", safety.OpExplainDDL.String())
+	require.Equal(t, "simulate", safety.OpSimulate.String())
 }
 
 func TestCheckRejectsNestedExplain(t *testing.T) {

--- a/internal/safety/envelope_test.go
+++ b/internal/safety/envelope_test.go
@@ -67,7 +67,7 @@ func TestEnvelopeSuggestionsByOp(t *testing.T) {
 
 func TestEnvelopeNoSuggestionForUnimplementedModes(t *testing.T) {
 	// safe_write/full_access violations are "not implemented" — the
-	// fix is to wait for issues #28/#29, not to escalate. So no
+	// fix is to wait for issue #29, not to escalate. So no
 	// suggestion is offered.
 	e := safety.Envelope(&safety.Violation{
 		Tag:  "SELECT",

--- a/internal/safety/mode.go
+++ b/internal/safety/mode.go
@@ -26,7 +26,7 @@
 // Design doc reference: §Safety Model (read_only is the default,
 // safe_write and full_access are opt-in escalations). Issue #21 wires
 // read_only end-to-end; safe_write and full_access enforcement land in
-// follow-up issues #28 and #29.
+// follow-up issue #29.
 package safety
 
 import "fmt"
@@ -38,7 +38,7 @@ type Mode string
 
 // Mode values. ModeReadOnly is the default for every Tier 3 command;
 // the other two are recognised by ParseMode but rejected by Check
-// until issues #28 and #29 land.
+// until issue #29 lands.
 const (
 	ModeReadOnly   Mode = "read_only"
 	ModeSafeWrite  Mode = "safe_write"
@@ -60,7 +60,7 @@ const DefaultMode = ModeReadOnly
 //
 // safe_write and full_access parse successfully even though Check
 // currently rejects them — the split keeps the flag-parsing layer
-// stable across issues #28/#29 so the only churn when those modes land
+// stable across issue #29 so the only churn when those modes land
 // is inside Check.
 func ParseMode(s string) (Mode, error) {
 	switch Mode(s) {


### PR DESCRIPTION
Add a `crdb-sql simulate` CLI subcommand and matching `simulate_sql`
MCP tool that show the effect of one or more statements without
applying them. Each parsed statement is dispatched to a non-executing
EXPLAIN flavor:

  - SELECT runs through EXPLAIN ANALYZE inside a read-only txn.
    ANALYZE physically executes the statement, but SELECT has no side
    effects, so the runtime stats (rows read, network bytes, time)
    come back without persisting anything.
  - INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN. The
    optimizer's estimated plan is returned and the write is never
    applied. We trade measured stats for honest safety here.
  - DDL runs through EXPLAIN (DDL, SHAPE) plus SHOW STATISTICS for
    each affected table. The declarative schema changer compiles a
    plan without applying it; the row-count annotation gives the
    agent a rough handle on backfill cost.

This intentionally rejects the txn+rollback wrapper that issue #28
originally proposed. That approach cannot suppress sequence
increments, volatile function side effects, or audit triggers
because those state changes are not transactional. The
EXPLAIN-based dispatcher avoids the leak surface entirely by never
executing the inner write or DDL at the cluster level.

A new `safety.OpSimulate` operation gates the dispatcher: under the
default `read_only` mode it admits SELECT, DML writes, and DDL
(because none of them execute), and rejects nested EXPLAIN, TCL,
and DCL — shapes the dispatcher has no route for. Multi-statement
input is per-statement: one SimulateStep is returned per parsed
statement, so a mixed batch like
`SELECT 1; INSERT ...; ALTER TABLE ...` returns three independently
routed steps in order.

Resolves: #28