### PR TITLE
risk: add cross-statement transactional and DDL hygiene rules

### DIFF
--- a/internal/risk/registry.go
+++ b/internal/risk/registry.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -81,19 +82,49 @@ type Rule struct {
 	Check      func(input CheckInput) []Finding
 }
 
-// Registry holds an ordered set of rules and runs them against parsed
-// SQL. Built by NewRegistry and immutable afterward; rule evaluation
-// order matches the order provided to the constructor.
-type Registry struct {
-	rules []Rule
+// MultiCheckInput is the context passed to a multi-statement rule's
+// check function. Stmts is the full parsed statement list for the SQL
+// passed to Analyze; Positions[i] is the location of Stmts[i] within
+// the original SQL. The two slices have the same length and are
+// indexed in parallel.
+type MultiCheckInput struct {
+	Stmts     statements.Statements
+	Positions []Position
 }
 
-// NewRegistry creates a registry from the given rules. Rules are
-// evaluated in the order provided. It panics if any rule has a nil
-// Check function, an empty ReasonCode, or a ReasonCode that duplicates
-// a previously registered rule.
-func NewRegistry(rules ...Rule) *Registry {
-	seen := make(map[string]bool, len(rules))
+// MultiRule defines a risk detection rule that needs to look across
+// more than one parsed statement at a time (e.g. spotting multiple
+// DDL statements inside a single explicit BEGIN..COMMIT block). The
+// Check function is invoked once per Analyze call with the full
+// statement list and returns any findings; it is expected to return
+// nil when the input does not contain anything relevant.
+type MultiRule struct {
+	ReasonCode string
+	Severity   Severity
+	Category   string
+	Check      func(input MultiCheckInput) []Finding
+}
+
+// Registry holds an ordered set of per-statement rules and an ordered
+// set of multi-statement rules, and runs them against parsed SQL.
+// Built by NewRegistry and immutable afterward; rule evaluation order
+// matches the order provided to the constructor (per-statement rules
+// run first, in registration order, for each statement; multi-rules
+// run afterward, in registration order, once per Analyze call).
+type Registry struct {
+	rules      []Rule
+	multiRules []MultiRule
+}
+
+// NewRegistry creates a registry from the given per-statement rules
+// and multi-statement rules. Either slice may be nil. Rules are
+// evaluated in the order provided: per-statement rules in
+// registration order for each statement, then multi-statement rules
+// in registration order once per Analyze call. It panics if any rule
+// has a nil Check function, an empty ReasonCode, or a ReasonCode that
+// duplicates any other registered rule (across both slices).
+func NewRegistry(rules []Rule, multiRules []MultiRule) *Registry {
+	seen := make(map[string]bool, len(rules)+len(multiRules))
 	for _, rule := range rules {
 		if rule.Check == nil {
 			panic(fmt.Sprintf("risk: rule %q has nil Check function", rule.ReasonCode))
@@ -106,15 +137,30 @@ func NewRegistry(rules ...Rule) *Registry {
 		}
 		seen[rule.ReasonCode] = true
 	}
-	return &Registry{rules: rules}
+	for _, rule := range multiRules {
+		if rule.Check == nil {
+			panic(fmt.Sprintf("risk: multi-rule %q has nil Check function", rule.ReasonCode))
+		}
+		if rule.ReasonCode == "" {
+			panic("risk: multi-rule has empty ReasonCode")
+		}
+		if seen[rule.ReasonCode] {
+			panic(fmt.Sprintf("risk: duplicate ReasonCode %q", rule.ReasonCode))
+		}
+		seen[rule.ReasonCode] = true
+	}
+	return &Registry{rules: rules, multiRules: multiRules}
 }
 
-// Analyze parses sql and applies every registered rule to every
-// statement. Findings are returned in statement order; within a
-// statement, rules are evaluated in registration order. The registry
-// stamps each finding's ReasonCode and Severity from the rule that
-// produced it, so individual rules only need to set Message, Position,
-// and FixHint.
+// Analyze parses sql and applies every registered rule. Per-statement
+// rules run first, in statement order, with rules evaluated in
+// registration order within each statement; multi-statement rules run
+// afterward, in registration order, each invoked once over the full
+// statement list. Findings are returned in production order, so all
+// per-statement findings precede all multi-statement findings. The
+// registry stamps each finding's ReasonCode and Severity from the
+// rule that produced it, so individual rules only need to set
+// Message, Position, and FixHint.
 func (r *Registry) Analyze(sql string) ([]Finding, error) {
 	stmts, err := parser.Parse(sql)
 	if err != nil {
@@ -122,9 +168,11 @@ func (r *Registry) Analyze(sql string) ([]Finding, error) {
 	}
 
 	findings := []Finding{}
+	positions := make([]Position, len(stmts))
 	offset := 0
-	for _, stmt := range stmts {
+	for i, stmt := range stmts {
 		pos := positionFromSQL(sql, stmt.SQL, &offset)
+		positions[i] = pos
 		input := CheckInput{
 			AST:      stmt.AST,
 			StmtSQL:  stmt.SQL,
@@ -138,13 +186,23 @@ func (r *Registry) Analyze(sql string) ([]Finding, error) {
 			}
 		}
 	}
+
+	multiInput := MultiCheckInput{Stmts: stmts, Positions: positions}
+	for _, rule := range r.multiRules {
+		for _, f := range rule.Check(multiInput) {
+			f.ReasonCode = rule.ReasonCode
+			f.Severity = rule.Severity
+			findings = append(findings, f)
+		}
+	}
 	return findings, nil
 }
 
 // Analyze is a convenience function that runs the default rule set
-// against sql. It is equivalent to NewRegistry(DefaultRules()...).Analyze(sql).
+// against sql. It is equivalent to
+// NewRegistry(DefaultRules(), DefaultMultiRules()).Analyze(sql).
 func Analyze(sql string) ([]Finding, error) {
-	return NewRegistry(DefaultRules()...).Analyze(sql)
+	return NewRegistry(DefaultRules(), DefaultMultiRules()).Analyze(sql)
 }
 
 // positionFromSQL computes the Position of stmtSQL within fullSQL,

--- a/internal/risk/rules.go
+++ b/internal/risk/rules.go
@@ -10,6 +10,7 @@ import (
 	"go/constant"
 	"strings"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -30,7 +31,8 @@ func isStar(expr tree.Expr) bool {
 	return false
 }
 
-// DefaultRules returns the built-in set of AST-only risk rules.
+// DefaultRules returns the built-in set of AST-only risk rules that
+// inspect a single statement at a time.
 func DefaultRules() []Rule {
 	return []Rule{
 		deleteNoWhereRule,
@@ -46,6 +48,16 @@ func DefaultRules() []Rule {
 		missingPrimaryKeyRule,
 		largeOffsetRule,
 		xaPreparedTxnRule,
+		savepointCockroachRestartRule,
+	}
+}
+
+// DefaultMultiRules returns the built-in set of AST-only risk rules
+// that need to look across more than one parsed statement at a time.
+func DefaultMultiRules() []MultiRule {
+	return []MultiRule{
+		multipleDDLInTxnRule,
+		ddlAndDMLInTxnRule,
 	}
 }
 
@@ -486,5 +498,187 @@ var selectStarRule = Rule{
 			}
 		}
 		return nil
+	},
+}
+
+// cockroachRestartSavepointName is the well-known savepoint name used
+// by the legacy CockroachDB client-side retry pattern.
+const cockroachRestartSavepointName = "cockroach_restart"
+
+// savepointName extracts the savepoint name from a SAVEPOINT, RELEASE
+// SAVEPOINT, or ROLLBACK TO SAVEPOINT statement and reports whether
+// the AST was one of those statement kinds.
+func savepointName(stmt tree.Statement) (tree.Name, bool) {
+	switch s := stmt.(type) {
+	case *tree.Savepoint:
+		return s.Name, true
+	case *tree.ReleaseSavepoint:
+		return s.Savepoint, true
+	case *tree.RollbackToSavepoint:
+		return s.Savepoint, true
+	}
+	return "", false
+}
+
+// savepointCockroachRestartRule flags any use of the well-known
+// `cockroach_restart` savepoint name. This is the legacy client-side
+// retry pattern for serialization failures (SQLSTATE 40001). The
+// recommended pattern in modern CockroachDB is to retry the whole
+// BEGIN..COMMIT with exponential backoff in the application or
+// driver, rather than relying on a per-savepoint rollback. The
+// savepoint syntax is still accepted, but applications that depend
+// on it are running fragile retry logic; the fix is to move retry
+// out of SQL and into the caller. Comparison is case-insensitive so
+// quoted variants like "Cockroach_Restart" are also caught.
+var savepointCockroachRestartRule = Rule{
+	ReasonCode: "SAVEPOINT_COCKROACH_RESTART",
+	Severity:   SeverityMedium,
+	Category:   "transactional_safety",
+	Check: func(input CheckInput) []Finding {
+		name, ok := savepointName(input.AST)
+		if !ok || !strings.EqualFold(string(name), cockroachRestartSavepointName) {
+			return nil
+		}
+		var verb string
+		switch input.AST.(type) {
+		case *tree.Savepoint:
+			verb = "SAVEPOINT cockroach_restart"
+		case *tree.ReleaseSavepoint:
+			verb = "RELEASE SAVEPOINT cockroach_restart"
+		case *tree.RollbackToSavepoint:
+			verb = "ROLLBACK TO SAVEPOINT cockroach_restart"
+		}
+		return []Finding{{
+			Message:  fmt.Sprintf("%s is the legacy client-side retry pattern; modern CockroachDB recommends retrying the whole BEGIN..COMMIT in the application instead", verb),
+			Position: &input.Position,
+			FixHint:  "Drop the savepoint and retry the entire BEGIN..COMMIT block with exponential backoff on SQLSTATE 40001",
+		}}
+	},
+}
+
+// txnBlock identifies one explicit BEGIN..COMMIT/ROLLBACK span
+// within a parsed statement list. Start is the index of the BEGIN
+// statement; End is the index of the closing COMMIT/ROLLBACK, or
+// len(stmts) if the block was never closed. The half-open range
+// [Start+1, End) covers the inner statements.
+type txnBlock struct {
+	Start, End int
+}
+
+// explicitTxnBlocks scans stmts for BEGIN..COMMIT/ROLLBACK spans and
+// returns one txnBlock per BEGIN encountered. CockroachDB does not
+// support real nested transactions, but the parser accepts a BEGIN
+// that appears while another block is open; in that case we open a
+// new block at the inner BEGIN and close it on the next
+// COMMIT/ROLLBACK (LIFO via a stack). Two consequences worth noting:
+//
+//   - In a nested case, the outer block's [Start+1, End) range
+//     subsumes the inner block's range, so each inner statement is
+//     visible to multi-rules as a member of every enclosing block.
+//     This matches CRDB semantics: anything inside the outer BEGIN is
+//     part of that outer transaction.
+//   - Any block that never sees a matching COMMIT/ROLLBACK keeps its
+//     initial End = len(stmts), so its range extends to end-of-input.
+//     Multi-rules then over-flag rather than under-flag, which is the
+//     intended conservative stance here.
+//
+// Surplus COMMIT/ROLLBACK statements with no open block are ignored.
+// Statements outside any block (implicit transactions) do not
+// contribute to any txnBlock.
+func explicitTxnBlocks(stmts statements.Statements) []txnBlock {
+	var blocks []txnBlock
+	// openStack holds indexes into blocks for currently-open spans;
+	// the innermost open block is at the top.
+	var openStack []int
+	for i, s := range stmts {
+		switch s.AST.(type) {
+		case *tree.BeginTransaction:
+			blocks = append(blocks, txnBlock{Start: i, End: len(stmts)})
+			openStack = append(openStack, len(blocks)-1)
+		case *tree.CommitTransaction, *tree.RollbackTransaction:
+			if len(openStack) == 0 {
+				continue
+			}
+			top := openStack[len(openStack)-1]
+			openStack = openStack[:len(openStack)-1]
+			blocks[top].End = i
+		}
+	}
+	return blocks
+}
+
+// multipleDDLInTxnRule flags any explicit BEGIN..COMMIT block that
+// contains more than one DDL statement. CockroachDB runs each DDL as
+// an asynchronous online schema change job; bundling several into one
+// user transaction is fragile because a failure mid-transaction can
+// leave the schema in a partially-applied state, and dropped names
+// cannot be reused in the same transaction. Best practice is one DDL
+// per transaction. The rule emits one finding per *extra* DDL beyond
+// the first, each pointing at the offending DDL's position, so a
+// block with three DDLs produces two findings.
+var multipleDDLInTxnRule = MultiRule{
+	ReasonCode: "MULTIPLE_DDL_IN_TXN",
+	Severity:   SeverityHigh,
+	Category:   "transactional_safety",
+	Check: func(input MultiCheckInput) []Finding {
+		var findings []Finding
+		for _, blk := range explicitTxnBlocks(input.Stmts) {
+			seenFirst := false
+			for i := blk.Start + 1; i < blk.End; i++ {
+				stmt := input.Stmts[i].AST
+				if stmt.StatementType() != tree.TypeDDL {
+					continue
+				}
+				if !seenFirst {
+					seenFirst = true
+					continue
+				}
+				pos := input.Positions[i]
+				findings = append(findings, Finding{
+					Message:  fmt.Sprintf("additional DDL (%s) in the same explicit transaction; CockroachDB runs each DDL as an online schema change and may leave the schema partially applied if any one fails", stmt.StatementTag()),
+					Position: &pos,
+					FixHint:  "Run each DDL in its own transaction (one BEGIN..COMMIT per DDL)",
+				})
+			}
+		}
+		return findings
+	},
+}
+
+// ddlAndDMLInTxnRule flags any explicit BEGIN..COMMIT block that
+// contains both a DDL statement and a DML statement, classified by
+// the parser's tree.StatementType() (TypeDDL vs TypeDML). The schema
+// change commits asynchronously, so the DML in the same txn may
+// observe an inconsistent intermediate schema or the txn may abort
+// with an error that is hard to reason about. The rule emits one
+// finding per offending block, anchored at the BEGIN, regardless of
+// how many DDL or DML statements the block contains.
+var ddlAndDMLInTxnRule = MultiRule{
+	ReasonCode: "DDL_AND_DML_IN_TXN",
+	Severity:   SeverityMedium,
+	Category:   "transactional_safety",
+	Check: func(input MultiCheckInput) []Finding {
+		var findings []Finding
+		for _, blk := range explicitTxnBlocks(input.Stmts) {
+			var hasDDL, hasDML bool
+			for i := blk.Start + 1; i < blk.End; i++ {
+				switch input.Stmts[i].AST.StatementType() {
+				case tree.TypeDDL:
+					hasDDL = true
+				case tree.TypeDML:
+					hasDML = true
+				}
+			}
+			if !hasDDL || !hasDML {
+				continue
+			}
+			pos := input.Positions[blk.Start]
+			findings = append(findings, Finding{
+				Message:  "explicit transaction mixes DDL and DML; the asynchronous schema change can leave the DML observing an inconsistent intermediate schema",
+				Position: &pos,
+				FixHint:  "Split the transaction so DDL and DML run separately (one BEGIN..COMMIT per DDL, with DML in its own transactions)",
+			})
+		}
+		return findings
 	},
 }

--- a/internal/risk/rules_test.go
+++ b/internal/risk/rules_test.go
@@ -287,6 +287,126 @@ func TestAnalyze(t *testing.T) {
 			sql:                 "PREPARE q AS SELECT 1",
 			expectedReasonCodes: nil,
 		},
+		{
+			name:                "two DDLs in explicit txn flag",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN"},
+		},
+		{
+			name:                "three DDLs in explicit txn flag twice",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); CREATE TABLE c (id INT PRIMARY KEY); COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN", "MULTIPLE_DDL_IN_TXN"},
+		},
+		{
+			name:                "single DDL in explicit txn is safe",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); COMMIT;",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "two DDLs in implicit txn do not flag",
+			sql:                 "CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY);",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "DDL then DML in explicit txn flags",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); SELECT 1; COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "DML then DDL in explicit txn flags",
+			sql:                 "BEGIN; INSERT INTO t VALUES (1); ALTER TABLE t ADD COLUMN x INT; COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "explicit txn with only DDLs does not trigger DDL_AND_DML",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN"},
+		},
+		{
+			name:                "explicit txn with only DML does not flag",
+			sql:                 "BEGIN; INSERT INTO t VALUES (1); SELECT id FROM t WHERE id = 1; COMMIT;",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "ROLLBACK closes the txn block for cross-stmt rules",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); SELECT 1; ROLLBACK;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "multi-DDL plus DML emits both rules",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); INSERT INTO a VALUES (1); COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN", "DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "SAVEPOINT cockroach_restart flags",
+			sql:                 "SAVEPOINT cockroach_restart",
+			expectedReasonCodes: []string{"SAVEPOINT_COCKROACH_RESTART"},
+		},
+		{
+			name:                "RELEASE SAVEPOINT cockroach_restart flags",
+			sql:                 "RELEASE SAVEPOINT cockroach_restart",
+			expectedReasonCodes: []string{"SAVEPOINT_COCKROACH_RESTART"},
+		},
+		{
+			name:                "ROLLBACK TO SAVEPOINT cockroach_restart flags",
+			sql:                 "ROLLBACK TO SAVEPOINT cockroach_restart",
+			expectedReasonCodes: []string{"SAVEPOINT_COCKROACH_RESTART"},
+		},
+		{
+			name:                "SAVEPOINT cockroach_restart case-insensitive",
+			sql:                 `SAVEPOINT "Cockroach_Restart"`,
+			expectedReasonCodes: []string{"SAVEPOINT_COCKROACH_RESTART"},
+		},
+		{
+			name:                "user-named savepoint is safe",
+			sql:                 "SAVEPOINT my_app_sp",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "explicit txn with multi-DDL plus multi-DML emits one DDL_AND_DML finding",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); INSERT INTO t VALUES (1); SELECT id FROM t WHERE id = 1; COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "DDL plus UPDATE flags DDL_AND_DML",
+			sql:                 "BEGIN; CREATE TABLE u (id INT PRIMARY KEY); UPDATE u SET id = 2 WHERE id = 1; COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "DDL plus DELETE flags DDL_AND_DML",
+			sql:                 "BEGIN; CREATE TABLE d (id INT PRIMARY KEY); DELETE FROM d WHERE id = 1; COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "DDL plus UPSERT flags DDL_AND_DML",
+			sql:                 "BEGIN; CREATE TABLE u (id INT PRIMARY KEY); UPSERT INTO u VALUES (1); COMMIT;",
+			expectedReasonCodes: []string{"DDL_AND_DML_IN_TXN"},
+		},
+		{
+			name:                "two consecutive explicit txns each with multi-DDL flag separately",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); COMMIT; BEGIN; CREATE TABLE c (id INT PRIMARY KEY); CREATE TABLE d (id INT PRIMARY KEY); COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN", "MULTIPLE_DDL_IN_TXN"},
+		},
+		{
+			name:                "BEGIN without matching COMMIT still scans the unterminated block",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY);",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN"},
+		},
+		{
+			name:                "surplus COMMIT before any BEGIN does not panic and emits nothing for the multi-rules",
+			sql:                 "COMMIT; CREATE TABLE x (id INT PRIMARY KEY);",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "surplus ROLLBACK before any BEGIN does not panic and emits nothing for the multi-rules",
+			sql:                 "ROLLBACK; CREATE TABLE x (id INT PRIMARY KEY);",
+			expectedReasonCodes: nil,
+		},
+		{
+			name:                "nested BEGIN: outer block sees both DDLs and flags MULTIPLE_DDL once",
+			sql:                 "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); BEGIN; CREATE TABLE b (id INT PRIMARY KEY); COMMIT; COMMIT;",
+			expectedReasonCodes: []string{"MULTIPLE_DDL_IN_TXN"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -385,6 +505,21 @@ func TestFindingSeverity(t *testing.T) {
 			sql:              "PREPARE TRANSACTION 'tx1'",
 			expectedSeverity: SeverityHigh,
 		},
+		{
+			name:             "MULTIPLE_DDL_IN_TXN is high",
+			sql:              "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); CREATE TABLE b (id INT PRIMARY KEY); COMMIT;",
+			expectedSeverity: SeverityHigh,
+		},
+		{
+			name:             "DDL_AND_DML_IN_TXN is medium",
+			sql:              "BEGIN; CREATE TABLE a (id INT PRIMARY KEY); SELECT 1; COMMIT;",
+			expectedSeverity: SeverityMedium,
+		},
+		{
+			name:             "SAVEPOINT_COCKROACH_RESTART is medium",
+			sql:              "SAVEPOINT cockroach_restart",
+			expectedSeverity: SeverityMedium,
+		},
 	}
 
 	for _, tc := range tests {
@@ -442,4 +577,46 @@ func TestTruncateCascadeMessageMentionsForeignKeys(t *testing.T) {
 	require.Len(t, findings, 1)
 	require.Contains(t, findings[0].Message, "CASCADE")
 	require.Contains(t, findings[0].Message, "foreign keys")
+}
+
+// TestMultipleDDLInTxnFindingPositions pins down the rule's "one
+// finding per *extra* DDL beyond the first, anchored at that DDL"
+// contract. Each statement is on its own line so position.Line
+// uniquely identifies which statement the finding refers to.
+func TestMultipleDDLInTxnFindingPositions(t *testing.T) {
+	sql := "BEGIN;\n" +
+		"CREATE TABLE a (id INT PRIMARY KEY);\n" +
+		"CREATE TABLE b (id INT PRIMARY KEY);\n" +
+		"CREATE TABLE c (id INT PRIMARY KEY);\n" +
+		"COMMIT;"
+	findings, err := Analyze(sql)
+	require.NoError(t, err)
+	require.Len(t, findings, 2)
+	require.Equal(t, "MULTIPLE_DDL_IN_TXN", findings[0].ReasonCode)
+	require.Equal(t, "MULTIPLE_DDL_IN_TXN", findings[1].ReasonCode)
+	require.NotNil(t, findings[0].Position)
+	require.NotNil(t, findings[1].Position)
+	// First finding points at the second DDL (line 3); second points
+	// at the third DDL (line 4). The first DDL on line 2 is never
+	// itself flagged.
+	require.Equal(t, 3, findings[0].Position.Line)
+	require.Equal(t, 4, findings[1].Position.Line)
+}
+
+// TestDDLAndDMLInTxnFindingAnchoredAtBegin pins down the
+// "one finding per offending block, anchored at the BEGIN" contract.
+func TestDDLAndDMLInTxnFindingAnchoredAtBegin(t *testing.T) {
+	sql := "SELECT 1;\n" +
+		"BEGIN;\n" +
+		"CREATE TABLE a (id INT PRIMARY KEY);\n" +
+		"INSERT INTO a VALUES (1);\n" +
+		"COMMIT;"
+	findings, err := Analyze(sql)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Equal(t, "DDL_AND_DML_IN_TXN", findings[0].ReasonCode)
+	require.NotNil(t, findings[0].Position)
+	// BEGIN is on line 2; finding must point there, not at the inner
+	// DDL (line 3) or DML (line 4).
+	require.Equal(t, 2, findings[0].Position.Line)
 }


### PR DESCRIPTION
Three new reason codes flag CockroachDB-specific transactional and DDL
hazards that the existing per-statement Rule shape could not express:

- **MULTIPLE_DDL_IN_TXN** (high) — more than one DDL in one explicit
  `BEGIN..COMMIT` block. CockroachDB runs each DDL as an asynchronous
  online schema change job; bundling several into one user transaction
  is fragile because a failure mid-transaction can leave the schema
  partially applied and dropped names cannot be reused.
- **DDL_AND_DML_IN_TXN** (medium) — an explicit transaction that
  contains both a DDL and a DML statement
  (`SELECT`/`INSERT`/`UPDATE`/`DELETE`/`UPSERT`). The schema change
  commits asynchronously, so the DML may observe an inconsistent
  intermediate schema.
- **SAVEPOINT_COCKROACH_RESTART** (medium) — any use of the legacy
  `cockroach_restart` savepoint name (case-insensitive) for
  `SAVEPOINT`, `RELEASE SAVEPOINT`, or `ROLLBACK TO SAVEPOINT`. The
  recommended pattern in modern CockroachDB is to retry the whole
  `BEGIN..COMMIT` in the application with exponential backoff on
  SQLSTATE 40001.

The first two rules need cross-statement context. Rather than
extending `CheckInput` (which would tax every per-statement rule), the
engine grows a parallel `MultiRule` shape:

```go
type MultiCheckInput struct {
    Stmts     statements.Statements
    Positions []Position
}
type MultiRule struct { ReasonCode; Severity; Category; Check }
```

`Registry` now holds both rule kinds. `Analyze` runs per-statement
rules in the existing loop, builds a positions slice in parallel,
then dispatches each `MultiRule` once with the full statement list.
`ReasonCode` uniqueness is enforced across both slices.

DDL/DML classification reuses the parser's `tree.StatementType()`
(`TypeDDL` / `TypeDML`), so coverage tracks the parser as new
statement kinds are added rather than requiring a hand-maintained
AST list.

A small `explicitTxnBlocks` helper walks `BEGIN`/`COMMIT`/`ROLLBACK`
with a stack so the parser-accepted (CRDB-rejected) nested-BEGIN case
is handled conservatively: each `BEGIN` opens a fresh block.

Resolves: #126