### PR TITLE
exec: add crdb-sql exec and execute_sql MCP tool with safety guardrails

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,275 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+)
+
+// defaultExecMaxRows is the row cap applied to execute results when
+// the user does not override --max-rows. Picked to be large enough
+// for typical agent-driven analysis while still bounding a runaway
+// SELECT * or a wide RETURNING set. The cap drives runtime row-scan
+// truncation in conn.Execute on every mode, and additionally drives
+// AST-level LIMIT injection on read_only SELECTs (only that mode
+// gets the rewrite, because non-read_only callers have explicitly
+// opted into writes / unbounded scans).
+//
+// The same default lives in internal/mcp/tools/execute.go
+// (defaultExecuteMaxRows); the two are intentionally not shared via
+// a common package so the cmd layer does not pull in
+// internal/mcp/tools (the MCP tool implementations) just to read a
+// constant. They must be kept in sync by hand.
+const defaultExecMaxRows = 1000
+
+// newExecCmd builds the `crdb-sql exec` subcommand. It runs the
+// supplied SQL against the cluster identified by --dsn (or the
+// CRDB_DSN env var) and renders the rows + command tag in the same
+// envelope shape used by the other Tier 3 commands.
+//
+// Safety policy is selected by --mode (default read_only). The flow:
+//
+//  1. Parse the mode and the input SQL (sqlinput allows -e, file arg,
+//     or stdin).
+//  2. Run safety.Check before any cluster contact. A violation produces
+//     a structured envelope with connection_status=disconnected.
+//  3. For read_only SELECTs without a LIMIT, inject one bounded by
+//     --max-rows so an unbounded SELECT * cannot blow up the response.
+//  4. Hand off to conn.Manager.Execute, which applies the per-mode
+//     transaction wrapper (read-only txn, sql_safe_updates, statement
+//     timeout) for cluster-side defense-in-depth.
+//
+// Demo (matches issue #29):
+//
+//	crdb-sql exec -e "SELECT * FROM users"             — succeeds (read_only)
+//	crdb-sql exec -e "DELETE FROM users"               — safety_violation
+//	crdb-sql exec --mode safe_write -e "DELETE FROM users WHERE id=1"
+//	                                                     — succeeds, prints DELETE 1
+func newExecCmd(state *rootState) *cobra.Command {
+	var (
+		expr    string
+		mode    string
+		timeout time.Duration
+		maxRows int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "exec [file]",
+		Short: "Execute SQL against the cluster with safety guardrails",
+		Long: `Connect to a CockroachDB cluster and execute the supplied SQL. Input
+is read from the -e flag (inline SQL), a positional file argument, or
+stdin. The connection string is read from --dsn or CRDB_DSN (flag wins).
+
+The --mode flag selects the safety policy applied before the cluster
+call:
+
+  read_only   (default) admits SELECT/SHOW/EXPLAIN and other
+              non-mutating statements; rejects writes and DDL.
+  safe_write  also admits INSERT/UPDATE/UPSERT/DELETE; rejects DDL
+              and privilege changes. The cluster also enforces
+              sql_safe_updates so unqualified UPDATE/DELETE fail at
+              runtime.
+  full_access admits any statement that parses; the only guardrail
+              is the statement timeout.
+
+For read_only SELECTs that lack a LIMIT clause, --max-rows is injected
+into the rewritten SQL so the cluster does not stream an unbounded
+result. Set --max-rows=0 to disable both injection and runtime
+truncation.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			sql, err := sqlinput.ReadSQL(expr, args, cmd.InOrStdin())
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			sql = strings.TrimSpace(sql)
+
+			if state.dsn == "" {
+				return r.RenderError(baseEnv,
+					fmt.Errorf("no connection string: pass --dsn or set CRDB_DSN"))
+			}
+
+			parsedMode, err := safety.ParseMode(mode)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+
+			violation, err := safety.Check(parsedMode, safety.OpExecute, sql)
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+			}
+			if violation != nil {
+				return r.RenderErrorEntry(baseEnv,
+					fmt.Errorf("safety violation: %s", violation.Reason),
+					safety.Envelope(violation))
+			}
+
+			// LIMIT injection is scoped to read_only because the other
+			// modes are explicit opt-ins where the user has already
+			// accepted writes / unbounded scans. Injection runs after
+			// safety.Check so we can rely on parsability.
+			rewritten := sql
+			var injected bool
+			if parsedMode == safety.ModeReadOnly && maxRows > 0 {
+				rewritten, injected, err = safety.MaybeInjectLimit(sql, maxRows)
+				if err != nil {
+					return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+				}
+			}
+
+			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
+			defer mgr.Close(cmd.Context()) //nolint:errcheck // best-effort cleanup
+
+			result, err := mgr.Execute(cmd.Context(), rewritten, conn.ExecuteOptions{
+				Mode:    parsedMode,
+				MaxRows: maxRows,
+			})
+			if err != nil {
+				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, rewritten))
+			}
+
+			if injected {
+				limit := maxRows
+				result.LimitInjected = &limit
+			}
+
+			baseEnv.ConnectionStatus = output.ConnectionConnected
+
+			data, err := json.Marshal(result)
+			if err != nil {
+				return r.RenderError(baseEnv, err)
+			}
+			baseEnv.Data = data
+
+			return r.Render(baseEnv, func(w io.Writer) error {
+				return renderExecText(w, result)
+			})
+		},
+	}
+
+	cmd.Flags().StringVarP(&expr, "expression", "e", "", "inline SQL to execute")
+	cmd.Flags().StringVar(&mode, "mode", string(safety.DefaultMode),
+		"safety mode: read_only (default), safe_write, full_access")
+	cmd.Flags().DurationVar(&timeout, "timeout", conn.DefaultStatementTimeout,
+		"statement timeout for the executed call")
+	cmd.Flags().IntVar(&maxRows, "max-rows", defaultExecMaxRows,
+		"maximum rows returned in any mode; additionally drives LIMIT injection on read_only SELECTs. 0 disables both.")
+
+	return cmd
+}
+
+// renderExecText emits the text-mode rendering of an ExecuteResult. The
+// shape splits along the same axis as the JSON envelope:
+//
+//   - Result-set statements (SELECT, RETURNING) render as a tabwriter
+//     table with column headers, followed by a "(N rows[, truncated])"
+//     trailer that names the row count.
+//
+//   - Side-effect-only statements (INSERT/UPDATE/DELETE without
+//     RETURNING, DDL) render as the cluster's command tag on a single
+//     line ("INSERT 0 5", "CREATE TABLE", etc.), which matches what an
+//     operator would see in psql / cockroach sql.
+//
+//   - LIMIT injection is surfaced as a trailing line so an agent
+//     parsing the text output can flag that the result may be
+//     incomplete relative to the original SQL.
+func renderExecText(w io.Writer, res conn.ExecuteResult) error {
+	if len(res.Columns) == 0 {
+		if _, err := fmt.Fprintln(w, res.CommandTag); err != nil {
+			return err
+		}
+		return writeLimitInjectedFooter(w, res.LimitInjected)
+	}
+
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	header := joinCells(columnNames(res.Columns))
+	if _, err := fmt.Fprintln(tw, header); err != nil {
+		return err
+	}
+	for _, row := range res.Rows {
+		cells := make([]string, len(row))
+		for i, v := range row {
+			cells[i] = formatCell(v)
+		}
+		if _, err := fmt.Fprintln(tw, joinCells(cells)); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	trailer := fmt.Sprintf("(%d rows)", res.RowsReturned)
+	if res.Truncated {
+		trailer = fmt.Sprintf("(%d rows, truncated)", res.RowsReturned)
+	}
+	if _, err := fmt.Fprintln(w, trailer); err != nil {
+		return err
+	}
+	return writeLimitInjectedFooter(w, res.LimitInjected)
+}
+
+// writeLimitInjectedFooter prints the "(LIMIT N injected)" trailer
+// when the rewriter ran. Pulled out so both the tabular and the
+// command-tag branches share the same wording.
+func writeLimitInjectedFooter(w io.Writer, limit *int) error {
+	if limit == nil {
+		return nil
+	}
+	_, err := fmt.Fprintf(w, "(LIMIT %d injected)\n", *limit)
+	return err
+}
+
+// columnNames extracts the Name field from each ColumnMeta in order,
+// for tabwriter header rendering. Kept as a separate helper so the
+// renderer body stays focused on flow control rather than slice
+// manipulation.
+func columnNames(cols []conn.ColumnMeta) []string {
+	names := make([]string, len(cols))
+	for i, c := range cols {
+		names[i] = c.Name
+	}
+	return names
+}
+
+// joinCells joins cells with the tab separator that tabwriter
+// expects. strings.Join is enough — no per-cell escaping is needed
+// because tabwriter only treats \t and \n specially.
+func joinCells(cells []string) string {
+	return strings.Join(cells, "\t")
+}
+
+// formatCell stringifies a single result-set value for tabwriter
+// rendering. NULL is the conventional uppercase token; everything else
+// goes through fmt's %v default so ints, strings, floats, and times
+// take their natural representation. Byte slices render as quoted
+// hex-escapes via %q to avoid corrupting the terminal.
+func formatCell(v any) string {
+	if v == nil {
+		return "NULL"
+	}
+	if b, ok := v.([]byte); ok {
+		return fmt.Sprintf("%q", b)
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/cmd/exec_integration_test.go
+++ b/cmd/exec_integration_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// Integration tests for `crdb-sql exec` exercising the full CLI path
+// against a real CockroachDB cluster. Build-tagged so `make test`
+// stays fast; run via `make test-integration`. Mirrors the structure
+// of ping_integration_test.go.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// TestIntegrationExecCmdLimitInjectionReachesEnvelope pins the
+// end-to-end LIMIT-injection contract of the CLI: an unbounded
+// SELECT under read_only with --max-rows must come back with
+// limit_injected populated in the envelope. The unit tests cover
+// MaybeInjectLimit and the renderer in isolation, but only an
+// integration call exercises the cmd/exec.go plumbing that copies
+// the cap onto ExecuteResult.LimitInjected after the rewrite ran.
+func TestIntegrationExecCmdLimitInjectionReachesEnvelope(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"exec",
+		"--output", "json",
+		"--dsn", cluster.DSN,
+		"--max-rows", "3",
+		"-e", "SELECT generate_series(1, 10) AS n",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, output.ConnectionConnected, env.ConnectionStatus)
+	require.Empty(t, env.Errors)
+
+	var res conn.ExecuteResult
+	require.NoError(t, json.Unmarshal(env.Data, &res))
+	require.NotNil(t, res.LimitInjected,
+		"unbounded SELECT under read_only must surface limit_injected")
+	require.Equal(t, 3, *res.LimitInjected)
+	require.Equal(t, 3, res.RowsReturned,
+		"injected LIMIT 3 must cap the result to 3 rows")
+}
+
+// TestIntegrationExecCmdNoLimitInjectionWhenBounded pins the
+// negative case: a SELECT that already has a LIMIT must not get
+// rewritten, and limit_injected must be absent from the envelope.
+func TestIntegrationExecCmdNoLimitInjectionWhenBounded(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"exec",
+		"--output", "json",
+		"--dsn", cluster.DSN,
+		"--max-rows", "1000",
+		"-e", "SELECT generate_series(1, 5) AS n LIMIT 5",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	var res conn.ExecuteResult
+	require.NoError(t, json.Unmarshal(env.Data, &res))
+	require.Nil(t, res.LimitInjected,
+		"caller-supplied LIMIT must not trigger injection")
+	require.Equal(t, 5, res.RowsReturned)
+}
+
+// TestIntegrationExecCmdEnforcesTimeoutFlag pins that the --timeout
+// CLI flag actually reaches conn.Manager. The conn-layer test pins
+// the SQLSTATE 57014 contract on the Manager itself; this CLI test
+// verifies the flag-binding plumbing (a regression that shadowed the
+// variable or used the wrong default would silently revert to 30s
+// and the manager-level test would still pass).
+func TestIntegrationExecCmdEnforcesTimeoutFlag(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"exec",
+		"--output", "json",
+		"--dsn", cluster.DSN,
+		"--timeout", "1ms",
+		"-e", "SELECT pg_sleep(5)",
+	})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "57014",
+		"--timeout=1ms must produce a SQLSTATE 57014 error from the cluster")
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+		"a cluster-side timeout error leaves the manager's recovery contract in place — connection_status reverts")
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// runExec executes `crdb-sql exec` with the supplied args and stdin,
+// returning the captured stdout buffer and the Execute error. Mirrors
+// runExplain so the two surfaces stay diff-friendly.
+func runExec(t *testing.T, stdin string, args ...string) (*bytes.Buffer, error) {
+	t.Helper()
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(append([]string{"exec"}, args...))
+	return &stdout, root.Execute()
+}
+
+// TestExecCmdNoDSN verifies that exec without a DSN fails before any
+// cluster contact, naming both the flag and the env var.
+func TestExecCmdNoDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	_, err := runExec(t, "", "-e", "SELECT 1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no connection string")
+}
+
+// TestExecCmdSafetyRejection verifies that the read_only allowlist
+// short-circuits each mutating statement before any cluster contact.
+// The DSN points at an unreachable host on purpose: a regression that
+// stops short-circuiting would surface a connect error instead of the
+// safety_violation we expect.
+//
+// Some rows pass --mode read_only explicitly to exercise the
+// flag-binding path (a regression that ignored --mode and always
+// used the default would silently pass these without that
+// distinction).
+func TestExecCmdSafetyRejection(t *testing.T) {
+	tests := []struct {
+		name         string
+		sql          string
+		passModeFlag bool
+		expectedTag  string
+	}{
+		{name: "delete (default mode)", sql: "DELETE FROM t WHERE id = 1", expectedTag: "DELETE"},
+		{name: "insert (default mode)", sql: "INSERT INTO t VALUES (1)", expectedTag: "INSERT"},
+		{name: "update (explicit read_only)", sql: "UPDATE t SET x = 1 WHERE id = 1", passModeFlag: true, expectedTag: "UPDATE"},
+		{name: "drop table (explicit read_only)", sql: "DROP TABLE users", passModeFlag: true, expectedTag: "DROP TABLE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"--output", "json",
+				"--dsn", "postgres://nope:1/db?connect_timeout=1"}
+			if tc.passModeFlag {
+				args = append(args, "--mode", "read_only")
+			}
+			args = append(args, "-e", tc.sql)
+			stdout, err := runExec(t, "", args...)
+			require.ErrorIs(t, err, output.ErrRendered)
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+				"safety rejection must short-circuit before any cluster contact")
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, "read_only", env.Errors[0].Context["mode"])
+			require.Equal(t, "execute", env.Errors[0].Context["operation"])
+		})
+	}
+}
+
+// TestExecCmdSafetyRejectionSuggestsEscalation verifies the
+// asymmetric escalation hints end-to-end. The decision is driven by
+// Violation.Kind, not Reason wording, so each row pins the
+// minimum-mode contract for one (Mode, Kind) cell.
+//
+// Critically, GRANT under read_only must escalate straight to
+// full_access — not safe_write, which itself rejects DCL and would
+// loop the agent through a second rejection.
+func TestExecCmdSafetyRejectionSuggestsEscalation(t *testing.T) {
+	tests := []struct {
+		name                string
+		mode                string
+		sql                 string
+		expectedReplacement string
+	}{
+		{
+			name:                "write under read_only suggests safe_write",
+			mode:                "read_only",
+			sql:                 "INSERT INTO t VALUES (1)",
+			expectedReplacement: "safe_write",
+		},
+		{
+			name:                "ddl under read_only suggests full_access",
+			mode:                "read_only",
+			sql:                 "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedReplacement: "full_access",
+		},
+		{
+			name:                "dcl under read_only suggests full_access (skips safe_write loop)",
+			mode:                "read_only",
+			sql:                 "GRANT SELECT ON t TO bob",
+			expectedReplacement: "full_access",
+		},
+		{
+			name:                "ddl under safe_write suggests full_access",
+			mode:                "safe_write",
+			sql:                 "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedReplacement: "full_access",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRDB_DSN", "")
+			stdout, err := runExec(t, "", "--output", "json",
+				"--dsn", "postgres://nope:1/db?connect_timeout=1",
+				"--mode", tc.mode,
+				"-e", tc.sql)
+			require.ErrorIs(t, err, output.ErrRendered)
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+			require.Len(t, env.Errors, 1)
+			require.Len(t, env.Errors[0].Suggestions, 1)
+			require.Equal(t, tc.expectedReplacement, env.Errors[0].Suggestions[0].Replacement)
+		})
+	}
+}
+
+// TestExecCmdInvalidMode verifies that --mode rejects unknown values
+// before any input or cluster contact.
+func TestExecCmdInvalidMode(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://envhost:26257/defaultdb")
+
+	stdout, err := runExec(t, "", "--output", "json",
+		"--mode", "yolo",
+		"-e", "SELECT 1")
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "invalid safety mode")
+}
+
+// TestRenderExecText covers the text-mode rendering branches:
+// tabular output for SELECT-shape results, command-tag-only output for
+// DML without RETURNING, the truncated trailer, and the LIMIT-injected
+// trailer. Pure rendering test; no cluster needed.
+func TestRenderExecText(t *testing.T) {
+	limit := 1000
+	tests := []struct {
+		name             string
+		input            conn.ExecuteResult
+		expectedContains []string
+	}{
+		{
+			name: "tabular select",
+			input: conn.ExecuteResult{
+				Columns:      []conn.ColumnMeta{{Name: "id"}, {Name: "name"}},
+				Rows:         [][]any{{int64(1), "alice"}, {int64(2), "bob"}},
+				RowsReturned: 2,
+				CommandTag:   "SELECT 2",
+			},
+			expectedContains: []string{"id", "name", "alice", "bob", "(2 rows)"},
+		},
+		{
+			name: "tabular truncated",
+			input: conn.ExecuteResult{
+				Columns:      []conn.ColumnMeta{{Name: "n"}},
+				Rows:         [][]any{{int64(1)}, {int64(2)}},
+				RowsReturned: 2,
+				Truncated:    true,
+			},
+			expectedContains: []string{"(2 rows, truncated)"},
+		},
+		{
+			name: "command tag only",
+			input: conn.ExecuteResult{
+				CommandTag:   "INSERT 0 5",
+				RowsAffected: 5,
+			},
+			expectedContains: []string{"INSERT 0 5"},
+		},
+		{
+			name: "limit injection annotated",
+			input: conn.ExecuteResult{
+				Columns:       []conn.ColumnMeta{{Name: "n"}},
+				Rows:          [][]any{{int64(1)}},
+				RowsReturned:  1,
+				LimitInjected: &limit,
+			},
+			expectedContains: []string{"(1 rows)", "LIMIT 1000 injected"},
+		},
+		{
+			name: "null rendered as uppercase token",
+			input: conn.ExecuteResult{
+				Columns:      []conn.ColumnMeta{{Name: "n"}},
+				Rows:         [][]any{{nil}},
+				RowsReturned: 1,
+			},
+			expectedContains: []string{"NULL"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, renderExecText(&buf, tc.input))
+			out := buf.String()
+			for _, want := range tc.expectedContains {
+				require.Contains(t, out, want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,6 +152,7 @@ round-tripping through a live cluster.`,
 	root.AddCommand(newExplainCmd(state))
 	root.AddCommand(newExplainDDLCmd(state))
 	root.AddCommand(newSimulateCmd(state))
+	root.AddCommand(newExecCmd(state))
 	root.AddCommand(newMCPCmd(state))
 	return root
 }

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -424,9 +424,35 @@ Tools that require a higher capability tier return structured
 
 | Mode | Default | Allowed Statements | Guardrails |
 |------|---------|-------------------|------------|
-| `read_only` | Yes | SELECT, SHOW, EXPLAIN, SET (session only) | LIMIT injection, statement timeouts, read-only txn |
-| `safe_write` | No | Above + INSERT, UPDATE, DELETE | `sql_safe_updates` enabled, WHERE required for UPDATE/DELETE, row caps, confirmation hooks |
-| `full_access` | No | All | Warning on dangerous statements, audit log |
+| `read_only` | Yes | SELECT, SHOW, EXPLAIN, SET (session only) | LIMIT injection + row-scan truncation (`--max-rows`, default 1000), statement timeouts, read-only txn |
+| `safe_write` | No | Above + INSERT, UPDATE, DELETE, UPSERT | `SET LOCAL sql_safe_updates = on` (cluster rejects bare UPDATE/DELETE), row-scan truncation, statement timeouts |
+| `full_access` | No | Anything that parses (DDL, DCL, etc.) | Row-scan truncation, statement timeouts (audit log planned) |
+
+Mode wiring per Tier 3 surface (issue #29 lands `execute_sql`; the
+explain surfaces still report "not yet implemented" for `safe_write` /
+`full_access` — wiring them is follow-up work):
+
+| Tool                   | `read_only` | `safe_write` | `full_access` |
+|------------------------|-------------|--------------|---------------|
+| `execute_sql` / `exec` | ✅          | ✅           | ✅            |
+| `explain_sql`          | ✅          | ⏳           | ⏳            |
+| `explain_schema_change`| ✅          | ⏳           | ⏳            |
+
+**LIMIT injection** (read_only only): `safety.MaybeInjectLimit` parses
+the SQL and, when the input is a single bare `SELECT` whose result is
+unbounded (no existing `LIMIT`/`LIMIT ALL`), rewrites it to add
+`LIMIT <max-rows>` before the cluster call. A `SELECT … OFFSET N`
+without a LIMIT counts as unbounded — the rewriter preserves the
+OFFSET and adds the LIMIT. The rewritten cap is surfaced in the
+result envelope (`limit_injected`) so an agent can tell the cluster
+did not return all rows.
+
+**Row-scan truncation** (every mode): independent of injection,
+`Manager.Execute` stops scanning rows from the wire once the cap is
+hit and sets `truncated=true` in the envelope. The statement still
+runs to completion on the cluster (so DML side effects of `INSERT …
+RETURNING` are not undone), but the response payload is bounded.
+`--max-rows 0` disables both LIMIT injection and runtime truncation.
 
 **Defense-in-depth** (three independent layers):
 

--- a/internal/conn/execute.go
+++ b/internal/conn/execute.go
@@ -1,0 +1,240 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+// ColumnMeta names a single column in an Execute result. Type is the
+// pgtype.Type.Name reported by the driver — best-effort, because the
+// pgx type map does not have a registered name for every CRDB-specific
+// OID. When the lookup misses, Type is left empty rather than guessed.
+type ColumnMeta struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
+}
+
+// ExecuteResult is the structured payload from Manager.Execute.
+//
+// Lifecycle: built once per call by runExecute on the success path;
+// consumed once by cmd/exec.go (or the MCP handler) to populate
+// Envelope.Data. The fields split along three axes:
+//
+//   - Result-set shape: Columns + Rows + RowsReturned describe what
+//     the cluster handed back. For DML without RETURNING, Columns is
+//     empty and Rows is nil — callers should check len(Columns) to
+//     decide between "tabular" and "command" rendering.
+//
+//   - Side-effect summary: RowsAffected and CommandTag mirror the
+//     pgwire CommandTag (e.g. "INSERT 0 5"). Always populated, even
+//     for SELECTs (RowsAffected matches RowsReturned in that case)
+//     and even on the truncation path (runExecute closes the rows
+//     handle before reading the tag, so the cluster reports the
+//     authoritative count regardless of how many rows we scanned).
+//
+//   - Guardrail telemetry: LimitInjected is non-nil when the caller
+//     ran safety.MaybeInjectLimit and a LIMIT was added; Truncated is
+//     true when row scanning hit MaxRows and stopped early. Both let
+//     an agent reason about whether the response is complete.
+type ExecuteResult struct {
+	Columns       []ColumnMeta `json:"columns,omitempty"`
+	Rows          [][]any      `json:"rows,omitempty"`
+	RowsReturned  int          `json:"rows_returned"`
+	RowsAffected  int64        `json:"rows_affected"`
+	CommandTag    string       `json:"command_tag,omitempty"`
+	LimitInjected *int         `json:"limit_injected,omitempty"`
+	Truncated     bool         `json:"truncated,omitempty"`
+}
+
+// ExecuteOptions configures a single Execute call. Mode determines the
+// transaction shape (read-only wrapper, sql_safe_updates, etc.); the
+// AST allowlist gate in internal/safety must already have admitted the
+// statement under this mode before Execute is called.
+//
+// MaxRows caps the number of rows scanned into ExecuteResult.Rows.
+// Hitting the cap sets Truncated=true and stops the scan early; the
+// statement still runs to completion on the cluster (so any side
+// effects of a DML … RETURNING are not undone). A zero or negative
+// value disables the cap entirely.
+type ExecuteOptions struct {
+	Mode    safety.Mode
+	MaxRows int
+}
+
+// Execute runs sql against the cluster and returns its rows + command
+// tag wrapped in an ExecuteResult. The mode in opts selects the txn
+// shape; the safety package is the only acceptable source of truth for
+// "is this statement permitted under this mode" — Execute does not
+// re-classify, it only enforces the cluster-side guardrails (read-only
+// txn for read_only, sql_safe_updates for safe_write, statement
+// timeout for all modes).
+//
+// On any begin/exec/query/scan failure after a successful connect, the
+// underlying connection is closed and the Manager reverts to its
+// pre-connect state, mirroring Explain's recovery contract.
+func (m *Manager) Execute(ctx context.Context, sql string, opts ExecuteOptions) (ExecuteResult, error) {
+	if err := m.connect(ctx); err != nil {
+		return ExecuteResult{}, err
+	}
+
+	result, err := m.runExecute(ctx, sql, opts)
+	if err != nil {
+		m.conn.Close(ctx) //nolint:errcheck // best-effort cleanup
+		m.conn = nil
+		return ExecuteResult{}, err
+	}
+	return result, nil
+}
+
+// runExecute is the inner half of Execute that owns the
+// txn/setup/query/scan pipeline. Splitting it out lets Execute
+// centralize the connection-recovery sequence so the failure modes
+// (BeginTx, Exec timeout, Exec sql_safe_updates, Query, Scan,
+// rows.Err, Commit) cannot drift apart.
+//
+// Per-mode txn shape:
+//
+//   - read_only: pgx.ReadOnly access mode. The cluster rejects writes
+//     (DML and DDL alike) with SQLSTATE 25006 ("read-only transaction").
+//     The AST allowlist already rejects both upstream, so this is
+//     defense-in-depth — but it is the same cluster behaviour
+//     ExplainDDL has to work around (see manager.go's runExplainDDL),
+//     and is why a future caller that bypassed the AST gate still
+//     could not write under read_only.
+//
+//   - safe_write: read-write txn plus SET LOCAL sql_safe_updates = on,
+//     so the cluster rejects unqualified UPDATE/DELETE at runtime.
+//
+//   - full_access: read-write txn with no extra session vars; the
+//     statement timeout is the only guardrail. The AST allowlist also
+//     does not gate full_access, by design (see classifyFullAccessExecute).
+//
+// Unknown modes are rejected up front rather than silently falling
+// through to a read-write txn — that fall-through would be a privilege
+// escalation if a future caller forgot to run safety.ParseMode.
+func (m *Manager) runExecute(ctx context.Context, sql string, opts ExecuteOptions) (ExecuteResult, error) {
+	txOpts, err := txOptionsForMode(opts.Mode)
+	if err != nil {
+		return ExecuteResult{}, err
+	}
+
+	tx, err := m.conn.BeginTx(ctx, txOpts)
+	if err != nil {
+		return ExecuteResult{}, fmt.Errorf("begin txn: %w", err)
+	}
+	// Rollback is best-effort and a no-op after a successful Commit.
+	// On the error paths it forces a server-side rollback if Commit
+	// never ran; on the panic path the deferred rollback releases the
+	// txn before the panic unwinds to the CLI/MCP caller's deferred
+	// mgr.Close. The errcheck suppression is therefore safe: any
+	// rollback failure is either post-Commit (harmless) or about to
+	// be eclipsed by the conn teardown that Execute performs on error.
+	defer tx.Rollback(ctx) //nolint:errcheck // see comment above
+
+	if _, err := tx.Exec(ctx,
+		fmt.Sprintf("SET LOCAL statement_timeout = '%dms'", m.stmtTimeout.Milliseconds())); err != nil {
+		return ExecuteResult{}, fmt.Errorf("set statement_timeout: %w", err)
+	}
+
+	if opts.Mode == safety.ModeSafeWrite {
+		// sql_safe_updates is the cluster-side runtime guard for
+		// safe_write: bare UPDATE/DELETE without a WHERE (or LIMIT)
+		// fails with a "rejected: UPDATE without WHERE clause"
+		// message. Pairs with the AST allowlist's admission of DML to
+		// give defense-in-depth.
+		if _, err := tx.Exec(ctx, "SET LOCAL sql_safe_updates = on"); err != nil {
+			return ExecuteResult{}, fmt.Errorf("set sql_safe_updates: %w", err)
+		}
+	}
+
+	rows, err := tx.Query(ctx, sql)
+	if err != nil {
+		return ExecuteResult{}, fmt.Errorf("execute statement: %w", err)
+	}
+	defer rows.Close()
+
+	cols := buildColumnMeta(m.conn, rows.FieldDescriptions())
+
+	out := ExecuteResult{Columns: cols}
+	for rows.Next() {
+		if opts.MaxRows > 0 && len(out.Rows) >= opts.MaxRows {
+			out.Truncated = true
+			break
+		}
+		values, err := rows.Values()
+		if err != nil {
+			return ExecuteResult{}, fmt.Errorf("scan row: %w", err)
+		}
+		out.Rows = append(out.Rows, values)
+	}
+
+	// Order matters here: pgx populates rows.commandTag inside Close,
+	// and a tail wire error (e.g. statement_timeout firing after the
+	// last data row) is observable only via rows.Err *after* Close.
+	// The natural-end path of rows.Next would call Close internally,
+	// but the truncation break above skips that — so we Close
+	// unconditionally here, then re-check Err, then read CommandTag.
+	// Reading CommandTag before Close on the truncation path would
+	// silently produce an empty tag and zero RowsAffected.
+	rows.Close() //nolint:errcheck // tail errors surface via rows.Err below
+	if err := rows.Err(); err != nil {
+		return ExecuteResult{}, fmt.Errorf("read rows: %w", err)
+	}
+
+	tag := rows.CommandTag()
+	out.RowsReturned = len(out.Rows)
+	out.RowsAffected = tag.RowsAffected()
+	out.CommandTag = tag.String()
+
+	if err := tx.Commit(ctx); err != nil {
+		return ExecuteResult{}, fmt.Errorf("commit txn: %w", err)
+	}
+	return out, nil
+}
+
+// txOptionsForMode picks the pgx transaction options for an Execute
+// call. The match is exhaustive on the safety.Mode set so a future
+// mode added without updating this switch fails loudly rather than
+// defaulting to a read-write (most-permissive) txn — which would be
+// silent privilege escalation if a caller bypassed safety.ParseMode.
+func txOptionsForMode(mode safety.Mode) (pgx.TxOptions, error) {
+	switch mode {
+	case safety.ModeReadOnly:
+		return pgx.TxOptions{AccessMode: pgx.ReadOnly}, nil
+	case safety.ModeSafeWrite, safety.ModeFullAccess:
+		return pgx.TxOptions{}, nil
+	default:
+		return pgx.TxOptions{}, fmt.Errorf("execute: unknown safety mode %q", mode)
+	}
+}
+
+// buildColumnMeta turns pgx FieldDescriptions into the public
+// ColumnMeta slice. Returns nil when fds is empty so the JSON envelope
+// omits the columns key for DML without RETURNING. Type names come
+// from the connection's pgtype.Map; an unknown OID leaves Type empty
+// rather than synthesising a fake name, so consumers can tell the
+// difference between "the cluster reported text" and "we don't know".
+func buildColumnMeta(conn *pgx.Conn, fds []pgconn.FieldDescription) []ColumnMeta {
+	if len(fds) == 0 {
+		return nil
+	}
+	tm := conn.TypeMap()
+	cols := make([]ColumnMeta, len(fds))
+	for i, fd := range fds {
+		cols[i].Name = fd.Name
+		if t, ok := tm.TypeForOID(fd.DataTypeOID); ok {
+			cols[i].Type = t.Name
+		}
+	}
+	return cols
+}

--- a/internal/conn/execute_integration_test.go
+++ b/internal/conn/execute_integration_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+package conn_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+// TestIntegrationManagerExecuteReadOnlySelect covers the read_only
+// happy path: a SELECT round-trips through Execute and returns rows,
+// columns, and a SELECT command tag. The asserts pin both the data
+// and the metadata pieces so a regression that drops either is loud.
+func TestIntegrationManagerExecuteReadOnlySelect(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, err := mgr.Execute(ctx, "SELECT 1 AS n, 'hi'::STRING AS s", conn.ExecuteOptions{
+		Mode: safety.ModeReadOnly,
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Columns, 2)
+	require.Equal(t, "n", res.Columns[0].Name)
+	require.Equal(t, "s", res.Columns[1].Name)
+	require.Equal(t, 1, res.RowsReturned)
+	require.Len(t, res.Rows, 1)
+	require.Equal(t, int64(1), res.Rows[0][0])
+	require.Equal(t, "hi", res.Rows[0][1])
+	require.True(t, strings.HasPrefix(res.CommandTag, "SELECT"),
+		"SELECT command tag expected, got %q", res.CommandTag)
+}
+
+// TestIntegrationManagerExecuteReadOnlyRejectsWrite pins the
+// defense-in-depth contract: even if a caller bypasses safety.Check
+// and submits a write under read_only, the cluster's BEGIN READ ONLY
+// wrapper rejects with SQLSTATE 25006.
+func TestIntegrationManagerExecuteReadOnlyRejectsWrite(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "exec_ro_write")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	_, err := mgr.Execute(ctx, "INSERT INTO t VALUES (1)", conn.ExecuteOptions{
+		Mode: safety.ModeReadOnly,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "25006",
+		"read-only-txn rejection must carry SQLSTATE 25006")
+}
+
+// TestIntegrationManagerExecuteSafeWriteInsertReturning pins
+// safe_write's happy path: DML succeeds, RETURNING surfaces rows, and
+// RowsAffected reflects the cluster's command tag.
+func TestIntegrationManagerExecuteSafeWriteInsertReturning(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "exec_sw_insert")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	res, err := mgr.Execute(ctx, "INSERT INTO t VALUES (1), (2) RETURNING id",
+		conn.ExecuteOptions{Mode: safety.ModeSafeWrite})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.RowsReturned)
+	require.Equal(t, int64(2), res.RowsAffected)
+	require.Len(t, res.Columns, 1)
+	require.Equal(t, "id", res.Columns[0].Name)
+}
+
+// TestIntegrationManagerExecuteSafeWriteRejectsBareUpdate pins the
+// runtime guard added by SET LOCAL sql_safe_updates: an UPDATE without
+// a WHERE clause is rejected by the cluster even though the AST
+// allowlist admits it (safe_write doesn't introspect for WHERE).
+func TestIntegrationManagerExecuteSafeWriteRejectsBareUpdate(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "exec_sw_bare_update")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+	mustExec(t, ctx, cluster.DSN,
+		"CREATE TABLE "+dbName+".public.t (id INT PRIMARY KEY, v INT)")
+	mustExec(t, ctx, cluster.DSN,
+		"INSERT INTO "+dbName+".public.t VALUES (1, 1)")
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	_, err := mgr.Execute(ctx, "UPDATE t SET v = 2", conn.ExecuteOptions{
+		Mode: safety.ModeSafeWrite,
+	})
+	require.Error(t, err,
+		"sql_safe_updates must reject UPDATE without WHERE")
+	require.Contains(t, strings.ToLower(err.Error()), "without where",
+		"error should name the missing WHERE clause")
+}
+
+// TestIntegrationManagerExecuteFullAccessDDL pins the full_access
+// contract: schema changes succeed without escalation hints because
+// the AST allowlist admits everything that parses.
+func TestIntegrationManagerExecuteFullAccessDDL(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	dbName := uniqueDBName(t, "exec_fa_ddl")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	mustExec(t, ctx, cluster.DSN, "CREATE DATABASE "+dbName)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		mustExec(t, ctx, cluster.DSN, "DROP DATABASE IF EXISTS "+dbName+" CASCADE")
+	})
+
+	mgr := conn.NewManager(dsnWithDatabase(t, cluster.DSN, dbName))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	_, err := mgr.Execute(ctx, "CREATE TABLE x (id INT PRIMARY KEY)",
+		conn.ExecuteOptions{Mode: safety.ModeFullAccess})
+	require.NoError(t, err, "full_access must admit DDL")
+}
+
+// TestIntegrationManagerExecuteTruncatesAtMaxRows pins the MaxRows
+// guardrail: scanning stops when the cap is hit and the result reports
+// Truncated=true. The statement still runs to completion on the
+// cluster, but the agent gets a bounded payload. Also pins that the
+// CommandTag and RowsAffected are correctly populated even on the
+// truncation path — this is load-bearing because pgx populates the
+// command tag inside Close, and a regression that read the tag before
+// Close would silently produce CommandTag="" and RowsAffected=0.
+func TestIntegrationManagerExecuteTruncatesAtMaxRows(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, err := mgr.Execute(ctx,
+		"SELECT generate_series(1, 5) AS n",
+		conn.ExecuteOptions{Mode: safety.ModeReadOnly, MaxRows: 2})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.RowsReturned, "scan must stop at MaxRows")
+	require.True(t, res.Truncated, "Truncated flag must be set")
+	require.NotEmpty(t, res.CommandTag,
+		"CommandTag must be populated on truncation (pgx populates it in Close)")
+	require.True(t, strings.HasPrefix(res.CommandTag, "SELECT"),
+		"CommandTag must report the cluster's authoritative tag, got %q", res.CommandTag)
+}
+
+// TestIntegrationManagerExecuteRecoversAfterError pins the
+// connection-recovery contract documented on Execute: an error after
+// a successful connect closes the cached connection and nils it so
+// the next call re-dials transparently. Mirrors
+// TestIntegrationManagerExplainDDLRecoversAfterError so the two
+// surfaces stay diff-friendly.
+func TestIntegrationManagerExecuteRecoversAfterError(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Force a cluster-side error after the lazy connect has succeeded.
+	_, err := mgr.Execute(ctx, "SELECT * FROM table_that_does_not_exist",
+		conn.ExecuteOptions{Mode: safety.ModeReadOnly})
+	require.Error(t, err, "SELECT against missing table must surface an error")
+
+	// Second call must succeed against a real query — proving the
+	// Manager re-dialed and is not stuck on the closed connection.
+	res, err := mgr.Execute(ctx, "SELECT 1",
+		conn.ExecuteOptions{Mode: safety.ModeReadOnly})
+	require.NoError(t, err, "Execute after a prior failure must reconnect")
+	require.Equal(t, 1, res.RowsReturned)
+}
+
+// TestIntegrationManagerExecuteRejectsUnknownMode pins the mode
+// validation added to runExecute: an unrecognised mode token must
+// fail loudly with no transaction opened, rather than silently
+// falling through to a read-write txn shape (which would be silent
+// privilege escalation if a future caller bypassed safety.ParseMode).
+func TestIntegrationManagerExecuteRejectsUnknownMode(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN)
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := mgr.Execute(ctx, "SELECT 1",
+		conn.ExecuteOptions{Mode: safety.Mode("yolo")})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown safety mode",
+		"unknown mode must surface a structured error, not silently use a default")
+}
+
+// TestIntegrationManagerExecuteEnforcesStatementTimeout mirrors the
+// matching test for Explain: an aggressive 1ms timeout forces a slow
+// statement to fail with SQLSTATE 57014.
+func TestIntegrationManagerExecuteEnforcesStatementTimeout(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	mgr := conn.NewManager(cluster.DSN, conn.WithStatementTimeout(1*time.Millisecond))
+	t.Cleanup(func() { _ = mgr.Close(context.Background()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := mgr.Execute(ctx, "SELECT pg_sleep(5)",
+		conn.ExecuteOptions{Mode: safety.ModeReadOnly})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "57014",
+		"timeout error must carry SQLSTATE 57014 (query_canceled)")
+}

--- a/internal/conn/execute_test.go
+++ b/internal/conn/execute_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+// TestTxOptionsForMode pins the mode-to-txOptions mapping. The
+// helper is the iteration-2 fix for the unknown-mode privilege-
+// escalation hazard: a future caller bypassing safety.ParseMode must
+// fail loudly here rather than silently land in a read-write txn.
+func TestTxOptionsForMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              safety.Mode
+		expectedAccess    pgx.TxAccessMode
+		expectedErrSubstr string
+	}{
+		{
+			name:           "read_only uses pgx.ReadOnly",
+			mode:           safety.ModeReadOnly,
+			expectedAccess: pgx.ReadOnly,
+		},
+		{
+			// pgx.TxOptions{} leaves AccessMode as the zero value
+			// ("", not pgx.ReadWrite). The cluster treats that as
+			// the default — a read-write txn — so the helper
+			// intentionally does not set AccessMode for the write
+			// modes.
+			name:           "safe_write leaves AccessMode unset (cluster default = read-write)",
+			mode:           safety.ModeSafeWrite,
+			expectedAccess: pgx.TxAccessMode(""),
+		},
+		{
+			name:           "full_access leaves AccessMode unset (cluster default = read-write)",
+			mode:           safety.ModeFullAccess,
+			expectedAccess: pgx.TxAccessMode(""),
+		},
+		{
+			name:              "unknown mode rejected",
+			mode:              safety.Mode("garbage"),
+			expectedErrSubstr: `unknown safety mode "garbage"`,
+		},
+		{
+			name:              "empty mode rejected (zero value of safety.Mode)",
+			mode:              safety.Mode(""),
+			expectedErrSubstr: `unknown safety mode ""`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := txOptionsForMode(tc.mode)
+			if tc.expectedErrSubstr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErrSubstr)
+				require.Equal(t, pgx.TxOptions{}, opts,
+					"error path must return zero-value opts so callers can't accidentally use them")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedAccess, opts.AccessMode)
+		})
+	}
+}

--- a/internal/conn/manager.go
+++ b/internal/conn/manager.go
@@ -25,11 +25,13 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// DefaultStatementTimeout is the per-EXPLAIN statement_timeout applied
-// inside the read-only transaction wrapper when the caller does not
-// override it via WithStatementTimeout. 30s is generous enough for
-// EXPLAIN and EXPLAIN (DDL, SHAPE) on large schemas while still
-// preventing a runaway plan from hanging an agent indefinitely.
+// DefaultStatementTimeout is the per-call statement_timeout applied
+// inside the transaction wrapper used by Explain, ExplainDDL, and
+// Execute when the caller does not override it via
+// WithStatementTimeout. 30s is generous enough for EXPLAIN and
+// EXPLAIN (DDL, SHAPE) on large schemas, and for typical interactive
+// queries via exec, while still preventing a runaway statement from
+// hanging an agent indefinitely.
 const DefaultStatementTimeout = 30 * time.Second
 
 // dsnCredentialPattern matches the userinfo portion of a postgres URI
@@ -70,8 +72,8 @@ type ExplainResult struct {
 // %v or %+v cannot leak credentials.
 //
 // The stmtTimeout field is the SET LOCAL statement_timeout applied
-// inside the read-only transaction that wraps every Explain /
-// ExplainDDL call. It is set once at construction (default
+// inside the transaction wrapper used by every Explain / ExplainDDL
+// / Execute call. It is set once at construction (default
 // DefaultStatementTimeout) via WithStatementTimeout; the Manager is
 // not safe for concurrent use, so the field never needs synchronisation.
 type Manager struct {
@@ -85,10 +87,11 @@ type Manager struct {
 // retry budget) extend the API without breaking call sites.
 type Option func(*Manager)
 
-// WithStatementTimeout overrides the per-EXPLAIN statement_timeout
-// applied inside the read-only transaction wrapper. A non-positive
-// value falls back to DefaultStatementTimeout so callers cannot
-// accidentally disable the guardrail by passing a zero duration.
+// WithStatementTimeout overrides the per-call statement_timeout
+// applied inside the transaction wrapper used by Explain, ExplainDDL,
+// and Execute. A non-positive value falls back to
+// DefaultStatementTimeout so callers cannot accidentally disable the
+// guardrail by passing a zero duration.
 func WithStatementTimeout(d time.Duration) Option {
 	return func(m *Manager) {
 		if d <= 0 {
@@ -105,7 +108,7 @@ func WithStatementTimeout(d time.Duration) Option {
 //
 // Options are applied in order; later options override earlier ones.
 // Callers that pass no options get DefaultStatementTimeout for the
-// EXPLAIN-wrapper guardrail.
+// txn-wrapper guardrail used by Explain, ExplainDDL, and Execute.
 func NewManager(dsn string, opts ...Option) *Manager {
 	m := &Manager{
 		dsn:         dsn,

--- a/internal/mcp/integration_tools_test.go
+++ b/internal/mcp/integration_tools_test.go
@@ -45,6 +45,7 @@ var expectedTools = []string{
 	tools.ExplainSQLToolName,
 	tools.ExplainSchemaChangeToolName,
 	tools.SimulateSQLToolName,
+	tools.ExecuteSQLToolName,
 	tools.ListTablesToolName,
 	tools.DescribeTableToolName,
 }
@@ -549,6 +550,35 @@ func TestIntegrationDescribeTableLive(t *testing.T) {
 		require.True(t, ok, "schemas context must be a JSON array")
 		require.ElementsMatch(t, []any{"app", "public"}, schemas)
 	})
+}
+
+// TestIntegrationExecuteSQL exercises the execute_sql Tier 3 tool
+// against a real cluster. Smoke-style: a SELECT round-trips through
+// the handler and lands rows in the envelope. Per-mode and edge-case
+// behaviour is covered by the conn-level integration tests; here we
+// just verify the MCP wiring reaches the cluster and returns a
+// well-formed envelope.
+func TestIntegrationExecuteSQL(t *testing.T) {
+	cluster := cockroachtest.Shared(t)
+	c := newMCPClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var req mcp.CallToolRequest
+	req.Params.Name = tools.ExecuteSQLToolName
+	req.Params.Arguments = map[string]any{
+		"sql": "SELECT 1 AS n",
+		"dsn": cluster.DSN,
+	}
+	res, err := c.CallTool(ctx, req)
+	require.NoError(t, err)
+
+	env := decodeEnvelope(t, res)
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionConnected, env.ConnectionStatus)
+	require.Empty(t, env.Errors, "SELECT 1 must succeed")
+	require.NotEmpty(t, env.Data, "execute_sql must populate data")
 }
 
 // TestIntegrationExplainSQL exercises the only Tier 3 tool. It is

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,12 +9,12 @@
 // tools (parse_sql, validate_sql, format_sql, detect_risky_query,
 // summarize_sql), two Tier 2 catalog tools (list_tables,
 // describe_table) that operate on inline CREATE TABLE schemas, and
-// three Tier 3 connected tools (explain_sql, explain_schema_change,
-// simulate_sql) that run against a live cluster. validate_sql is
-// dual-tier: it runs Tier 1 by default and lifts to Tier 2 (name
-// resolution) when the caller supplies inline schemas. Keeping
-// construction pure (no transport, no I/O) lets the cmd layer pick
-// a transport — currently just stdio — and lets tests exercise
+// four Tier 3 connected tools (explain_sql, explain_schema_change,
+// simulate_sql, execute_sql) that run against a live cluster.
+// validate_sql is dual-tier: it runs Tier 1 by default and lifts to
+// Tier 2 (name resolution) when the caller supplies inline schemas.
+// Keeping construction pure (no transport, no I/O) lets the cmd layer
+// pick a transport — currently just stdio — and lets tests exercise
 // individual tool handlers directly.
 //
 // Versions are passed in by the caller rather than read from
@@ -78,6 +78,7 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ExplainSchemaChangeTool(), tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.SimulateSQLTool(), tools.SimulateSQLHandler(parserVersion, defaultTargetVersion))
+	s.AddTool(tools.ExecuteSQLTool(), tools.ExecuteSQLHandler(parserVersion, defaultTargetVersion))
 	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))
 	s.AddTool(tools.DescribeTableTool(), tools.DescribeTableHandler(parserVersion))
 	return s

--- a/internal/mcp/tools/execute.go
+++ b/internal/mcp/tools/execute.go
@@ -1,0 +1,129 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/conn"
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+// defaultExecuteMaxRows is the row cap applied to read_only SELECTs
+// when the caller does not override max_rows. Mirrors the CLI's
+// --max-rows default so the two surfaces produce identical bounded
+// results for the same input.
+const defaultExecuteMaxRows = 1000
+
+// ExecuteSQLTool returns the MCP tool definition for execute_sql.
+// Like explain_sql, the dsn parameter is required because MCP
+// sessions are stateless. The mode/timeout/max_rows knobs all carry
+// the same semantics as the CLI's --mode/--timeout/--max-rows flags.
+func ExecuteSQLTool() mcp.Tool {
+	return mcp.NewTool(
+		ExecuteSQLToolName,
+		mcp.WithDescription(`Execute SQL against a CockroachDB cluster with safety guardrails. Returns rows, columns, and the command tag in a structured envelope. The mode parameter selects the safety policy: read_only (default) admits non-mutating statements only; safe_write also admits INSERT/UPDATE/DELETE; full_access admits any parsed statement. For read_only SELECTs without a LIMIT, max_rows is injected so the cluster does not stream an unbounded result.`),
+		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement to execute")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
+		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
+		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
+		mcp.WithNumber(MaxRowsParamName, mcp.Description(MaxRowsParamDescription)),
+	)
+}
+
+// ExecuteSQLHandler returns the handler for the execute_sql tool. The
+// envelope's ConnectionStatus starts disconnected and flips to
+// connected only after a successful Execute, so partial-failure
+// envelopes report the actual reached state. Cluster-side errors
+// (timeouts, syntax errors, perm denied) populate env.Errors via
+// diag.FromClusterError; tool-level errors (missing parameters) come
+// back as mcp.NewToolResultError per the discipline in tools.go.
+func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		sql, toolErr := extractRequiredString(req, "sql")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		dsn, toolErr := extractRequiredString(req, "dsn")
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		target, toolErr := resolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		mode, toolErr := resolveSafetyMode(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		timeout, toolErr := resolveStatementTimeout(req)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		maxRows, toolErr := resolveMaxRows(req, defaultExecuteMaxRows)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		env := connectedEnvelope(parserVersion, target)
+
+		violation, err := safety.Check(mode, safety.OpExecute, sql)
+		if err != nil {
+			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			return envelopeResult(env)
+		}
+		if violation != nil {
+			env.Errors = []output.Error{safety.Envelope(violation)}
+			return envelopeResult(env)
+		}
+
+		// LIMIT injection is scoped to read_only because the other
+		// modes are explicit opt-ins where the user has already
+		// accepted writes / unbounded scans.
+		rewritten := sql
+		var injected bool
+		if mode == safety.ModeReadOnly && maxRows > 0 {
+			rewritten, injected, err = safety.MaybeInjectLimit(sql, maxRows)
+			if err != nil {
+				env.Errors = []output.Error{diag.FromParseError(err, sql)}
+				return envelopeResult(env)
+			}
+		}
+
+		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
+
+		result, err := mgr.Execute(ctx, rewritten, conn.ExecuteOptions{
+			Mode:    mode,
+			MaxRows: maxRows,
+		})
+		if err != nil {
+			env.Errors = []output.Error{diag.FromClusterError(err, rewritten)}
+			return envelopeResult(env)
+		}
+
+		if injected {
+			limit := maxRows
+			result.LimitInjected = &limit
+		}
+
+		env.ConnectionStatus = output.ConnectionConnected
+		data, err := json.Marshal(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
+		}
+		env.Data = data
+		return envelopeResult(env)
+	}
+}

--- a/internal/mcp/tools/execute_test.go
+++ b/internal/mcp/tools/execute_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// TestExecuteSQLHandlerParameterValidation covers the tool-level
+// error path for execute_sql. Mirrors the explain_sql validation
+// table; the two surfaces share extractRequiredString and
+// resolveTargetVersion plumbing, but pinning the call shape here
+// guards against accidental divergence (e.g. forgetting to call one
+// of the resolvers in the new handler).
+func TestExecuteSQLHandlerParameterValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "missing both params", args: map[string]any{}},
+		{name: "missing dsn", args: map[string]any{"sql": "SELECT 1"}},
+		{name: "missing sql", args: map[string]any{"dsn": "postgres://h:26257/db"}},
+		{name: "empty sql", args: map[string]any{"sql": "", "dsn": "postgres://h:26257/db"}},
+		{name: "empty dsn", args: map[string]any{"sql": "SELECT 1", "dsn": ""}},
+		{name: "wrong type sql", args: map[string]any{"sql": 1, "dsn": "postgres://h:26257/db"}},
+		{name: "wrong type max_rows", args: map[string]any{"sql": "SELECT 1", "dsn": "postgres://h:26257/db", "max_rows": "many"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.True(t, res.IsError, "expected tool-level error")
+		})
+	}
+}
+
+// TestExecuteSQLHandlerRejectsInvalidMode pins the same tool-level
+// error contract for --mode that explain_sql enforces: an unknown
+// token must produce a clear "valid choices are…" error rather than
+// a misleading envelope entry.
+func TestExecuteSQLHandlerRejectsInvalidMode(t *testing.T) {
+	handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":  "SELECT 1",
+		"dsn":  "postgres://nope:1/db",
+		"mode": "yolo",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "invalid mode must produce a tool-level error")
+}
+
+// TestExecuteSQLHandlerSafetyRejection verifies that the read_only
+// allowlist intercepts mutating statements before any cluster
+// contact. The DSN is unreachable on purpose: a regression that
+// lets the safety check fall through would surface as a connect
+// error instead of the safety_violation we expect.
+func TestExecuteSQLHandlerSafetyRejection(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		sql         string
+		expectedTag string
+	}{
+		{name: "delete under read_only", mode: "read_only", sql: "DELETE FROM t WHERE id = 1", expectedTag: "DELETE"},
+		{name: "ddl under safe_write", mode: "safe_write", sql: "DROP TABLE users", expectedTag: "DROP TABLE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"sql":  tc.sql,
+				"dsn":  "postgres://nope:1/db?connect_timeout=1",
+				"mode": tc.mode,
+			}
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
+				"safety rejection must short-circuit before any cluster contact")
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, "execute", env.Errors[0].Context["operation"])
+		})
+	}
+}
+
+// TestExecuteSQLHandlerConnectionFailureSurfacesEnvelopeError pins
+// the same connection-failure → envelope-error contract that
+// explain_sql enforces. A read_only SELECT must reach the connect
+// step and surface a "connect to CockroachDB" envelope error rather
+// than a tool-level error.
+func TestExecuteSQLHandlerConnectionFailureSurfacesEnvelopeError(t *testing.T) {
+	handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql": "SELECT 1",
+		"dsn": "postgres://nope:1/db?connect_timeout=1",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.TierConnected, env.Tier)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+}
+
+// TestExecuteSQLToolAdvertisesParams pins the tool's discoverable
+// schema: clients must be able to see all the optional knobs without
+// reading source.
+func TestExecuteSQLToolAdvertisesParams(t *testing.T) {
+	tool := ExecuteSQLTool()
+	props := tool.InputSchema.Properties
+	for _, want := range []string{"sql", "dsn", TargetVersionParamName, ModeParamName, StatementTimeoutParamName, MaxRowsParamName} {
+		require.Contains(t, props, want, "execute_sql schema must advertise %q", want)
+	}
+}
+
+// TestResolveMaxRows pins the documented contract on the max_rows
+// resolver: missing → defaultMax; positive → cast to int; negative
+// → 0 ("unlimited"); non-numeric → tool-level error. Each case is a
+// distinct user-visible behaviour, and a regression in any one
+// silently changes how guardrails behave.
+func TestResolveMaxRows(t *testing.T) {
+	const defaultMax = 1000
+	tests := []struct {
+		name              string
+		args              map[string]any
+		expectedMax       int
+		expectedToolError bool
+	}{
+		{name: "missing returns default", args: map[string]any{}, expectedMax: defaultMax},
+		{name: "explicit zero disables cap", args: map[string]any{"max_rows": float64(0)}, expectedMax: 0},
+		{name: "negative clamps to zero", args: map[string]any{"max_rows": float64(-5)}, expectedMax: 0},
+		{name: "positive forwarded as int", args: map[string]any{"max_rows": float64(50)}, expectedMax: 50},
+		{name: "wrong type produces tool error", args: map[string]any{"max_rows": "many"}, expectedToolError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+			got, toolErr := resolveMaxRows(req, defaultMax)
+			if tc.expectedToolError {
+				require.NotNil(t, toolErr, "expected a tool-level error")
+				return
+			}
+			require.Nil(t, toolErr)
+			require.Equal(t, tc.expectedMax, got)
+		})
+	}
+}

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -7,9 +7,9 @@
 // tools. The Tier 1 (zero-config) tools are parse_sql, validate_sql,
 // format_sql, detect_risky_query, and summarize_sql; the Tier 2
 // (schema_file) tools are list_tables and describe_table; the Tier 3
-// (connected) tools are explain_sql and explain_schema_change, which
-// require a per-call DSN since the MCP server holds no per-session
-// connection state.
+// (connected) tools are explain_sql, explain_schema_change, and
+// execute_sql, which require a per-call DSN since the MCP server
+// holds no per-session connection state.
 //
 // Each handler returns the same output.Envelope JSON shape that the CLI
 // emits under --output=json, so MCP clients get structured errors,
@@ -45,6 +45,7 @@ const (
 	ExplainSQLToolName          = "explain_sql"
 	ExplainSchemaChangeToolName = "explain_schema_change"
 	SimulateSQLToolName         = "simulate_sql"
+	ExecuteSQLToolName          = "execute_sql"
 	ListTablesToolName          = "list_tables"
 	DescribeTableToolName       = "describe_table"
 )
@@ -69,20 +70,28 @@ const ModeParamName = "mode"
 
 // ModeParamDescription is the shared MCP-schema description for the
 // mode parameter so every Tier 3 tool documents the argument
-// identically.
-const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" and "full_access" are reserved for follow-up work and currently reject every statement.`
+// identically. The accepted set is the same across tools, but the
+// modes that any given tool actually admits depend on the tool:
+// today only execute_sql wires safe_write and full_access;
+// explain_sql and explain_schema_change still report "not yet
+// implemented" for those modes (follow-up work). The per-tool
+// wording stays accurate via the envelope's safety_violation Reason.
+const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" additionally admits INSERT/UPDATE/DELETE; "full_access" admits any parsed statement. Today only execute_sql admits safe_write/full_access; explain_sql and explain_schema_change still report "not yet implemented" for those modes (follow-up work).`
 
 // StatementTimeoutParamName is the optional MCP tool parameter name
 // that lets a client override the per-call SET LOCAL statement_timeout
-// applied inside the read-only transaction wrapper. The value is in
-// milliseconds (numeric) so the wire format matches MCP's JSON
+// applied inside the cluster-side transaction wrapper. The value is
+// in milliseconds (numeric) so the wire format matches MCP's JSON
 // type-system without parsing duration strings.
 const StatementTimeoutParamName = "statement_timeout_ms"
 
 // StatementTimeoutParamDescription is the shared MCP-schema
 // description for the statement_timeout_ms parameter so every Tier 3
-// tool documents the argument identically.
-const StatementTimeoutParamDescription = "Optional statement_timeout (milliseconds) applied inside the read-only transaction wrapper. Default 30000 (30s). Non-positive values fall back to the default."
+// tool documents the argument identically. Wording is mode-agnostic
+// because execute_sql's txn is read-only only when mode=read_only;
+// safe_write/full_access use a read-write txn but the timeout still
+// applies.
+const StatementTimeoutParamDescription = "Optional statement_timeout (milliseconds) applied inside the cluster-side transaction wrapper. Default 30000 (30s). Non-positive values fall back to the default."
 
 // extractRequiredString validates and returns a required string
 // parameter from an MCP tool request. Leading and trailing whitespace
@@ -250,6 +259,39 @@ func resolveSafetyMode(req mcp.CallToolRequest) (safety.Mode, *mcp.CallToolResul
 			"%s parameter: %v", ModeParamName, err))
 	}
 	return m, nil
+}
+
+// MaxRowsParamName is the optional MCP tool parameter name for the
+// row cap applied to execute_sql results. The cap drives both the
+// AST-level LIMIT injection on read_only SELECTs and the runtime
+// row-scan truncation in conn.Manager.Execute.
+const MaxRowsParamName = "max_rows"
+
+// MaxRowsParamDescription is the shared MCP-schema description for
+// the max_rows parameter. Default mirrors the CLI's --max-rows.
+const MaxRowsParamDescription = "Optional row cap for execute_sql (default 1000). Bounds rows returned in any mode; additionally drives AST-level LIMIT injection on read_only SELECTs. 0 disables both."
+
+// resolveMaxRows picks the row cap for an execute_sql tool call.
+// Missing arguments fall back to the supplied default. A non-numeric
+// value is a tool-level error so the agent gets a precise diagnostic
+// rather than silent fallback. Negative values are clamped to 0
+// ("unlimited") rather than errored — clients that send -1 most
+// likely mean "no cap" and the alternative would punish a typo more
+// than necessary.
+func resolveMaxRows(req mcp.CallToolRequest, defaultMax int) (int, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[MaxRowsParamName]
+	if !exists {
+		return defaultMax, nil
+	}
+	n, ok := raw.(float64)
+	if !ok {
+		return 0, mcp.NewToolResultError(fmt.Sprintf(
+			"%s parameter must be a number, got %T", MaxRowsParamName, raw))
+	}
+	if n < 0 {
+		return 0, nil
+	}
+	return int(n), nil
 }
 
 // resolveStatementTimeout picks the statement_timeout for a single

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -18,14 +18,21 @@ import (
 // (otherwise the underlying EXPLAIN (DDL, SHAPE) would always error),
 // while OpExplain must reject it (because the inner statement of plain
 // EXPLAIN is what defines the read/write character of the call).
+// OpSimulate dispatches each statement through a non-executing EXPLAIN
+// flavour, so it admits DDL/DML/SELECT under read_only without ever
+// reaching cluster execution. OpExecute, in contrast, admits the
+// read-only set under read_only, adds DML under safe_write, and
+// admits anything that parses under full_access — the full per-mode
+// matrix in the design doc.
 type Operation int
 
-// Operation values. New surfaces (e.g. an eventual OpExecute for
-// issue #29) extend this enum; the existing rules stay untouched.
+// Operation values. New surfaces extend this enum; the existing rules
+// stay untouched.
 const (
 	OpExplain Operation = iota + 1
 	OpExplainDDL
 	OpSimulate
+	OpExecute
 )
 
 // String returns the wire-stable token for op. Used in violation
@@ -38,10 +45,76 @@ func (op Operation) String() string {
 		return "explain_ddl"
 	case OpSimulate:
 		return "simulate"
+	case OpExecute:
+		return "execute"
 	default:
 		return "unknown"
 	}
 }
+
+// ViolationKind labels the structural reason a statement was
+// rejected, separate from the human-readable Reason text. Code that
+// needs to act on the rejection (e.g. envelope.suggestionsFor picking
+// the smallest mode that would admit the call) branches on Kind so
+// the decision is not coupled to specific Reason wording.
+type ViolationKind int
+
+// ViolationKind values. Start at one so the zero value is invalid;
+// Check always sets a meaningful kind on every Violation it produces.
+const (
+	// KindOther covers rejections that do not need fine-grained
+	// classification — currently the empty-input defensive case, the
+	// unknown-mode programmer-error case, and the unknown-Operation
+	// programmer-error case in classifyReadOnly. None can be
+	// unblocked by escalating mode, so suggestionsFor emits no
+	// escalation hint for them.
+	KindOther ViolationKind = iota + 1
+
+	// KindWrite labels statements rejected because they would mutate
+	// data (INSERT/UPDATE/UPSERT/DELETE/TRUNCATE). Escalating to
+	// safe_write unblocks these.
+	KindWrite
+
+	// KindSchema labels statements rejected because they would
+	// mutate schema (CREATE/ALTER/DROP). Escalating to full_access
+	// unblocks these — safe_write does not.
+	KindSchema
+
+	// KindPrivilege labels privilege and identity statements
+	// (GRANT/REVOKE, CREATE/DROP/ALTER ROLE, ownership and default-
+	// privilege changes). The classic SQL Data Control Language set.
+	// Escalating to full_access unblocks these — safe_write rejects
+	// privilege management even though the parser also tags GRANT
+	// and friends as schema-modifying.
+	KindPrivilege
+
+	// KindClusterAdmin labels statements that the parser also tags
+	// TypeDCL but that aren't privilege/role changes — cluster
+	// configuration (SET CLUSTER SETTING, SET TRACING), zone
+	// configuration (ALTER ... CONFIGURE ZONE), and tenant lifecycle
+	// (CREATE/DROP/ALTER TENANT). Treated as a separate Kind from
+	// KindPrivilege so the rejection Reason names what the user is
+	// actually doing rather than misleading them about a privilege
+	// change. Escalates to full_access.
+	KindClusterAdmin
+
+	// KindNestedExplain labels EXPLAIN/EXPLAIN ANALYZE wrappers
+	// rejected to prevent the inner statement from sneaking past
+	// CanWriteData / CanModifySchema. Mode escalation does not help
+	// — the user must pass the inner statement directly.
+	KindNestedExplain
+
+	// KindUnimplemented labels (mode, op) pairs that the package
+	// recognises at the flag layer but does not yet wire (today:
+	// safe_write/full_access for OpExplain/OpExplainDDL). The fix is
+	// for the upstream feature to land, not for the user to escalate.
+	KindUnimplemented
+
+	// KindBadOpInput labels rejections caused by the user passing the
+	// wrong shape of input for the operation — currently only
+	// non-DDL statements to OpExplainDDL.
+	KindBadOpInput
+)
 
 // Violation is the structured payload returned by Check when a
 // statement is rejected. It carries everything an agent (or the
@@ -53,13 +126,14 @@ func (op Operation) String() string {
 type Violation struct {
 	// Tag is the cockroachdb-parser StatementTag for the offending
 	// statement (e.g. "DROP TABLE", "INSERT", "SELECT"). Stable across
-	// CRDB versions for any given statement type.
+	// CRDB versions for any given statement type. Empty for the
+	// empty-input defensive case (no statement to tag).
 	Tag string
 
 	// Reason is a short human-readable explanation of why the
 	// statement was rejected (e.g. "writes data", "modifies schema",
 	// "expected DDL"). Embedded into the rendered Message; agents
-	// should branch on Mode/Operation/Tag rather than Reason.
+	// should branch on Kind/Mode/Operation/Tag rather than Reason.
 	Reason string
 
 	// Mode is the safety mode that was in effect when the violation
@@ -71,6 +145,12 @@ type Violation struct {
 	// agents distinguish "explain rejected DROP TABLE" from
 	// "explain-ddl rejected SELECT", which point at different fixes.
 	Op Operation
+
+	// Kind is the structural reason for the rejection. Used by
+	// envelope.suggestionsFor to pick the smallest mode escalation
+	// that would admit the call (or to skip the suggestion entirely
+	// when no escalation helps).
+	Kind ViolationKind
 }
 
 // Check parses sql and decides whether every statement in it is
@@ -112,10 +192,14 @@ func Check(mode Mode, op Operation, sql string) (*Violation, error) {
 		// the safety package's contract is "the single decision point"
 		// — keep the gate self-contained so a future caller that
 		// bypasses sqlinput cannot pass an empty batch through.
+		// Tag is the literal "EMPTY" sentinel so formatMessage doesn't
+		// render a stray empty parens cell ("(, mode=…, op=…)").
 		return &Violation{
+			Tag:    "EMPTY",
 			Reason: "no statements parsed",
 			Mode:   mode,
 			Op:     op,
+			Kind:   KindOther,
 		}, nil
 	}
 	for _, s := range stmts {
@@ -130,22 +214,29 @@ func Check(mode Mode, op Operation, sql string) (*Violation, error) {
 // Returns nil when the statement is permitted; a populated *Violation
 // otherwise. Pulled out of Check so the per-statement decision tree
 // stays readable as new (mode, op) combinations are added.
+//
+// Mode coverage is intentionally scoped per Operation:
+//
+//   - read_only is wired for every Op via classifyReadOnly.
+//   - safe_write and full_access are wired only for OpExecute (issue
+//     #29). OpExplain, OpExplainDDL, and OpSimulate in those modes
+//     still return the "not yet implemented" violation; wiring them
+//     is follow-up work so the other surfaces' mode story stays
+//     stable while exec adopts the full safety model.
 func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 	switch mode {
 	case ModeReadOnly:
 		return classifyReadOnly(op, stmt)
-	case ModeSafeWrite, ModeFullAccess:
-		// Modes are recognised at the flag layer (so the CLI accepts
-		// --mode=safe_write today without a "bad value" error), but
-		// no statement is admitted until issue #29 wires the
-		// per-mode rules. Returning a violation here keeps the
-		// rejection path uniform with read_only.
-		return &Violation{
-			Tag:    stmt.StatementTag(),
-			Reason: fmt.Sprintf("safety mode %q is not yet implemented", mode),
-			Mode:   mode,
-			Op:     op,
+	case ModeSafeWrite:
+		if op == OpExecute {
+			return classifySafeWriteExecute(stmt)
 		}
+		return notYetImplemented(mode, op, stmt)
+	case ModeFullAccess:
+		if op == OpExecute {
+			return classifyFullAccessExecute(stmt)
+		}
+		return notYetImplemented(mode, op, stmt)
 	default:
 		// Defensive: ParseMode should have rejected this earlier.
 		// Treat as a violation rather than admitting unknown modes.
@@ -154,7 +245,21 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 			Reason: fmt.Sprintf("unknown safety mode %q", mode),
 			Mode:   mode,
 			Op:     op,
+			Kind:   KindOther,
 		}
+	}
+}
+
+// notYetImplemented builds the placeholder violation returned for
+// (mode, op) pairs that ParseMode admits but Check does not yet wire.
+// Centralised so the message text stays consistent across surfaces.
+func notYetImplemented(mode Mode, op Operation, stmt tree.Statement) *Violation {
+	return &Violation{
+		Tag:    stmt.StatementTag(),
+		Reason: fmt.Sprintf("safety mode %q is not yet implemented", mode),
+		Mode:   mode,
+		Op:     op,
+		Kind:   KindUnimplemented,
 	}
 }
 
@@ -178,23 +283,19 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 //     user error. But because read_only mode is meant to forbid all
 //     schema modification, we reject DDL too — leaving OpExplainDDL
 //     effectively unusable in read_only mode. Users must escalate to
-//     safe_write or full_access (issue #29) to use explain-ddl.
-//     The reason text names the escalation path so the rejection is
-//     actionable.
-//
-//   - OpSimulate dispatches per-statement to a non-executing EXPLAIN
-//     flavor (EXPLAIN ANALYZE for SELECT, plain EXPLAIN for DML
-//     writes, EXPLAIN (DDL, SHAPE) for DDL). Because the dispatcher
-//     never executes the inner write or DDL at the cluster level,
-//     read_only mode admits every dispatched class — SELECT, DML
-//     writes, and DDL alike — and only rejects shapes the dispatcher
-//     has no route for: nested EXPLAIN (defense in depth, mirroring
-//     OpExplain), TCL (BEGIN/COMMIT/ROLLBACK have no EXPLAIN form),
-//     and DCL (GRANT/REVOKE, out of scope for the dispatcher).
+//     safe_write or full_access to use explain-ddl. The reason text
+//     names the escalation path so the rejection is actionable.
 func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 	tag := stmt.StatementTag()
 	switch op {
-	case OpExplain:
+	case OpExplain, OpExecute:
+		// OpExplain wraps the inner stmt in `EXPLAIN <stmt>` and
+		// OpExecute runs it directly; both share the same read-only
+		// admission set because either path that touches a write would
+		// violate the read_only contract (EXPLAIN doesn't execute, but
+		// nested EXPLAIN ANALYZE wrappers do — and OpExecute's runtime
+		// is the very thing we're gating).
+		//
 		// Reject nested EXPLAIN wrappers explicitly. The inner stmt of
 		// an *Explain or *ExplainAnalyze node is not classified by
 		// tree.CanWriteData/CanModifySchema, so without this branch a
@@ -210,6 +311,48 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 				Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
 				Mode:   ModeReadOnly,
 				Op:     op,
+				Kind:   KindNestedExplain,
+			}
+		}
+		// Order matters: a statement can satisfy more than one of
+		// these predicates, and the Kind we tag determines which
+		// escalation suggestion the envelope emits. Picking the
+		// *most-permissive-needed* mode keeps an agent from looping
+		// through retries on a mode that would also reject the
+		// statement.
+		//
+		// CRDB overloads TypeDCL beyond the SQL-standard "Data Control
+		// Language" definition — it covers GRANT/REVOKE/role
+		// management AND cluster configuration AND tenant lifecycle.
+		// We split the two so the rejection Reason matches what the
+		// user is actually doing. classifyDCL routes both cases.
+		//
+		// Empirical predicate matrix (verified against
+		// cockroachdb-parser v0.26.2):
+		//
+		//   GRANT/REVOKE/role mgmt
+		//                     : DCL + schema + write   → KindPrivilege    → full_access
+		//   SET CLUSTER SETTING / SET TRACING
+		//                     : DCL + write            → KindClusterAdmin → full_access
+		//   ALTER ... CONFIGURE ZONE
+		//                     : DCL + schema + write   → KindClusterAdmin → full_access
+		//   CREATE/DROP/ALTER TENANT *
+		//                     : DCL + write            → KindClusterAdmin → full_access
+		//   CREATE/DROP/ALTER TABLE etc.
+		//                     : DDL + schema           → KindSchema       → full_access
+		//   TRUNCATE          : DDL + schema + write   → KindSchema       → full_access
+		//   INSERT/UPDATE/DELETE/UPSERT
+		//                     : DML + write            → KindWrite        → safe_write
+		if v := classifyDCL(stmt, tag, ModeReadOnly, op); v != nil {
+			return v
+		}
+		if tree.CanModifySchema(stmt) {
+			return &Violation{
+				Tag:    tag,
+				Reason: "statement modifies schema; read_only mode forbids it",
+				Mode:   ModeReadOnly,
+				Op:     op,
+				Kind:   KindSchema,
 			}
 		}
 		if tree.CanWriteData(stmt) {
@@ -218,14 +361,7 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 				Reason: "statement writes data; read_only mode forbids it",
 				Mode:   ModeReadOnly,
 				Op:     op,
-			}
-		}
-		if tree.CanModifySchema(stmt) {
-			return &Violation{
-				Tag:    tag,
-				Reason: "statement modifies schema; read_only mode forbids it",
-				Mode:   ModeReadOnly,
-				Op:     op,
+				Kind:   KindWrite,
 			}
 		}
 		return nil
@@ -236,6 +372,7 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 				Reason: "explain_ddl requires a DDL statement",
 				Mode:   ModeReadOnly,
 				Op:     op,
+				Kind:   KindBadOpInput,
 			}
 		}
 		// Inner stmt is DDL, so it modifies schema. read_only mode
@@ -247,6 +384,7 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 			Reason: "explain_ddl modifies schema; rerun with --mode=safe_write or --mode=full_access",
 			Mode:   ModeReadOnly,
 			Op:     op,
+			Kind:   KindSchema,
 		}
 	case OpSimulate:
 		// Reject nested EXPLAIN wrappers explicitly. The dispatcher
@@ -263,6 +401,7 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 				Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
 				Mode:   ModeReadOnly,
 				Op:     op,
+				Kind:   KindNestedExplain,
 			}
 		}
 		switch stmt.StatementType() {
@@ -282,14 +421,159 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 				Reason: "simulate has no route for this statement type; only DDL, DML, and SELECT are supported",
 				Mode:   ModeReadOnly,
 				Op:     op,
+				Kind:   KindBadOpInput,
 			}
 		}
 	default:
 		return &Violation{
 			Tag:    tag,
-			Reason: fmt.Sprintf("unknown operation %v", op),
+			Reason: fmt.Sprintf("unknown operation %v (programmer error)", op),
 			Mode:   ModeReadOnly,
 			Op:     op,
+			Kind:   KindOther,
 		}
 	}
+}
+
+// classifySafeWriteExecute is the safe_write rule for OpExecute. It
+// admits the read_only set plus DML (INSERT/UPDATE/UPSERT/DELETE)
+// while still rejecting DDL and DCL.
+//
+//   - DDL: schema mutation is reserved for full_access. The reason
+//     names the escalation path so the rejection is actionable.
+//   - DCL: GRANT/REVOKE escape sql_safe_updates and can hand out
+//     privileges that outlive the session, so they require the
+//     explicit full_access opt-in.
+//
+// Defense-in-depth: Manager.Execute additionally sets
+// `SET LOCAL sql_safe_updates = on` for safe_write so the cluster
+// rejects unqualified UPDATE/DELETE at runtime, even though the AST
+// allowlist admits them in principle.
+func classifySafeWriteExecute(stmt tree.Statement) *Violation {
+	tag := stmt.StatementTag()
+	switch stmt.(type) {
+	case *tree.Explain, *tree.ExplainAnalyze:
+		// Same defense-in-depth as classifyReadOnly: the inner stmt of
+		// an EXPLAIN node is invisible to CanWriteData/CanModifySchema,
+		// so a wrapper around DDL would otherwise sneak through here.
+		return &Violation{
+			Tag:    tag,
+			Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+			Mode:   ModeSafeWrite,
+			Op:     OpExecute,
+			Kind:   KindNestedExplain,
+		}
+	}
+	// classifyDCL handles the TypeDCL surface (privilege/role +
+	// cluster admin) with mode-appropriate Reason text. Both Kinds
+	// it produces — KindPrivilege and KindClusterAdmin — escalate
+	// to full_access; safe_write rejects both even though the parser
+	// also tags GRANT and friends as schema-modifying.
+	if v := classifyDCL(stmt, tag, ModeSafeWrite, OpExecute); v != nil {
+		return v
+	}
+	if tree.CanModifySchema(stmt) {
+		return &Violation{
+			Tag:    tag,
+			Reason: "statement modifies schema; rerun with --mode=full_access",
+			Mode:   ModeSafeWrite,
+			Op:     OpExecute,
+			Kind:   KindSchema,
+		}
+	}
+	return nil
+}
+
+// classifyDCL produces the Violation for a TypeDCL statement, or nil
+// if stmt isn't TypeDCL. It splits CRDB's overloaded TypeDCL set
+// (privilege/role changes vs. cluster admin / tenant lifecycle) so
+// the rejection Reason names the actual operation domain.
+//
+// The Reason wording is mode-specific: read_only's "forbids it"
+// framing wouldn't make sense for safe_write (where the same
+// statement is also rejected, but the user has already opted into
+// some writes), so safe_write uses "rerun with --mode=full_access".
+func classifyDCL(stmt tree.Statement, tag string, mode Mode, op Operation) *Violation {
+	if stmt.StatementType() != tree.TypeDCL {
+		return nil
+	}
+	if isClusterAdminStmt(stmt) {
+		reason := clusterAdminReason(stmt, mode)
+		return &Violation{
+			Tag:    tag,
+			Reason: reason,
+			Mode:   mode,
+			Op:     op,
+			Kind:   KindClusterAdmin,
+		}
+	}
+	return &Violation{
+		Tag:    tag,
+		Reason: "privilege/role changes require --mode=full_access",
+		Mode:   mode,
+		Op:     op,
+		Kind:   KindPrivilege,
+	}
+}
+
+// isClusterAdminStmt reports whether stmt is one of the TypeDCL nodes
+// that isn't actually a privilege/role change. The set is enumerated
+// rather than described by a predicate because the parser exposes no
+// "is admin" classification — see cockroachdb-parser v0.26.2's
+// pkg/sql/sem/tree/stmt.go for the full TypeDCL inventory.
+//
+// Defaulting to "privilege" (rather than "admin") is intentional: if
+// a future CRDB version adds a new privilege-related TypeDCL node
+// without updating this list, the agent gets the right escalation
+// hint with a slightly less-specific Reason. If the new node is an
+// admin one, this list is the only place to update.
+func isClusterAdminStmt(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.SetZoneConfig,
+		*tree.SetClusterSetting, *tree.SetTracing,
+		*tree.CreateTenant, *tree.DropTenant,
+		*tree.AlterTenantSetClusterSetting, *tree.AlterTenantRename,
+		*tree.AlterTenantReset, *tree.AlterTenantService:
+		return true
+	}
+	return false
+}
+
+// clusterAdminReason returns the Reason text for a cluster-admin
+// rejection, tailored both to the mode (so the verbiage matches the
+// rest of the classifier) and to the operation domain so an agent
+// reading the envelope knows whether it's tweaking a zone, a cluster
+// setting, tracing, or a tenant.
+func clusterAdminReason(stmt tree.Statement, mode Mode) string {
+	suffix := "rerun with --mode=full_access"
+	if mode == ModeReadOnly {
+		suffix = "read_only mode forbids it"
+	}
+	switch stmt.(type) {
+	case *tree.SetZoneConfig:
+		return "zone configuration changes require full_access; " + suffix
+	case *tree.SetClusterSetting:
+		return "cluster setting changes require full_access; " + suffix
+	case *tree.SetTracing:
+		return "tracing changes require full_access; " + suffix
+	case *tree.CreateTenant, *tree.DropTenant,
+		*tree.AlterTenantSetClusterSetting, *tree.AlterTenantRename,
+		*tree.AlterTenantReset, *tree.AlterTenantService:
+		return "tenant management requires full_access; " + suffix
+	}
+	// Defensive fallback — isClusterAdminStmt returned true so the
+	// switch above should be exhaustive over the cluster-admin set;
+	// a generic message keeps the user unblocked if the two lists
+	// drift.
+	return "cluster administration requires full_access; " + suffix
+}
+
+// classifyFullAccessExecute is the full_access rule for OpExecute.
+// Per design doc §Safety Model, full_access admits anything that
+// parses; defense-in-depth comes from the statement timeout enforced
+// by Manager.Execute and (eventually) an audit log. Empty input is
+// already rejected upstream by Check's defensive guard, so we have no
+// special case to handle here.
+func classifyFullAccessExecute(_ tree.Statement) *Violation {
+	return nil
 }

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -105,25 +105,206 @@ func TestCheckReadOnlyExplainDDL(t *testing.T) {
 }
 
 func TestCheckRejectsUnimplementedModes(t *testing.T) {
-	// safe_write and full_access parse successfully (per ParseMode)
-	// but Check rejects them until issue #29. The rejection
-	// reason names the mode so an agent can recognise the
-	// "not implemented" condition vs a real classification miss.
+	// safe_write and full_access for the non-execute surfaces still
+	// report "not yet implemented" — only OpExecute (issue #29)
+	// wires those modes today; OpExplain/OpExplainDDL/OpSimulate are
+	// tracked separately as follow-up work.
 	tests := []struct {
 		name string
 		mode safety.Mode
+		op   safety.Operation
 	}{
-		{name: "safe_write not yet implemented", mode: safety.ModeSafeWrite},
-		{name: "full_access not yet implemented", mode: safety.ModeFullAccess},
+		{name: "safe_write OpExplain not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpExplain},
+		{name: "full_access OpExplain not yet implemented", mode: safety.ModeFullAccess, op: safety.OpExplain},
+		{name: "safe_write OpExplainDDL not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpExplainDDL},
+		{name: "full_access OpExplainDDL not yet implemented", mode: safety.ModeFullAccess, op: safety.OpExplainDDL},
+		{name: "safe_write OpSimulate not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpSimulate},
+		{name: "full_access OpSimulate not yet implemented", mode: safety.ModeFullAccess, op: safety.OpSimulate},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			v, err := safety.Check(tc.mode, safety.OpExplain, "SELECT 1")
+			v, err := safety.Check(tc.mode, tc.op, "SELECT 1")
 			require.NoError(t, err)
-			require.NotNil(t, v, "non-read_only modes are not admitted yet")
+			require.NotNil(t, v, "non-read_only modes are not admitted yet for explain ops")
 			require.Contains(t, v.Reason, "not yet implemented")
 			require.Equal(t, tc.mode, v.Mode)
+		})
+	}
+}
+
+func TestCheckReadOnlyExecute(t *testing.T) {
+	// OpExecute under read_only mirrors OpExplain's read-only set:
+	// SELECT/SHOW/etc. pass; writes, DDL, and DCL are rejected before
+	// any cluster contact. Differs from TestCheckReadOnlyExplain in
+	// the Op assertion AND in pinning the structural Kind on each
+	// rejection so escalation logic in envelope.suggestionsFor stays
+	// correct.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedTag    string
+		expectedKind   safety.ViolationKind
+	}{
+		{name: "select", sql: "SELECT * FROM t"},
+		{name: "show", sql: "SHOW TABLES"},
+		{name: "values", sql: "VALUES (1), (2)"},
+		{name: "with cte", sql: "WITH cte AS (SELECT 1) SELECT * FROM cte"},
+
+		{name: "insert rejected", sql: "INSERT INTO t VALUES (1)", expectedReject: true, expectedTag: "INSERT", expectedKind: safety.KindWrite},
+		{name: "update rejected", sql: "UPDATE t SET x = 1 WHERE id = 1", expectedReject: true, expectedTag: "UPDATE", expectedKind: safety.KindWrite},
+		{name: "delete rejected", sql: "DELETE FROM t WHERE id = 1", expectedReject: true, expectedTag: "DELETE", expectedKind: safety.KindWrite},
+		{name: "truncate rejected", sql: "TRUNCATE TABLE t", expectedReject: true, expectedTag: "TRUNCATE", expectedKind: safety.KindSchema},
+
+		{name: "drop table rejected", sql: "DROP TABLE users", expectedReject: true, expectedTag: "DROP TABLE", expectedKind: safety.KindSchema},
+		{name: "create table rejected", sql: "CREATE TABLE x (id INT PRIMARY KEY)", expectedReject: true, expectedTag: "CREATE TABLE", expectedKind: safety.KindSchema},
+
+		// GRANT under read_only must be tagged KindPrivilege even
+		// though the parser also reports it as schema-modifying. If
+		// it landed as KindWrite or KindSchema the escalation hint
+		// would suggest safe_write — which itself rejects privilege
+		// changes — and the agent would loop. Pinning Kind here
+		// closes that loop.
+		{name: "grant rejected", sql: "GRANT SELECT ON t TO bob", expectedReject: true, expectedTag: "GRANT", expectedKind: safety.KindPrivilege},
+		{name: "revoke rejected", sql: "REVOKE SELECT ON t FROM bob", expectedReject: true, expectedTag: "REVOKE", expectedKind: safety.KindPrivilege},
+		{name: "create role rejected", sql: "CREATE ROLE alice", expectedReject: true, expectedTag: "CREATE ROLE", expectedKind: safety.KindPrivilege},
+
+		// CRDB tags several non-privilege statements as TypeDCL
+		// (cluster config, tracing, zone config, tenant lifecycle).
+		// These get KindClusterAdmin and a domain-specific Reason
+		// rather than the misleading "privilege/role changes" message
+		// the SQL-standard reading of DCL would imply.
+		{name: "set cluster setting tagged as cluster admin",
+			sql:            "SET CLUSTER SETTING sql.defaults.distsql = 'on'",
+			expectedReject: true, expectedTag: "SET CLUSTER SETTING", expectedKind: safety.KindClusterAdmin},
+		{name: "set tracing tagged as cluster admin",
+			sql:            "SET TRACING = on",
+			expectedReject: true, expectedTag: "SET TRACING", expectedKind: safety.KindClusterAdmin},
+		{name: "configure zone tagged as cluster admin",
+			sql:            "ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5",
+			expectedReject: true, expectedTag: "CONFIGURE ZONE", expectedKind: safety.KindClusterAdmin},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeReadOnly, safety.OpExecute, tc.sql)
+			require.NoError(t, err)
+
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v, "expected statement to be rejected")
+			require.Equal(t, tc.expectedTag, v.Tag)
+			require.Equal(t, safety.ModeReadOnly, v.Mode)
+			require.Equal(t, safety.OpExecute, v.Op)
+			require.Equal(t, tc.expectedKind, v.Kind)
+		})
+	}
+}
+
+func TestCheckReadOnlyExecuteNestedExplain(t *testing.T) {
+	// The nested-EXPLAIN guard is shared between OpExplain and
+	// OpExecute (same case arm in classifyReadOnly). A future
+	// refactor that splits the case must not silently drop OpExecute
+	// coverage; this test pins it.
+	v, err := safety.Check(safety.ModeReadOnly, safety.OpExecute,
+		"EXPLAIN ANALYZE INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.Contains(t, v.Reason, "nested EXPLAIN")
+	require.Equal(t, safety.KindNestedExplain, v.Kind)
+}
+
+func TestCheckSafeWriteExecute(t *testing.T) {
+	// safe_write admits the read-only set plus DML, but still rejects
+	// DDL (with a full_access escalation hint) and DCL. The cluster's
+	// sql_safe_updates session var is the runtime guard against
+	// unqualified UPDATE/DELETE — that's wired in conn.Manager.Execute,
+	// not in Check, so even bare-WHERE-less UPDATEs pass the AST gate.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedReason string
+	}{
+		{name: "select admitted", sql: "SELECT 1"},
+		{name: "insert admitted", sql: "INSERT INTO t VALUES (1)"},
+		{name: "update admitted", sql: "UPDATE t SET x = 1 WHERE id = 1"},
+		{name: "delete admitted", sql: "DELETE FROM t WHERE id = 1"},
+		{name: "upsert admitted", sql: "UPSERT INTO t VALUES (1)"},
+		{name: "unqualified update admitted at AST layer",
+			sql: "UPDATE t SET x = 1"},
+
+		{name: "create table rejected with full_access hint",
+			sql:            "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedReject: true,
+			expectedReason: "rerun with --mode=full_access"},
+		{name: "drop table rejected",
+			sql:            "DROP TABLE users",
+			expectedReject: true,
+			expectedReason: "rerun with --mode=full_access"},
+		{name: "grant rejected as privilege change",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedReject: true,
+			expectedReason: "privilege/role changes require --mode=full_access"},
+		{name: "configure zone rejected as cluster admin",
+			sql:            "ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5",
+			expectedReject: true,
+			expectedReason: "zone configuration changes require full_access"},
+		{name: "set cluster setting rejected as cluster admin",
+			sql:            "SET CLUSTER SETTING sql.defaults.distsql = 'on'",
+			expectedReject: true,
+			expectedReason: "cluster setting changes require full_access"},
+		{name: "set tracing rejected as cluster admin",
+			sql:            "SET TRACING = on",
+			expectedReject: true,
+			expectedReason: "tracing changes require full_access"},
+		{name: "explain analyze ddl rejected as nested",
+			sql:            "EXPLAIN ANALYZE ALTER TABLE t ADD COLUMN x INT",
+			expectedReject: true,
+			expectedReason: "nested EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeSafeWrite, safety.OpExecute, tc.sql)
+			require.NoError(t, err)
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v)
+			require.Equal(t, safety.ModeSafeWrite, v.Mode)
+			require.Equal(t, safety.OpExecute, v.Op)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
+func TestCheckFullAccessExecute(t *testing.T) {
+	// full_access admits anything that parses; defense-in-depth comes
+	// from the statement timeout (and eventually an audit log), not
+	// from the AST allowlist. Empty input is still rejected by Check's
+	// defensive guard — that's covered by TestCheckRejectsEmptyInput.
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "select", sql: "SELECT 1"},
+		{name: "insert", sql: "INSERT INTO t VALUES (1)"},
+		{name: "drop table", sql: "DROP TABLE users"},
+		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
+		{name: "grant", sql: "GRANT SELECT ON t TO bob"},
+		{name: "multi statement", sql: "SELECT 1; INSERT INTO t VALUES (1)"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeFullAccess, safety.OpExecute, tc.sql)
+			require.NoError(t, err)
+			require.Nil(t, v, "full_access admits any parsed statement")
 		})
 	}
 }
@@ -151,22 +332,36 @@ func TestCheckParseErrorPropagates(t *testing.T) {
 func TestCheckRejectsEmptyInput(t *testing.T) {
 	// parser.Parse("") returns zero stmts and no error, which without
 	// an explicit empty-batch guard would be (nil, nil) — i.e.
-	// "permitted". Pin the defensive rejection so a regression that
-	// removes the guard is loud.
+	// "permitted". Pin the defensive rejection across every Op so a
+	// regression that removes the guard is loud, and pin the Tag
+	// sentinel so the rendered Message doesn't contain a stray empty
+	// parens cell ("(, mode=…, op=…)").
 	tests := []struct {
 		name string
 		sql  string
+		op   safety.Operation
 	}{
-		{name: "empty string", sql: ""},
-		{name: "whitespace only", sql: "   \n\t  "},
-		{name: "comment only", sql: "-- nothing here"},
+		{name: "explain empty string", sql: "", op: safety.OpExplain},
+		{name: "explain whitespace only", sql: "   \n\t  ", op: safety.OpExplain},
+		{name: "explain comment only", sql: "-- nothing here", op: safety.OpExplain},
+		{name: "execute empty string", sql: "", op: safety.OpExecute},
+		{name: "execute whitespace only", sql: "   \n\t  ", op: safety.OpExecute},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			v, err := safety.Check(safety.ModeReadOnly, safety.OpExplain, tc.sql)
+			v, err := safety.Check(safety.ModeReadOnly, tc.op, tc.sql)
 			require.NoError(t, err)
 			require.NotNil(t, v, "empty input must not bypass the gate")
 			require.Contains(t, v.Reason, "no statements parsed")
+			require.Equal(t, "EMPTY", v.Tag, "empty-input Tag must use the EMPTY sentinel")
+			require.Equal(t, safety.KindOther, v.Kind)
+
+			// No escalation hint helps an empty input; pin that no
+			// suggestion leaks out via Envelope.
+			env := safety.Envelope(v)
+			require.Empty(t, env.Suggestions,
+				"empty input must not produce a mode-escalation hint")
+			require.NotContains(t, env.Message, "(,", "Message must not contain an empty parens cell")
 		})
 	}
 }

--- a/internal/safety/envelope.go
+++ b/internal/safety/envelope.go
@@ -59,21 +59,68 @@ func contextMap(v *Violation) map[string]any {
 }
 
 // suggestionsFor proposes the higher-mode escape hatch when the
-// violation is mode-driven. We always suggest the lowest-privilege
-// mode that would admit the call — safe_write per design doc §Safety
-// Model — rather than jumping straight to full_access, so agents
-// follow the principle of least privilege.
+// violation can be unblocked by mode escalation. The decision uses
+// Violation.Kind (the structural reason) rather than scanning the
+// human-readable Reason string — that keeps the escalation logic
+// independent of wording tweaks in classifyReadOnly /
+// classifySafeWriteExecute.
+//
+// Principle: pick the smallest mode bump that would admit the call.
+// Schema and DCL skip safe_write (which also rejects them) and go
+// straight to full_access. Writes go to safe_write. Rejections that
+// no escalation can fix (KindNestedExplain, KindUnimplemented,
+// KindBadOpInput, KindOther) get no suggestion.
 func suggestionsFor(v *Violation) []output.Suggestion {
-	if v.Mode != ModeReadOnly {
+	target, ok := escalationTargetFor(v)
+	if !ok {
 		return nil
 	}
-	switch v.Op {
-	case OpExplain, OpExplainDDL:
-		return []output.Suggestion{{
-			Replacement: string(ModeSafeWrite),
-			Reason:      "safety_mode_escalation",
-		}}
-	default:
-		return nil
+	return []output.Suggestion{{
+		Replacement: string(target),
+		Reason:      "safety_mode_escalation",
+	}}
+}
+
+// escalationTargetFor returns the mode an agent should retry with
+// when v is unblockable by escalation, and false otherwise. Lifted
+// out of suggestionsFor so the escalation matrix is a single
+// (Mode, Op, Kind) → Mode table that's easy to scan and update.
+//
+// Unactionable Kinds short-circuit at the top: nested-EXPLAIN
+// wrappers, the empty-input defensive case, unimplemented (mode, op)
+// pairs, and explain-DDL wrong-input-shape rejections all need the
+// caller to fix the input or wait for upstream work, not to bump the
+// mode. Producing a hint anyway would burn an agent's retry on a
+// path that cannot succeed.
+func escalationTargetFor(v *Violation) (Mode, bool) {
+	switch v.Kind {
+	case KindNestedExplain, KindUnimplemented, KindBadOpInput, KindOther:
+		return "", false
 	}
+	switch v.Mode {
+	case ModeReadOnly:
+		switch v.Op {
+		case OpExplain, OpExplainDDL:
+			// The explain surfaces don't yet wire safe_write /
+			// full_access, but for read_only rejections the path
+			// forward when those land will be safe_write — keep the
+			// hint in place so agents can already discover the lever.
+			return ModeSafeWrite, true
+		case OpExecute:
+			switch v.Kind {
+			case KindWrite:
+				return ModeSafeWrite, true
+			case KindSchema, KindPrivilege, KindClusterAdmin:
+				return ModeFullAccess, true
+			}
+		}
+	case ModeSafeWrite:
+		if v.Op == OpExecute {
+			switch v.Kind {
+			case KindSchema, KindPrivilege, KindClusterAdmin:
+				return ModeFullAccess, true
+			}
+		}
+	}
+	return "", false
 }

--- a/internal/safety/envelope_test.go
+++ b/internal/safety/envelope_test.go
@@ -43,6 +43,11 @@ func TestEnvelopeSuggestionsByOp(t *testing.T) {
 	// design doc §Safety Model. Jumping to full_access would violate
 	// principle of least privilege, and the test pins the symmetry so
 	// a future change can't accidentally regress only one op.
+	//
+	// Kind is set explicitly to KindSchema (the most common explain
+	// rejection class) so the test exercises the same code path a
+	// real classifyReadOnly call would produce — Violations from
+	// production code never have Kind=0.
 	tests := []struct {
 		name string
 		op   safety.Operation
@@ -57,6 +62,7 @@ func TestEnvelopeSuggestionsByOp(t *testing.T) {
 				Tag:  "ANY",
 				Mode: safety.ModeReadOnly,
 				Op:   tc.op,
+				Kind: safety.KindSchema,
 			})
 			require.Len(t, e.Suggestions, 1)
 			require.Equal(t, string(safety.ModeSafeWrite), e.Suggestions[0].Replacement)
@@ -66,13 +72,119 @@ func TestEnvelopeSuggestionsByOp(t *testing.T) {
 }
 
 func TestEnvelopeNoSuggestionForUnimplementedModes(t *testing.T) {
-	// safe_write/full_access violations are "not implemented" — the
-	// fix is to wait for issue #29, not to escalate. So no
-	// suggestion is offered.
+	// OpExplain in safe_write/full_access still reports "not yet
+	// implemented" (the explain-side mode wiring is tracked
+	// separately). No escalation makes sense — the user has to wait
+	// — so no suggestion is offered.
 	e := safety.Envelope(&safety.Violation{
 		Tag:  "SELECT",
 		Mode: safety.ModeSafeWrite,
 		Op:   safety.OpExplain,
+		Kind: safety.KindUnimplemented,
 	})
 	require.Empty(t, e.Suggestions)
+}
+
+func TestEnvelopeExecuteSuggestions(t *testing.T) {
+	// OpExecute escalation is asymmetric: a write under read_only
+	// escalates to safe_write (the smallest bump), but schema changes
+	// and DCL under read_only must jump to full_access because
+	// safe_write itself rejects them. A safe_write rejection of
+	// schema/DCL escalates to full_access — there's no intermediate
+	// stop. The decision is driven by Violation.Kind, not by the
+	// human-readable Reason text, so wording tweaks in the classifier
+	// cannot silently break the escalation contract.
+	tests := []struct {
+		name                string
+		mode                safety.Mode
+		kind                safety.ViolationKind
+		expectedReplacement safety.Mode
+	}{
+		{
+			name:                "write under read_only suggests safe_write",
+			mode:                safety.ModeReadOnly,
+			kind:                safety.KindWrite,
+			expectedReplacement: safety.ModeSafeWrite,
+		},
+		{
+			name:                "schema change under read_only suggests full_access",
+			mode:                safety.ModeReadOnly,
+			kind:                safety.KindSchema,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+		{
+			name:                "privilege change under read_only suggests full_access",
+			mode:                safety.ModeReadOnly,
+			kind:                safety.KindPrivilege,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+		{
+			name:                "cluster admin under read_only suggests full_access",
+			mode:                safety.ModeReadOnly,
+			kind:                safety.KindClusterAdmin,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+		{
+			name:                "schema change under safe_write suggests full_access",
+			mode:                safety.ModeSafeWrite,
+			kind:                safety.KindSchema,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+		{
+			name:                "privilege change under safe_write suggests full_access",
+			mode:                safety.ModeSafeWrite,
+			kind:                safety.KindPrivilege,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+		{
+			name:                "cluster admin under safe_write suggests full_access",
+			mode:                safety.ModeSafeWrite,
+			kind:                safety.KindClusterAdmin,
+			expectedReplacement: safety.ModeFullAccess,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := safety.Envelope(&safety.Violation{
+				Tag:  "ANY",
+				Mode: tc.mode,
+				Op:   safety.OpExecute,
+				Kind: tc.kind,
+			})
+			require.Len(t, e.Suggestions, 1)
+			require.Equal(t, string(tc.expectedReplacement), e.Suggestions[0].Replacement)
+			require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
+		})
+	}
+}
+
+func TestEnvelopeNoSuggestionForUnactionableKinds(t *testing.T) {
+	// Some rejections cannot be unblocked by mode escalation —
+	// nested EXPLAIN wrappers, the empty-input defensive case,
+	// unknown-mode programmer errors, and explain-DDL-with-non-DDL.
+	// suggestionsFor must return no escalation hint for these so
+	// agents don't burn a retry on a mode that won't help.
+	tests := []struct {
+		name string
+		mode safety.Mode
+		op   safety.Operation
+		kind safety.ViolationKind
+	}{
+		{name: "nested explain", mode: safety.ModeReadOnly, op: safety.OpExecute, kind: safety.KindNestedExplain},
+		{name: "empty input", mode: safety.ModeReadOnly, op: safety.OpExecute, kind: safety.KindOther},
+		{name: "explain_ddl wrong input shape", mode: safety.ModeReadOnly, op: safety.OpExplainDDL, kind: safety.KindBadOpInput},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := safety.Envelope(&safety.Violation{
+				Tag:  "ANY",
+				Mode: tc.mode,
+				Op:   tc.op,
+				Kind: tc.kind,
+			})
+			require.Empty(t, e.Suggestions)
+		})
+	}
 }

--- a/internal/safety/limit.go
+++ b/internal/safety/limit.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety
+
+import (
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+)
+
+// MaybeInjectLimit returns sql with an injected LIMIT clause when the
+// input is a single bare SELECT without a LIMIT. The boolean reports
+// whether an injection happened so the caller can surface it in the
+// result envelope (transparency: agents must know the cluster did not
+// return all rows).
+//
+// The rewriter is conservative — it only fires when:
+//
+//   - maxRows > 0 (zero or negative means "unlimited", so skip).
+//   - sql parses to exactly one statement (multi-statement batches are
+//     left alone; it's not obvious which one to bound).
+//   - the statement is *tree.Select whose result is unbounded (no
+//     existing Count and no LIMIT ALL — see selectIsBounded). Note
+//     that tree.Limit holds both Count and Offset, so a SELECT with
+//     OFFSET but no LIMIT still has a non-nil Limit pointer; the
+//     bounded check looks at Count specifically rather than the
+//     pointer's nil-ness.
+//
+// Anything else — DML, DDL, parse errors, EXPLAIN wrappers — returns
+// the input unchanged with injected=false. Callers that already ran
+// safety.Check can treat the error path as unreachable; we still
+// surface parser errors rather than silently swallowing them so a
+// caller skipping Check won't get mysterious behaviour.
+func MaybeInjectLimit(sql string, maxRows int) (string, bool, error) {
+	if maxRows <= 0 {
+		return sql, false, nil
+	}
+	stmts, err := parser.Parse(sql)
+	if err != nil {
+		return sql, false, err
+	}
+	if len(stmts) != 1 {
+		return sql, false, nil
+	}
+	sel, ok := stmts[0].AST.(*tree.Select)
+	if !ok || selectIsBounded(sel) {
+		return sql, false, nil
+	}
+	if sel.Limit == nil {
+		sel.Limit = &tree.Limit{Count: tree.NewDInt(tree.DInt(maxRows))}
+	} else {
+		// Preserve any existing OFFSET (the only field that can be set
+		// when selectIsBounded returns false) and only add the Count.
+		sel.Limit.Count = tree.NewDInt(tree.DInt(maxRows))
+	}
+	return tree.AsStringWithFlags(sel, tree.FmtSimple), true, nil
+}
+
+// selectIsBounded reports whether sel already has a row-count cap.
+// Either an explicit Count or LIMIT ALL counts as "the caller has
+// expressed intent about cardinality"; we respect their bound (or
+// explicit unboundedness) rather than overwriting it.
+func selectIsBounded(sel *tree.Select) bool {
+	if sel.Limit == nil {
+		return false
+	}
+	return sel.Limit.Count != nil || sel.Limit.LimitAll
+}

--- a/internal/safety/limit_test.go
+++ b/internal/safety/limit_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package safety_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/safety"
+)
+
+func TestMaybeInjectLimit(t *testing.T) {
+	tests := []struct {
+		name                   string
+		sql                    string
+		max                    int
+		expectedInjected       bool
+		expectedContains       string
+		expectedContainsOffset bool
+	}{
+		{
+			name:             "bare select gets limit",
+			sql:              "SELECT * FROM t",
+			max:              1000,
+			expectedInjected: true,
+			expectedContains: "LIMIT 1000",
+		},
+		{
+			name:             "select with where gets limit",
+			sql:              "SELECT id FROM t WHERE id = 1",
+			max:              50,
+			expectedInjected: true,
+			expectedContains: "LIMIT 50",
+		},
+		{
+			name: "select with existing limit unchanged",
+			sql:  "SELECT * FROM t LIMIT 5",
+			max:  1000,
+		},
+		{
+			name: "select with offset and existing limit unchanged",
+			// Pin that the bounded check sees both flavours of "the
+			// caller already capped it".
+			sql: "SELECT * FROM t LIMIT 5 OFFSET 10",
+			max: 1000,
+		},
+		{
+			name: "select with limit all unchanged",
+			// LIMIT ALL is the explicit "give me everything" knob;
+			// honour it rather than overwriting with maxRows.
+			sql: "SELECT * FROM t LIMIT ALL",
+			max: 1000,
+		},
+		{
+			name: "insert returning unchanged",
+			sql:  "INSERT INTO t VALUES (1) RETURNING id",
+			max:  1000,
+		},
+		{
+			name: "delete unchanged",
+			sql:  "DELETE FROM t WHERE id = 1",
+			max:  1000,
+		},
+		{
+			name: "ddl unchanged",
+			sql:  "CREATE TABLE x (id INT PRIMARY KEY)",
+			max:  1000,
+		},
+		{
+			name: "multi-statement batch unchanged",
+			sql:  "SELECT 1; SELECT 2",
+			max:  1000,
+		},
+		{
+			name: "max zero means unlimited",
+			sql:  "SELECT * FROM t",
+			max:  0,
+		},
+		{
+			name: "negative max means unlimited",
+			sql:  "SELECT * FROM t",
+			max:  -1,
+		},
+		{
+			name: "explain wrapper unchanged",
+			sql:  "EXPLAIN SELECT * FROM t",
+			max:  1000,
+		},
+		{
+			name: "select with offset only gets limit injected",
+			// SELECT … OFFSET N (no LIMIT) is still unbounded — the
+			// parser stores OFFSET inside the same *Limit node as
+			// Count, so a naive Limit==nil check would skip injection
+			// and let an unbounded result stream through. The rewriter
+			// looks at Count specifically and preserves the OFFSET.
+			// Both LIMIT and OFFSET are asserted: a regression that
+			// overwrote sel.Limit (instead of mutating Count) would
+			// drop the OFFSET silently and still match a "LIMIT N"
+			// substring check.
+			sql:                    "SELECT * FROM t OFFSET 10",
+			max:                    500,
+			expectedInjected:       true,
+			expectedContains:       "LIMIT 500",
+			expectedContainsOffset: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, injected, err := safety.MaybeInjectLimit(tc.sql, tc.max)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedInjected, injected)
+			if !tc.expectedInjected {
+				require.Equal(t, tc.sql, out, "input must be returned verbatim when no injection")
+				return
+			}
+			require.True(t, strings.Contains(strings.ToUpper(out), tc.expectedContains),
+				"expected output %q to contain %q", out, tc.expectedContains)
+			if tc.expectedContainsOffset {
+				require.True(t, strings.Contains(strings.ToUpper(out), "OFFSET 10"),
+					"expected output %q to preserve OFFSET 10 alongside the injected LIMIT", out)
+			}
+		})
+	}
+}
+
+func TestMaybeInjectLimitParseError(t *testing.T) {
+	// Parser errors propagate unchanged so callers skipping safety.Check
+	// don't see silent no-ops.
+	out, injected, err := safety.MaybeInjectLimit("SELEKT broken", 1000)
+	require.Error(t, err)
+	require.False(t, injected)
+	require.Equal(t, "SELEKT broken", out)
+}

--- a/internal/safety/mode.go
+++ b/internal/safety/mode.go
@@ -24,9 +24,11 @@
 // envelope. envelope.go is the single bridge between the two.
 //
 // Design doc reference: §Safety Model (read_only is the default,
-// safe_write and full_access are opt-in escalations). Issue #21 wires
-// read_only end-to-end; safe_write and full_access enforcement land in
-// follow-up issue #29.
+// safe_write and full_access are opt-in escalations). Issue #21
+// wired read_only end-to-end; issue #29 wired safe_write and
+// full_access for OpExecute. The explain surfaces still report
+// "not yet implemented" for safe_write/full_access — wiring them is
+// follow-up work.
 package safety
 
 import "fmt"
@@ -37,8 +39,9 @@ import "fmt"
 type Mode string
 
 // Mode values. ModeReadOnly is the default for every Tier 3 command;
-// the other two are recognised by ParseMode but rejected by Check
-// until issue #29 lands.
+// the other two are recognised by ParseMode and admitted by Check
+// for OpExecute (issue #29). For OpExplain/OpExplainDDL/OpSimulate,
+// safe_write and full_access still report "not yet implemented".
 const (
 	ModeReadOnly   Mode = "read_only"
 	ModeSafeWrite  Mode = "safe_write"
@@ -58,10 +61,10 @@ const DefaultMode = ModeReadOnly
 // that names the valid choices, so the message a user sees on a typo
 // is actionable on its own.
 //
-// safe_write and full_access parse successfully even though Check
-// currently rejects them — the split keeps the flag-parsing layer
-// stable across issue #29 so the only churn when those modes land
-// is inside Check.
+// safe_write and full_access parse successfully for every Op even
+// though Check rejects them for OpExplain/OpExplainDDL/OpSimulate
+// today — the split keeps the flag-parsing layer stable so the only
+// churn when those modes land for the other surfaces is inside Check.
 func ParseMode(s string) (Mode, error) {
 	switch Mode(s) {
 	case "":


### PR DESCRIPTION
Wires the final Tier 3 capability: actually run user SQL against the
cluster, but only after the safety allowlist (issue #21) admits it
and the per-mode cluster wrapper enforces guardrails. The CLI gets a
new `crdb-sql exec` subcommand and the MCP server gets a parallel
`execute_sql` tool; both share the same safety / connection pipeline.

The safety package learns OpExecute and per-mode rules: read_only
admits the same set as OpExplain, safe_write also admits DML (with
DDL and privilege/cluster-admin rejected and a full_access
escalation hint), and full_access admits anything that parses.
Envelope suggestions branch on a new typed Violation.Kind
(KindWrite/KindSchema/KindPrivilege/KindClusterAdmin/...) so the
escalation hint stays correct without scanning Reason text — a
write under read_only suggests safe_write, while a schema change,
privilege change, or cluster-admin op suggests full_access because
safe_write rejects all three.

CRDB overloads the parser's TypeDCL beyond the SQL-standard "Data
Control Language" set — it covers GRANT/REVOKE/role mgmt AND cluster
configuration (SET CLUSTER SETTING, SET TRACING), zone configuration
(ALTER ... CONFIGURE ZONE), and tenant lifecycle. The classifier
splits the two into KindPrivilege vs KindClusterAdmin so the
rejection Reason names what the user is actually doing rather than
mislabelling a SET CLUSTER SETTING as a "privilege/role change".

A new MaybeInjectLimit helper rewrites unbounded read_only SELECTs
to add LIMIT <max-rows> via AST mutation. It looks at the parser's
Limit.Count field rather than Limit==nil so SELECT ... OFFSET N
(which parses as a non-nil Limit with Count=nil) still gets bounded
and OFFSET preserved. The result envelope's limit_injected field
surfaces the cap so an agent knows the response may be incomplete;
the CLI's --max-rows defaults to 1000.

Manager.Execute owns the per-mode transaction shape via an
exhaustive txOptionsForMode helper that errors on unknown modes
(defense against a caller that bypasses safety.ParseMode). Per-mode
shape: pgx.ReadOnly + statement_timeout for read_only, SET LOCAL
sql_safe_updates = on for safe_write (so the cluster rejects bare
UPDATE/DELETE at runtime), and statement_timeout only for
full_access. Row scanning closes the rows handle before reading
the command tag (pgx populates it inside Close), so CommandTag and
RowsAffected stay populated even on the MaxRows truncation path.
The connection-recovery contract mirrors Explain — any failure
closes the cached connection so the next call re-dials.

Resolves: #29