### PR TITLE
version: emit feature warnings from summarize, format, and risk

### DIFF
--- a/cmd/format.go
+++ b/cmd/format.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // colorMode is the value space accepted by --color. It mirrors the
@@ -110,14 +111,15 @@ JSON output is never colorized.`,
 
 			sql = strings.TrimSpace(sqlformat.StripShellPrompts(sql))
 
-			formatted, err := sqlformat.Format(sql)
+			parsed, parseErr := parser.Parse(sql)
+			if parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
+			}
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(parsed, state.targetVersion, nil)...)
+
+			formatted, err := sqlformat.FormatParsed(parsed)
 			if err != nil {
-				// Format can fail during parsing (candidate PGCODE
-				// present) or during pretty-printing (no candidate
-				// code). Only parser errors get the enriched path.
-				if pgerror.HasCandidateCode(err) {
-					return renderParseError(r, baseEnv, err, sql)
-				}
 				return r.RenderError(baseEnv, err)
 			}
 

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -314,3 +314,92 @@ func TestFormatCmdConflictingInput(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot use -e flag and file argument together")
 }
+
+// plpgsqlFormatWarningSQL is the PL/pgSQL fixture used by the format-side
+// version-warning tests, mirroring the parse-side fixture.
+const plpgsqlFormatWarningSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+// TestFormatCmdVersionWarning_PLpgSQL is the format mirror of
+// TestParseCmdVersionWarning_PLpgSQL: --target-version=23.2 with PL/pgSQL
+// emits a feature_not_yet_introduced warning while the data payload (the
+// formatted SQL) still populates.
+func TestFormatCmdVersionWarning_PLpgSQL(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"format",
+		"--target-version", "23.2",
+		"-e", plpgsqlFormatWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "23.2", env.TargetVersion)
+
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected a feature_not_yet_introduced warning in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, got.Severity)
+	require.Equal(t, "plpgsql_function_body", got.Context["feature_tag"])
+	require.Equal(t, "24.1", got.Context["introduced"])
+	require.Equal(t, "23.2", got.Context["target"])
+	require.NotEmpty(t, env.Data, "format must still succeed and emit a data payload")
+}
+
+// TestFormatCmdVersionWarning_NoneAtNewerTarget pins the negative case:
+// target at or after Introduced emits no feature warning.
+func TestFormatCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"format",
+		"--target-version", "24.1",
+		"-e", plpgsqlFormatWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestFormatCmdVersionWarning_NoFlagSkips covers the documented short-
+// circuit: no --target-version means version.Inspect is skipped.
+func TestFormatCmdVersionWarning_NoFlagSkips(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"format",
+		"-e", plpgsqlFormatWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.TargetVersion)
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"no --target-version must skip feature warnings, got %+v", e)
+	}
+}

--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -11,11 +11,13 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // newRiskCmd builds the `crdb-sql risk` subcommand. It reads SQL from
@@ -50,10 +52,13 @@ human-readable message, and fix hint.`,
 				return r.RenderError(baseEnv, err)
 			}
 
-			findings, err := risk.Analyze(sql)
-			if err != nil {
-				return r.RenderError(baseEnv, err)
+			parsed, parseErr := parser.Parse(sql)
+			if parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
 			}
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(parsed, state.targetVersion, nil)...)
+			findings := risk.AnalyzeParsed(parsed, sql)
 
 			data, err := json.Marshal(findings)
 			if err != nil {

--- a/cmd/risk_test.go
+++ b/cmd/risk_test.go
@@ -141,7 +141,11 @@ func TestRiskCmdNoFindings(t *testing.T) {
 }
 
 // TestRiskCmdParseErrorJSON verifies that invalid SQL in JSON mode
-// produces an envelope with errors and nil data.
+// produces an envelope with errors and nil data, and that the parse
+// error surfaces with its real PGCODE (42601) rather than a generic
+// internal_error. The PGCODE assertion is the regression guard for the
+// risk-cmd switch from r.RenderError to renderParseError — without it,
+// reverting that switch would silently demote agents' parser errors.
 func TestRiskCmdParseErrorJSON(t *testing.T) {
 	root := newRootCmd()
 	var stdout bytes.Buffer
@@ -157,6 +161,15 @@ func TestRiskCmdParseErrorJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.NotEmpty(t, env.Errors)
 	require.Nil(t, env.Data)
+
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == "42601" {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected SQLSTATE 42601 (syntax_error) in %+v", env.Errors)
 }
 
 // TestRiskCmdEmptyInput verifies that empty stdin produces an error.
@@ -168,4 +181,93 @@ func TestRiskCmdEmptyInput(t *testing.T) {
 	root.SetArgs([]string{"risk"})
 
 	require.Error(t, root.Execute())
+}
+
+// plpgsqlRiskWarningSQL is the PL/pgSQL fixture used by the risk-side
+// version-warning tests, mirroring the parse-side fixture.
+const plpgsqlRiskWarningSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+// TestRiskCmdVersionWarning_PLpgSQL is the risk mirror of
+// TestParseCmdVersionWarning_PLpgSQL: --target-version=23.2 with PL/pgSQL
+// emits a feature_not_yet_introduced warning while the data payload (the
+// risk findings array, possibly empty) still populates.
+func TestRiskCmdVersionWarning_PLpgSQL(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"risk",
+		"--target-version", "23.2",
+		"-e", plpgsqlRiskWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "23.2", env.TargetVersion)
+
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected a feature_not_yet_introduced warning in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, got.Severity)
+	require.Equal(t, "plpgsql_function_body", got.Context["feature_tag"])
+	require.Equal(t, "24.1", got.Context["introduced"])
+	require.Equal(t, "23.2", got.Context["target"])
+	require.NotEmpty(t, env.Data, "risk must still succeed and emit a data payload")
+}
+
+// TestRiskCmdVersionWarning_NoneAtNewerTarget pins the negative case:
+// target at or after Introduced emits no feature warning.
+func TestRiskCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"risk",
+		"--target-version", "24.1",
+		"-e", plpgsqlRiskWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestRiskCmdVersionWarning_NoFlagSkips covers the documented short-
+// circuit: no --target-version means version.Inspect is skipped.
+func TestRiskCmdVersionWarning_NoFlagSkips(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"risk",
+		"-e", plpgsqlRiskWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.TargetVersion)
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"no --target-version must skip feature warnings, got %+v", e)
+	}
 }

--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
 	"github.com/spilchen/sql-ai-tools/internal/summarize"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // newSummarizeCmd builds the `crdb-sql summarize` subcommand. It reads
@@ -53,10 +55,13 @@ read from the -e flag, a positional file argument, or stdin.`,
 				return r.RenderError(baseEnv, err)
 			}
 
-			summaries, err := summarize.Summarize(sql)
-			if err != nil {
-				return renderParseError(r, baseEnv, err, sql)
+			parsed, parseErr := parser.Parse(sql)
+			if parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
 			}
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(parsed, state.targetVersion, nil)...)
+			summaries := summarize.Parsed(parsed, sql)
 
 			data, err := json.Marshal(summaries)
 			if err != nil {

--- a/cmd/summarize_test.go
+++ b/cmd/summarize_test.go
@@ -205,3 +205,94 @@ func TestSummarizeCmdEmptyInput(t *testing.T) {
 
 	require.Error(t, root.Execute())
 }
+
+// plpgsqlSummarizeWarningSQL is the PL/pgSQL fixture used by the
+// summarize-side version-warning tests. It mirrors the fixture used by
+// TestParseCmdVersionWarning_PLpgSQL so a regression in either path is
+// caught locally.
+const plpgsqlSummarizeWarningSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+// TestSummarizeCmdVersionWarning_PLpgSQL is the summarize mirror of
+// TestParseCmdVersionWarning_PLpgSQL: --target-version=23.2 with PL/pgSQL
+// emits a feature_not_yet_introduced warning while the data payload (the
+// per-statement summaries) still populates.
+func TestSummarizeCmdVersionWarning_PLpgSQL(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"summarize",
+		"--target-version", "23.2",
+		"-e", plpgsqlSummarizeWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "23.2", env.TargetVersion)
+
+	var got *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			got = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, got, "expected a feature_not_yet_introduced warning in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, got.Severity)
+	require.Equal(t, "plpgsql_function_body", got.Context["feature_tag"])
+	require.Equal(t, "24.1", got.Context["introduced"])
+	require.Equal(t, "23.2", got.Context["target"])
+	require.NotEmpty(t, env.Data, "summarize must still succeed and emit a data payload")
+}
+
+// TestSummarizeCmdVersionWarning_NoneAtNewerTarget pins the negative
+// case: target at or after Introduced emits no feature warning.
+func TestSummarizeCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"summarize",
+		"--target-version", "24.1",
+		"-e", plpgsqlSummarizeWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestSummarizeCmdVersionWarning_NoFlagSkips covers the documented
+// short-circuit: no --target-version means version.Inspect is skipped.
+func TestSummarizeCmdVersionWarning_NoFlagSkips(t *testing.T) {
+	root := newRootCmd()
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"summarize",
+		"-e", plpgsqlSummarizeWarningSQL,
+		"--output", "json",
+	})
+
+	require.NoError(t, root.Execute())
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.TargetVersion)
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"no --target-version must skip feature warnings, got %+v", e)
+	}
+}

--- a/internal/mcp/tools/detect_risky_query.go
+++ b/internal/mcp/tools/detect_risky_query.go
@@ -10,12 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/diag"
-	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // DetectRiskyQueryTool returns the MCP tool definition for detect_risky_query.
@@ -46,11 +47,13 @@ func DetectRiskyQueryHandler(parserVersion, defaultTargetVersion string) server.
 
 		env := baseEnvelope(parserVersion, target)
 
-		findings, err := risk.Analyze(sql)
+		parsed, err := parser.Parse(sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
 			return envelopeResult(env)
 		}
+		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
+		findings := risk.AnalyzeParsed(parsed, sql)
 
 		data, err := json.Marshal(findings)
 		if err != nil {

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -10,12 +10,14 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // FormatSQLTool returns the MCP tool definition for format_sql.
@@ -51,9 +53,26 @@ func FormatSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHan
 		// get the same forgiving behavior.
 		sql = sqlformat.StripShellPrompts(sql)
 
-		formatted, err := sqlformat.Format(sql)
+		parsed, err := parser.Parse(sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			return envelopeResult(env)
+		}
+		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
+
+		formatted, err := sqlformat.FormatParsed(parsed)
+		if err != nil {
+			// Surface pretty-printer failures through the envelope (not
+			// mcp.NewToolResultError) so any version.Inspect warnings
+			// already appended above survive into the response. Without
+			// this, an opt-in target_version warning would be silently
+			// dropped the moment cfg.Pretty hiccuped — exactly the
+			// regression this tool was wired to prevent.
+			env.Errors = append(env.Errors, output.Error{
+				Code:     "internal_error",
+				Severity: output.SeverityError,
+				Message:  fmt.Sprintf("format: %v", err),
+			})
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/summarize.go
+++ b/internal/mcp/tools/summarize.go
@@ -10,12 +10,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/spilchen/sql-ai-tools/internal/diag"
-	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/summarize"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // SummarizeSQLTool returns the MCP tool definition for summarize_sql.
@@ -29,7 +30,9 @@ func SummarizeSQLTool() mcp.Tool {
 }
 
 // SummarizeSQLHandler returns the handler for the summarize_sql tool.
-// It delegates to summarize.Summarize and wraps the result in the
+// It parses the SQL once, runs version.Inspect on the AST so a
+// per-call target_version emits feature warnings into the envelope,
+// then delegates to summarize.Parsed and wraps the result in the
 // standard output.Envelope used by all tools in this package.
 // defaultTargetVersion is the server-level default; per-call
 // target_version arguments override it.
@@ -46,11 +49,13 @@ func SummarizeSQLHandler(parserVersion, defaultTargetVersion string) server.Tool
 
 		env := baseEnvelope(parserVersion, target)
 
-		summaries, err := summarize.Summarize(sql)
+		parsed, err := parser.Parse(sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
 			return envelopeResult(env)
 		}
+		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
+		summaries := summarize.Parsed(parsed, sql)
 
 		data, err := json.Marshal(summaries)
 		if err != nil {

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -1343,3 +1343,205 @@ func TestValidateSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
 	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
 		"parse error must still be present: %+v", env.Errors)
 }
+
+// plpgsqlVersionWarningSQL is the PL/pgSQL fixture shared by the
+// version-warning tests for summarize_sql, format_sql, and
+// detect_risky_query. The plpgsql_function_body feature is registered
+// as introduced in v24.1 (see internal/version/registry.go), so any
+// target_version older than that produces a feature_not_yet_introduced
+// warning when version.Inspect runs over the parsed AST.
+const plpgsqlVersionWarningSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+// TestSummarizeSQLHandler_VersionWarning is the summarize_sql mirror of
+// TestParseSQLHandler_VersionWarning: a per-call target_version that
+// predates the seeded plpgsql_function_body Introduced version produces
+// a feature_not_yet_introduced WARNING in the envelope while the data
+// payload (per-statement summaries) still populates.
+func TestSummarizeSQLHandler_VersionWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetVersion  string
+		expectFeatWarn bool
+	}{
+		{name: "before introduced", targetVersion: "23.2", expectFeatWarn: true},
+		{name: "at introduced", targetVersion: "24.1", expectFeatWarn: false},
+		{name: "no target version skips", targetVersion: "", expectFeatWarn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := SummarizeSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			args := map[string]any{"sql": plpgsqlVersionWarningSQL}
+			if tc.targetVersion != "" {
+				args["target_version"] = tc.targetVersion
+			}
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.NotEmpty(t, env.Data, "data payload must populate even with warnings")
+
+			featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+			if !tc.expectFeatWarn {
+				require.Nilf(t, featWarn, "unexpected feature warning: %+v", featWarn)
+				return
+			}
+			require.NotNilf(t, featWarn, "expected feature_not_yet_introduced in %+v", env.Errors)
+			require.Equal(t, output.SeverityWarning, featWarn.Severity)
+			require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
+		})
+	}
+}
+
+// TestFormatSQLHandler_VersionWarning is the format_sql mirror of
+// TestParseSQLHandler_VersionWarning. Same three-case shape: warn when
+// target predates the feature, no warn at-or-after, no warn when
+// target_version is unset.
+func TestFormatSQLHandler_VersionWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetVersion  string
+		expectFeatWarn bool
+	}{
+		{name: "before introduced", targetVersion: "23.2", expectFeatWarn: true},
+		{name: "at introduced", targetVersion: "24.1", expectFeatWarn: false},
+		{name: "no target version skips", targetVersion: "", expectFeatWarn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := FormatSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			args := map[string]any{"sql": plpgsqlVersionWarningSQL}
+			if tc.targetVersion != "" {
+				args["target_version"] = tc.targetVersion
+			}
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.NotEmpty(t, env.Data, "data payload must populate even with warnings")
+
+			featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+			if !tc.expectFeatWarn {
+				require.Nilf(t, featWarn, "unexpected feature warning: %+v", featWarn)
+				return
+			}
+			require.NotNilf(t, featWarn, "expected feature_not_yet_introduced in %+v", env.Errors)
+			require.Equal(t, output.SeverityWarning, featWarn.Severity)
+			require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
+		})
+	}
+}
+
+// TestSummarizeSQLHandler_ParseErrorPreservesPriorWarnings is the
+// summarize_sql mirror of TestParseSQLHandler_ParseErrorPreservesPriorWarnings:
+// a pre-stamped target_version_mismatch warning from baseEnvelope must
+// survive the parse-error branch. Pins that the handler appends rather
+// than overwrites env.Errors on parse failure.
+func TestSummarizeSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := SummarizeSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}
+
+// TestFormatSQLHandler_ParseErrorPreservesPriorWarnings is the
+// format_sql mirror — same append-not-overwrite contract on the
+// format handler's parse-error branch.
+func TestFormatSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := FormatSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}
+
+// TestDetectRiskyQueryHandler_ParseErrorPreservesPriorWarnings is the
+// detect_risky_query mirror — same append-not-overwrite contract on
+// the risk handler's parse-error branch.
+func TestDetectRiskyQueryHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := DetectRiskyQueryHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}
+
+// TestDetectRiskyQueryHandler_VersionWarning is the detect_risky_query
+// mirror of TestParseSQLHandler_VersionWarning. Risk findings remain
+// in the data payload regardless of the version warning.
+func TestDetectRiskyQueryHandler_VersionWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetVersion  string
+		expectFeatWarn bool
+	}{
+		{name: "before introduced", targetVersion: "23.2", expectFeatWarn: true},
+		{name: "at introduced", targetVersion: "24.1", expectFeatWarn: false},
+		{name: "no target version skips", targetVersion: "", expectFeatWarn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := DetectRiskyQueryHandler(testParserVersion, "" /* defaultTargetVersion */)
+			args := map[string]any{"sql": plpgsqlVersionWarningSQL}
+			if tc.targetVersion != "" {
+				args["target_version"] = tc.targetVersion
+			}
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.NotEmpty(t, env.Data, "data payload must populate even with warnings")
+
+			featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+			if !tc.expectFeatWarn {
+				require.Nilf(t, featWarn, "unexpected feature warning: %+v", featWarn)
+				return
+			}
+			require.NotNilf(t, featWarn, "expected feature_not_yet_introduced in %+v", env.Errors)
+			require.Equal(t, output.SeverityWarning, featWarn.Severity)
+			require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
+		})
+	}
+}

--- a/internal/risk/registry.go
+++ b/internal/risk/registry.go
@@ -166,7 +166,16 @@ func (r *Registry) Analyze(sql string) ([]Finding, error) {
 	if err != nil {
 		return nil, err
 	}
+	return r.AnalyzeParsed(stmts, sql), nil
+}
 
+// AnalyzeParsed runs every registered rule against already-parsed
+// statements. sql is the original source text — required for
+// positionFromSQL to locate each statement's line/column. Exposed so
+// callers that already invoked parser.Parse (e.g. to also run
+// version.Inspect on the same AST) can reuse the parsed output rather
+// than reparsing. Returns no error: parsing happened upstream.
+func (r *Registry) AnalyzeParsed(stmts statements.Statements, sql string) []Finding {
 	findings := []Finding{}
 	positions := make([]Position, len(stmts))
 	offset := 0
@@ -195,7 +204,7 @@ func (r *Registry) Analyze(sql string) ([]Finding, error) {
 			findings = append(findings, f)
 		}
 	}
-	return findings, nil
+	return findings
 }
 
 // Analyze is a convenience function that runs the default rule set
@@ -203,6 +212,13 @@ func (r *Registry) Analyze(sql string) ([]Finding, error) {
 // NewRegistry(DefaultRules(), DefaultMultiRules()).Analyze(sql).
 func Analyze(sql string) ([]Finding, error) {
 	return NewRegistry(DefaultRules(), DefaultMultiRules()).Analyze(sql)
+}
+
+// AnalyzeParsed is a convenience function that runs the default rule
+// set against already-parsed statements. It is equivalent to
+// NewRegistry(DefaultRules(), DefaultMultiRules()).AnalyzeParsed(stmts, sql).
+func AnalyzeParsed(stmts statements.Statements, sql string) []Finding {
+	return NewRegistry(DefaultRules(), DefaultMultiRules()).AnalyzeParsed(stmts, sql)
 }
 
 // positionFromSQL computes the Position of stmtSQL within fullSQL,

--- a/internal/sqlformat/format.go
+++ b/internal/sqlformat/format.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -27,6 +28,15 @@ func Format(sql string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return FormatParsed(stmts)
+}
+
+// FormatParsed pretty-prints already-parsed statements. Exposed so
+// callers that already invoked parser.Parse (e.g. to also run
+// version.Inspect on the same AST) can reuse the parsed output rather
+// than reparsing. The only error surface is the pretty-printer itself
+// (cfg.Pretty); parser errors are no longer possible at this layer.
+func FormatParsed(stmts statements.Statements) (string, error) {
 	if len(stmts) == 0 {
 		return "", nil
 	}

--- a/internal/summarize/summarize.go
+++ b/internal/summarize/summarize.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 
 	"github.com/spilchen/sql-ai-tools/internal/risk"
@@ -115,7 +116,17 @@ func Summarize(sql string) ([]Summary, error) {
 	if err != nil {
 		return nil, err
 	}
+	return Parsed(stmts, sql), nil
+}
 
+// Parsed produces summaries for already-parsed statements. sql is the
+// original source text — required for positionFromSQL to locate each
+// statement's line/column. Exposed so callers that already invoked
+// parser.Parse (e.g. to also run version.Inspect on the same AST) can
+// reuse the parsed output rather than reparsing. Mirrors the
+// Classify/ClassifyParsed split in package sqlparse; the shorter name
+// avoids stuttering with the package name.
+func Parsed(stmts statements.Statements, sql string) []Summary {
 	summaries := make([]Summary, 0, len(stmts))
 	offset := 0
 	for _, stmt := range stmts {
@@ -125,7 +136,7 @@ func Summarize(sql string) ([]Summary, error) {
 		s.RiskLevel = riskLevelFor(stmt.SQL)
 		summaries = append(summaries, s)
 	}
-	return summaries, nil
+	return summaries
 }
 
 // summarizeStatement summarizes one already-parsed statement. Position


### PR DESCRIPTION
Two unrelated commits on this branch.

## version: emit feature warnings from summarize, format, and risk

Resolves #116. PR #84 wired version-aware feature warnings into parse and validate; this commit extends the same pattern to summarize, format, and risk (CLI + MCP). Each tool already accepted `--target-version` / `target_version` but silently discarded it, breaking the per-tool contract from #84.

The internal packages (`summarize`, `sqlformat`, `risk`) gained a `*Parsed` entry point that takes already-parsed `statements.Statements`, mirroring `sqlparse.ClassifyParsed`. The CLI/MCP handlers parse once, run `version.Inspect(parsed, target, nil)` on the AST, append warnings to the envelope, and feed the parsed statements into the tool's logic — no double-parse. The string-based entry points stay and now delegate.

`summarize.SummarizeParsed` is named `summarize.Parsed` to satisfy revive's stuttering-export rule (the package name matches the verb prefix). `cmd/format.go` drops the `pgerror.HasCandidateCode` branch (no longer reachable). `cmd/risk.go` switches its parse-error path from `r.RenderError` to `renderParseError` so malformed SQL yields a real SQLSTATE in the envelope rather than `internal_error`. `internal/mcp/tools/format.go` routes pretty-printer failures through the envelope so version warnings already appended on the same call survive into the response.

15 new tests: 3 MCP version-warning tables (3 cases each), 3 MCP `*ParseErrorPreservesPriorWarnings` mirrors of the parse/validate twins, and 9 CLI tests (3 per command) using the same PL/pgSQL fixture as the existing parse/validate version-warning tests.

**Follow-up:** the `exec` / `execute_sql` tool added in #115 (commit 9e6e8c1) has the same target_version-but-no-warnings gap — surfaced during this PR's review and tracked as #143.

## build: move main.go into cmd/crdb-sql so go install names binary correctly

Pre-existing commit on this branch unrelated to #116 — moves `main.go` into `cmd/crdb-sql/` so `go install` names the binary `crdb-sql` instead of the repo name. Also updates `.goreleaser.yaml`, `Makefile`, and `README.md` accordingly.