### PR TITLE
safety: gate tenant-DML statements behind full_access

### DIFF
--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -327,6 +327,13 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 		// We split the two so the rejection Reason matches what the
 		// user is actually doing. classifyDCL routes both cases.
 		//
+		// Three tenant lifecycle nodes — AlterTenantCapability,
+		// AlterTenantReplication, CreateTenantFromReplication — are
+		// tagged TypeDML rather than TypeDCL upstream. That's an
+		// upstream classification quirk, not a deliberate policy
+		// signal, so we route them through isTenantMgmtDMLStmt to
+		// land in the cluster-admin gate alongside their DCL siblings.
+		//
 		// Empirical predicate matrix (verified against
 		// cockroachdb-parser v0.26.2):
 		//
@@ -338,6 +345,11 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 		//                     : DCL + schema + write   → KindClusterAdmin → full_access
 		//   CREATE/DROP/ALTER TENANT *
 		//                     : DCL + write            → KindClusterAdmin → full_access
+		//   ALTER VIRTUAL CLUSTER CAPABILITY
+		//                     : DML                    → KindClusterAdmin → full_access
+		//   ALTER VIRTUAL CLUSTER REPLICATION,
+		//   CREATE VIRTUAL CLUSTER FROM REPLICATION
+		//                     : DML + write            → KindClusterAdmin → full_access
 		//   CREATE/DROP/ALTER TABLE etc.
 		//                     : DDL + schema           → KindSchema       → full_access
 		//   TRUNCATE          : DDL + schema + write   → KindSchema       → full_access
@@ -345,6 +357,25 @@ func classifyReadOnly(op Operation, stmt tree.Statement) *Violation {
 		//                     : DML + write            → KindWrite        → safe_write
 		if v := classifyDCL(stmt, tag, ModeReadOnly, op); v != nil {
 			return v
+		}
+		// Tenant lifecycle nodes the parser tags TypeDML rather than
+		// TypeDCL belong with the cluster-admin family, not the
+		// generic write/schema branches below. Without this guard,
+		// AlterTenantCapability — for which the parser marks neither
+		// CanWriteData nor CanModifySchema — would slip past every
+		// remaining check and be silently admitted under read_only.
+		// AlterTenantReplication and CreateTenantFromReplication do
+		// have CanWriteData=true, so they would still be rejected by
+		// the branch below, but as KindWrite — pointing the agent at
+		// safe_write, which would also reject them.
+		if isTenantMgmtDMLStmt(stmt) {
+			return &Violation{
+				Tag:    tag,
+				Reason: clusterAdminReason(stmt, ModeReadOnly),
+				Mode:   ModeReadOnly,
+				Op:     op,
+				Kind:   KindClusterAdmin,
+			}
 		}
 		if tree.CanModifySchema(stmt) {
 			return &Violation{
@@ -472,6 +503,23 @@ func classifySafeWriteExecute(stmt tree.Statement) *Violation {
 	if v := classifyDCL(stmt, tag, ModeSafeWrite, OpExecute); v != nil {
 		return v
 	}
+	// Tenant lifecycle DML nodes (see isTenantMgmtDMLStmt) require
+	// full_access for the same reason their DCL siblings do — they
+	// reshape cluster-level tenant state, not row data. Without this
+	// guard, AlterTenantReplication and CreateTenantFromReplication
+	// would be admitted as ordinary CanWriteData=true statements
+	// (safe_write permits writes), and AlterTenantCapability — which
+	// the parser marks neither CanWriteData nor CanModifySchema —
+	// would fall through every remaining check.
+	if isTenantMgmtDMLStmt(stmt) {
+		return &Violation{
+			Tag:    tag,
+			Reason: clusterAdminReason(stmt, ModeSafeWrite),
+			Mode:   ModeSafeWrite,
+			Op:     OpExecute,
+			Kind:   KindClusterAdmin,
+		}
+	}
 	if tree.CanModifySchema(stmt) {
 		return &Violation{
 			Tag:    tag,
@@ -539,6 +587,40 @@ func isClusterAdminStmt(stmt tree.Statement) bool {
 	return false
 }
 
+// isTenantMgmtDMLStmt reports whether stmt is one of the tenant
+// lifecycle nodes the parser tags TypeDML rather than TypeDCL. These
+// belong in the cluster-admin gate alongside CreateTenant /
+// DropTenant / AlterTenant* — the parser tag is an upstream
+// classification quirk, not a deliberate choice that the safety
+// model should honour. Kept as a sibling of isClusterAdminStmt (and
+// not folded into it) so the invariant "isClusterAdminStmt is only
+// consulted for TypeDCL nodes" — relied on by classifyDCL — stays
+// intact.
+//
+// Without this list:
+//   - AlterTenantCapability is silently admitted under read_only
+//     (its CanWriteData and CanModifySchema both return false).
+//   - AlterTenantReplication and CreateTenantFromReplication land at
+//     KindWrite under read_only (admitted under safe_write), so the
+//     escalation hint and Reason mislabel a tenant-lifecycle
+//     operation as a row write.
+//
+// Invariant: every type in this switch must also appear in
+// clusterAdminReason's switch. A type listed here without a matching
+// reason case is not a security bug (the reason fallback still says
+// "cluster administration requires full_access"), but the agent loses
+// the tenant-specific Reason text. The two switches are kept
+// physically adjacent so the coupling is easy to see.
+func isTenantMgmtDMLStmt(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.AlterTenantCapability,
+		*tree.AlterTenantReplication,
+		*tree.CreateTenantFromReplication:
+		return true
+	}
+	return false
+}
+
 // clusterAdminReason returns the Reason text for a cluster-admin
 // rejection, tailored both to the mode (so the verbiage matches the
 // rest of the classifier) and to the operation domain so an agent
@@ -558,7 +640,9 @@ func clusterAdminReason(stmt tree.Statement, mode Mode) string {
 		return "tracing changes require full_access; " + suffix
 	case *tree.CreateTenant, *tree.DropTenant,
 		*tree.AlterTenantSetClusterSetting, *tree.AlterTenantRename,
-		*tree.AlterTenantReset, *tree.AlterTenantService:
+		*tree.AlterTenantReset, *tree.AlterTenantService,
+		*tree.AlterTenantCapability, *tree.AlterTenantReplication,
+		*tree.CreateTenantFromReplication:
 		return "tenant management requires full_access; " + suffix
 	}
 	// Defensive fallback — isClusterAdminStmt returned true so the

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -42,6 +42,20 @@ func TestCheckReadOnlyExplain(t *testing.T) {
 		// Read-only allowlist rejects DCL writes.
 		{name: "grant", sql: "GRANT SELECT ON t TO bob", expectedReject: true, expectedTag: "GRANT"},
 		{name: "revoke", sql: "REVOKE SELECT ON t FROM bob", expectedReject: true, expectedTag: "REVOKE"},
+
+		// classifyReadOnly's OpExplain/OpExecute case arm is shared,
+		// so the tenant-DML gate added for issue #136 must reject
+		// these on the OpExplain path too. A future refactor that
+		// splits the case must not silently drop OpExplain coverage.
+		{name: "alter tenant capability rejected on explain path",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split",
+			expectedReject: true, expectedTag: "ALTER VIRTUAL CLUSTER CAPABILITY"},
+		{name: "alter tenant replication rejected on explain path",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION",
+			expectedReject: true, expectedTag: "ALTER VIRTUAL CLUSTER REPLICATION"},
+		{name: "create tenant from replication rejected on explain path",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'",
+			expectedReject: true, expectedTag: "CREATE VIRTUAL CLUSTER FROM REPLICATION"},
 	}
 
 	for _, tc := range tests {
@@ -184,6 +198,26 @@ func TestCheckReadOnlyExecute(t *testing.T) {
 		{name: "configure zone tagged as cluster admin",
 			sql:            "ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5",
 			expectedReject: true, expectedTag: "CONFIGURE ZONE", expectedKind: safety.KindClusterAdmin},
+
+		// The parser tags these three nodes TypeDML rather than
+		// TypeDCL, so without the dedicated isTenantMgmtDMLStmt
+		// guard AlterTenantCapability would be silently admitted
+		// (its CanWriteData/CanModifySchema both return false) and
+		// the other two would be tagged KindWrite — pointing the
+		// escalation hint at safe_write, which itself rejects them.
+		// These rows pin the cluster-admin classification.
+		{name: "alter tenant capability tagged as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split",
+			expectedReject: true, expectedTag: "ALTER VIRTUAL CLUSTER CAPABILITY",
+			expectedKind: safety.KindClusterAdmin},
+		{name: "alter tenant replication tagged as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION",
+			expectedReject: true, expectedTag: "ALTER VIRTUAL CLUSTER REPLICATION",
+			expectedKind: safety.KindClusterAdmin},
+		{name: "create tenant from replication tagged as cluster admin",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'",
+			expectedReject: true, expectedTag: "CREATE VIRTUAL CLUSTER FROM REPLICATION",
+			expectedKind: safety.KindClusterAdmin},
 	}
 
 	for _, tc := range tests {
@@ -261,6 +295,29 @@ func TestCheckSafeWriteExecute(t *testing.T) {
 			sql:            "SET TRACING = on",
 			expectedReject: true,
 			expectedReason: "tracing changes require full_access"},
+
+		// Tenant-management DML nodes (parser tags them TypeDML
+		// rather than TypeDCL) must reject under safe_write with the
+		// same tenant-management Reason as their TypeDCL siblings.
+		// AlterTenantReplication and CreateTenantFromReplication were
+		// previously admitted here because safe_write permits
+		// CanWriteData=true statements and the parser marks both as
+		// writes. AlterTenantCapability was admitted for the opposite
+		// reason: neither CanWriteData nor CanModifySchema returns
+		// true for it, so nothing in classifySafeWriteExecute rejected
+		// it either.
+		{name: "alter tenant capability rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split",
+			expectedReject: true,
+			expectedReason: "tenant management requires full_access"},
+		{name: "alter tenant replication rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION",
+			expectedReject: true,
+			expectedReason: "tenant management requires full_access"},
+		{name: "create tenant from replication rejected as cluster admin",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'",
+			expectedReject: true,
+			expectedReason: "tenant management requires full_access"},
 		{name: "explain analyze ddl rejected as nested",
 			sql:            "EXPLAIN ANALYZE ALTER TABLE t ADD COLUMN x INT",
 			expectedReject: true,
@@ -298,6 +355,18 @@ func TestCheckFullAccessExecute(t *testing.T) {
 		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
 		{name: "grant", sql: "GRANT SELECT ON t TO bob"},
 		{name: "multi statement", sql: "SELECT 1; INSERT INTO t VALUES (1)"},
+
+		// The tenant-DML gate added for issue #136 must not leak into
+		// full_access — these are the explicit opt-in cases, so the
+		// allowlist must admit them. Pin all three so a future
+		// classifyFullAccessExecute that grew an unrelated rejection
+		// branch can't silently re-block the tenant-management path.
+		{name: "alter tenant capability admitted under full_access",
+			sql: "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split"},
+		{name: "alter tenant replication admitted under full_access",
+			sql: "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION"},
+		{name: "create tenant from replication admitted under full_access",
+			sql: "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Three tenant-management AST nodes are tagged TypeDML rather than TypeDCL
in cockroachdb-parser, so the cluster-admin classifier added in #29 did
not catch them. Their previous handling was wrong:

  AlterTenantCapability        — silently admitted under read_only
                                 (CanWriteData and CanModifySchema both
                                 return false, so it slipped past every
                                 check in classifyReadOnly)
  AlterTenantReplication       — admitted under safe_write; rejected
                                 under read_only as KindWrite, so the
                                 escalation hint pointed at safe_write
                                 (which would also have rejected it)
  CreateTenantFromReplication  — same as AlterTenantReplication

The first row was the worst — `ALTER VIRTUAL CLUSTER … GRANT CAPABILITY
…` ran unimpeded under the default mode. All three are tenant lifecycle
operations and belong with the existing CreateTenant / DropTenant /
AlterTenant* set, which already require full_access.

Add a sibling predicate `isTenantMgmtDMLStmt` consulted in
classifyReadOnly (OpExplain/OpExecute) and classifySafeWriteExecute
ahead of the generic CanWriteData/CanModifySchema branches. The new
predicate is kept separate from isClusterAdminStmt so the invariant
"isClusterAdminStmt is only consulted for TypeDCL nodes" — relied on by
classifyDCL — stays intact. The existing clusterAdminReason machinery
is reused so the rejection Reason and KindClusterAdmin escalation hint
stay consistent across the whole tenant family.

Out of scope: changing the parser's StatementType for these nodes;
that is an upstream concern.

Resolves: #136

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>