### PR TITLE
exec: assert SQLSTATE on envelope Code field, not Message substring

### DIFF
--- a/cmd/exec_integration_test.go
+++ b/cmd/exec_integration_test.go
@@ -121,7 +121,7 @@ func TestIntegrationExecCmdEnforcesTimeoutFlag(t *testing.T) {
 	var env output.Envelope
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
 	require.Len(t, env.Errors, 1)
-	require.Contains(t, env.Errors[0].Message, "57014",
+	require.Equal(t, "57014", env.Errors[0].Code,
 		"--timeout=1ms must produce a SQLSTATE 57014 error from the cluster")
 	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus,
 		"a cluster-side timeout error leaves the manager's recovery contract in place — connection_status reverts")


### PR DESCRIPTION
TestIntegrationExecCmdEnforcesTimeoutFlag asserted that
env.Errors[0].Message contained "57014", but pgconn surfaces the
SQLSTATE only on PgError.Code; the Message field is just the prose
("query execution canceled due to statement timeout"). FromClusterError
already routes Code and Message into separate envelope fields, so the
test was looking in the wrong place and failed against any cluster
that returned a clean Message.

Switch the assertion to require.Equal on env.Errors[0].Code, matching
the documented contract of output.Error and the path FromClusterError
populates.

Resolves: #137