### PR TITLE
version: emit feature warnings from exec and execute_sql

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -13,6 +13,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/spf13/cobra"
 
 	"github.com/spilchen/sql-ai-tools/internal/conn"
@@ -20,6 +21,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/safety"
 	"github.com/spilchen/sql-ai-tools/internal/sqlinput"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // defaultExecMaxRows is the row cap applied to execute results when
@@ -115,11 +117,23 @@ truncation.`,
 				return r.RenderError(baseEnv, err)
 			}
 
-			violation, err := safety.Check(parsedMode, safety.OpExecute, sql)
-			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+			// Parse once up front so version.Inspect, safety.CheckParsed,
+			// and safety.MaybeInjectLimitParsed share a single AST. The
+			// cluster will reparse on its own — that's the cluster's
+			// concern — but the client-side parses collapse to one.
+			//
+			// Order matters: version.Inspect and safety.CheckParsed are
+			// read-only walks; safety.MaybeInjectLimitParsed mutates
+			// stmts[0].AST.Limit in place when injection fires, so the
+			// inspectors must run first.
+			parsed, parseErr := parser.Parse(sql)
+			if parseErr != nil {
+				return renderParseError(r, baseEnv, parseErr, sql)
 			}
-			if violation != nil {
+			baseEnv.Errors = append(baseEnv.Errors,
+				version.Inspect(parsed, state.targetVersion, nil)...)
+
+			if violation := safety.CheckParsed(parsedMode, safety.OpExecute, parsed); violation != nil {
 				return r.RenderErrorEntry(baseEnv,
 					fmt.Errorf("safety violation: %s", violation.Reason),
 					safety.Envelope(violation))
@@ -127,14 +141,13 @@ truncation.`,
 
 			// LIMIT injection is scoped to read_only because the other
 			// modes are explicit opt-ins where the user has already
-			// accepted writes / unbounded scans. Injection runs after
-			// safety.Check so we can rely on parsability.
+			// accepted writes / unbounded scans.
 			rewritten := sql
 			var injected bool
 			if parsedMode == safety.ModeReadOnly && maxRows > 0 {
-				rewritten, injected, err = safety.MaybeInjectLimit(sql, maxRows)
-				if err != nil {
-					return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+				if rw, did := safety.MaybeInjectLimitParsed(parsed, maxRows); did {
+					rewritten = rw
+					injected = true
 				}
 			}
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -163,6 +163,100 @@ func TestExecCmdInvalidMode(t *testing.T) {
 	require.Contains(t, env.Errors[0].Message, "invalid safety mode")
 }
 
+// plpgsqlExecVersionWarningSQL is the PL/pgSQL fixture shared by the
+// exec version-warning tests. plpgsql_function_body is registered as
+// introduced in v24.1 (see internal/version/registry.go), so any
+// --target-version older than that triggers a feature_not_yet_introduced
+// warning when version.Inspect runs over the parsed AST.
+const plpgsqlExecVersionWarningSQL = `CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$`
+
+// TestExecCmdVersionWarning_PLpgSQL pins that --target-version below
+// the feature's Introduced version emits a feature_not_yet_introduced
+// WARNING into env.Errors AND that the warning survives a downstream
+// safety_violation (the append-not-overwrite invariant the parse
+// handler tests pin on its own surface). CREATE FUNCTION is DDL, so
+// the read_only allowlist rejects it before any cluster contact —
+// connection_status stays disconnected and the test does not need a
+// reachable cluster.
+func TestExecCmdVersionWarning_PLpgSQL(t *testing.T) {
+	stdout, err := runExec(t, "",
+		"--target-version", "23.2",
+		"--dsn", "postgres://nope:1/db",
+		"--output", "json",
+		"-e", plpgsqlExecVersionWarningSQL)
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Equal(t, "23.2", env.TargetVersion)
+
+	// Filter rather than index: the envelope may also carry a
+	// target_version_mismatch warning (parser is on v0.26 in this
+	// build) and the safety_violation appended after the warning.
+	var featWarn *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeFeatureNotYetIntroduced {
+			featWarn = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, featWarn, "expected a feature_not_yet_introduced warning in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, featWarn.Severity)
+	require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+	require.Equal(t, "24.1", featWarn.Context["introduced"])
+	require.Equal(t, "23.2", featWarn.Context["target"])
+
+	var safetyErr *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeSafetyViolation {
+			safetyErr = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNilf(t, safetyErr,
+		"version warning must coexist with the safety violation in %+v", env.Errors)
+}
+
+// TestExecCmdVersionWarning_NoneAtNewerTarget pins the negative case:
+// when target is at or after the feature's Introduced version, no
+// feature warning is emitted.
+func TestExecCmdVersionWarning_NoneAtNewerTarget(t *testing.T) {
+	stdout, err := runExec(t, "",
+		"--target-version", "24.1",
+		"--dsn", "postgres://nope:1/db",
+		"--output", "json",
+		"-e", plpgsqlExecVersionWarningSQL)
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"target at Introduced must not warn, got %+v", e)
+	}
+}
+
+// TestExecCmdVersionWarning_NoFlagSkips covers the documented
+// short-circuit: omitting --target-version skips the inspector
+// entirely. Without this, a regression that promoted "" to "warn
+// anyway" would only surface on the parse / validate / summarize
+// surfaces.
+func TestExecCmdVersionWarning_NoFlagSkips(t *testing.T) {
+	stdout, err := runExec(t, "",
+		"--dsn", "postgres://nope:1/db",
+		"--output", "json",
+		"-e", plpgsqlExecVersionWarningSQL)
+	require.ErrorIs(t, err, output.ErrRendered)
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env))
+	require.Empty(t, env.TargetVersion)
+	for _, e := range env.Errors {
+		require.NotEqualf(t, output.CodeFeatureNotYetIntroduced, e.Code,
+			"no --target-version must skip inspector, got %+v", e)
+	}
+}
+
 // TestRenderExecText covers the text-mode rendering branches:
 // tabular output for SELECT-shape results, command-tag-only output for
 // DML without RETURNING, the truncated trailer, and the LIMIT-injected

--- a/internal/mcp/tools/execute.go
+++ b/internal/mcp/tools/execute.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/safety"
+	"github.com/spilchen/sql-ai-tools/internal/version"
 )
 
 // defaultExecuteMaxRows is the row cap applied to read_only SELECTs
@@ -78,13 +80,25 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 
 		env := connectedEnvelope(parserVersion, target)
 
-		violation, err := safety.Check(mode, safety.OpExecute, sql)
+		// Parse once up front so version.Inspect, safety.CheckParsed,
+		// and safety.MaybeInjectLimitParsed share a single AST. Append
+		// (not assign) into env.Errors so a pre-stamped warning from
+		// connectedEnvelope (e.g. target_version_mismatch) survives a
+		// downstream parse / safety / cluster failure.
+		//
+		// Order matters: version.Inspect and safety.CheckParsed are
+		// read-only walks; safety.MaybeInjectLimitParsed mutates
+		// stmts[0].AST.Limit in place when injection fires, so the
+		// inspectors must run first.
+		parsed, err := parser.Parse(sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
 			return envelopeResult(env)
 		}
-		if violation != nil {
-			env.Errors = []output.Error{safety.Envelope(violation)}
+		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
+
+		if violation := safety.CheckParsed(mode, safety.OpExecute, parsed); violation != nil {
+			env.Errors = append(env.Errors, safety.Envelope(violation))
 			return envelopeResult(env)
 		}
 
@@ -94,10 +108,9 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 		rewritten := sql
 		var injected bool
 		if mode == safety.ModeReadOnly && maxRows > 0 {
-			rewritten, injected, err = safety.MaybeInjectLimit(sql, maxRows)
-			if err != nil {
-				env.Errors = []output.Error{diag.FromParseError(err, sql)}
-				return envelopeResult(env)
+			if rw, did := safety.MaybeInjectLimitParsed(parsed, maxRows); did {
+				rewritten = rw
+				injected = true
 			}
 		}
 
@@ -109,7 +122,7 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 			MaxRows: maxRows,
 		})
 		if err != nil {
-			env.Errors = []output.Error{diag.FromClusterError(err, rewritten)}
+			env.Errors = append(env.Errors, diag.FromClusterError(err, rewritten))
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/execute_test.go
+++ b/internal/mcp/tools/execute_test.go
@@ -139,6 +139,117 @@ func TestExecuteSQLToolAdvertisesParams(t *testing.T) {
 	}
 }
 
+// TestExecuteSQLHandler_VersionWarning is the execute_sql mirror of
+// TestParseSQLHandler_VersionWarning: a per-call target_version that
+// predates the seeded plpgsql_function_body Introduced version emits
+// a feature_not_yet_introduced WARNING into env.Errors. Because
+// CREATE FUNCTION is DDL, the read_only allowlist rejects it before
+// any cluster contact, so the test runs without a reachable cluster
+// — the warning simply coexists with the safety_violation in
+// env.Errors, which also pins the append-not-overwrite invariant on
+// the safety-rejection branch.
+func TestExecuteSQLHandler_VersionWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetVersion  string
+		expectFeatWarn bool
+	}{
+		{name: "before introduced", targetVersion: "23.2", expectFeatWarn: true},
+		{name: "at introduced", targetVersion: "24.1", expectFeatWarn: false},
+		{name: "no target version skips", targetVersion: "", expectFeatWarn: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+			args := map[string]any{
+				"sql": plpgsqlVersionWarningSQL,
+				"dsn": "postgres://nope:1/db",
+			}
+			if tc.targetVersion != "" {
+				args["target_version"] = tc.targetVersion
+			}
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = args
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+
+			featWarn := findEnvErrorByCode(env.Errors, output.CodeFeatureNotYetIntroduced)
+			if !tc.expectFeatWarn {
+				require.Nilf(t, featWarn, "unexpected feature warning: %+v", featWarn)
+				return
+			}
+			require.NotNilf(t, featWarn, "expected feature_not_yet_introduced in %+v", env.Errors)
+			require.Equal(t, output.SeverityWarning, featWarn.Severity)
+			require.Equal(t, "plpgsql_function_body", featWarn.Context["feature_tag"])
+			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
+
+			require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeSafetyViolation),
+				"version warning must coexist with the safety violation in %+v", env.Errors)
+		})
+	}
+}
+
+// TestExecuteSQLHandler_ParseErrorPreservesPriorWarnings is the
+// execute_sql mirror of TestParseSQLHandler_ParseErrorPreservesPriorWarnings:
+// a pre-stamped target_version_mismatch warning from connectedEnvelope
+// must survive the parse-error branch. Pins that the handler appends
+// rather than overwrites env.Errors on parse failure.
+func TestExecuteSQLHandler_ParseErrorPreservesPriorWarnings(t *testing.T) {
+	handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	// target_version with a different MAJOR.MINOR than testParserVersion
+	// (v0.26.2) triggers VersionMismatchWarning; SELECTT 1 then forces
+	// a parse error.
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECTT 1",
+		"dsn":            "postgres://nope:1/db",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive parse failure: %+v", env.Errors)
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, "42601"),
+		"parse error must still be present: %+v", env.Errors)
+}
+
+// TestExecuteSQLHandler_ConnectFailurePreservesPriorWarnings pins
+// the cluster-error append-not-overwrite invariant: a pre-stamped
+// target_version_mismatch warning from connectedEnvelope must
+// survive a downstream cluster connect failure. Distinct from
+// TestExecuteSQLHandler_ParseErrorPreservesPriorWarnings (parse
+// branch) and TestExecuteSQLHandler_VersionWarning (safety branch);
+// without this, a regression that reverted only the
+// diag.FromClusterError append back to assignment would silently
+// drop version warnings whenever the cluster was unreachable.
+//
+// Uses a SELECT (admits under read_only so safety does not
+// short-circuit) and an unreachable DSN with a 1s connect_timeout
+// so the handler reaches the mgr.Execute branch and fails there.
+func TestExecuteSQLHandler_ConnectFailurePreservesPriorWarnings(t *testing.T) {
+	handler := ExecuteSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":            "SELECT 1",
+		"dsn":            "postgres://nope:1/db?connect_timeout=1",
+		"target_version": "25.4",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+
+	require.NotNilf(t, findEnvErrorByCode(env.Errors, output.CodeTargetVersionMismatch),
+		"target_version_mismatch warning must survive cluster connect failure: %+v", env.Errors)
+	require.NotEmpty(t, env.Errors, "expected at least the cluster-error entry alongside the warning")
+}
+
 // TestResolveMaxRows pins the documented contract on the max_rows
 // resolver: missing → defaultMax; positive → cast to int; negative
 // → 0 ("unlimited"); non-numeric → tool-level error. Each case is a

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -186,6 +187,20 @@ func Check(mode Mode, op Operation, sql string) (*Violation, error) {
 	if err != nil {
 		return nil, err
 	}
+	return CheckParsed(mode, op, stmts), nil
+}
+
+// CheckParsed is the parsed-input variant of Check. Callers that
+// already invoked parser.Parse (e.g. to also run version.Inspect on
+// the same AST) use it to avoid a second parse.
+//
+// Return contract: nil when every statement in stmts is permitted
+// under (mode, op), or *Violation describing the first offending
+// statement (multi-statement inputs short-circuit on the first
+// reject). The empty-batch defensive case from Check is preserved so
+// a caller that hands in an empty Statements slice still gets the
+// "no statements parsed" sentinel rather than a silent pass.
+func CheckParsed(mode Mode, op Operation, stmts statements.Statements) *Violation {
 	if len(stmts) == 0 {
 		// Defensive: parser.Parse("") returns zero stmts and no error.
 		// The CLI's sqlinput layer rejects empty input upstream, but
@@ -200,14 +215,14 @@ func Check(mode Mode, op Operation, sql string) (*Violation, error) {
 			Mode:   mode,
 			Op:     op,
 			Kind:   KindOther,
-		}, nil
+		}
 	}
 	for _, s := range stmts {
 		if v := classify(mode, op, s.AST); v != nil {
-			return v, nil
+			return v
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 // classify applies the (mode, op) rule to a single parsed statement.

--- a/internal/safety/limit.go
+++ b/internal/safety/limit.go
@@ -7,6 +7,7 @@ package safety
 
 import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 )
 
@@ -33,6 +34,10 @@ import (
 // safety.Check can treat the error path as unreachable; we still
 // surface parser errors rather than silently swallowing them so a
 // caller skipping Check won't get mysterious behaviour.
+//
+// See MaybeInjectLimitParsed for callers (cmd/exec.go,
+// internal/mcp/tools/execute.go) that already ran parser.Parse and
+// want to skip a second client-side parse.
 func MaybeInjectLimit(sql string, maxRows int) (string, bool, error) {
 	if maxRows <= 0 {
 		return sql, false, nil
@@ -41,12 +46,42 @@ func MaybeInjectLimit(sql string, maxRows int) (string, bool, error) {
 	if err != nil {
 		return sql, false, err
 	}
-	if len(stmts) != 1 {
+	rewritten, injected := MaybeInjectLimitParsed(stmts, maxRows)
+	if !injected {
 		return sql, false, nil
+	}
+	return rewritten, true, nil
+}
+
+// MaybeInjectLimitParsed is the parsed-input variant of
+// MaybeInjectLimit. Callers that already invoked parser.Parse use it
+// to avoid a second parse. Mirrors summarize.Parsed /
+// sqlformat.FormatParsed in shape: the parsed-input variant drops
+// the parse-error return since the parse already succeeded upstream.
+//
+// Return contract: on injection (rewritten, true). On no-injection
+// — including the maxRows<=0, multi-statement, non-Select, and
+// already-bounded cases — ("", false). Callers MUST keep their own
+// SQL string and fall back to it on false; the parsed variant
+// deliberately does not round-trip the AST back through
+// tree.AsStringWithFlags on the no-injection path so it cannot
+// reformat or drop comments. Nil-string-on-false is loud-by-design:
+// a caller that writes `rewritten, _ = MaybeInjectLimitParsed(...)`
+// would dispatch an empty query rather than fail-silently to the
+// original input, surfacing the contract violation immediately.
+//
+// Ownership: stmts[0].AST is mutated in place when injection fires
+// (the slice itself is not retained past return). The same AST
+// cannot be safely re-fed to a downstream consumer that expects the
+// pre-injection shape, so run version.Inspect / safety.CheckParsed
+// on the AST first, then call MaybeInjectLimitParsed last.
+func MaybeInjectLimitParsed(stmts statements.Statements, maxRows int) (string, bool) {
+	if maxRows <= 0 || len(stmts) != 1 {
+		return "", false
 	}
 	sel, ok := stmts[0].AST.(*tree.Select)
 	if !ok || selectIsBounded(sel) {
-		return sql, false, nil
+		return "", false
 	}
 	if sel.Limit == nil {
 		sel.Limit = &tree.Limit{Count: tree.NewDInt(tree.DInt(maxRows))}
@@ -55,7 +90,7 @@ func MaybeInjectLimit(sql string, maxRows int) (string, bool, error) {
 		// when selectIsBounded returns false) and only add the Count.
 		sel.Limit.Count = tree.NewDInt(tree.DInt(maxRows))
 	}
-	return tree.AsStringWithFlags(sel, tree.FmtSimple), true, nil
+	return tree.AsStringWithFlags(sel, tree.FmtSimple), true
 }
 
 // selectIsBounded reports whether sel already has a row-count cap.

--- a/internal/safety/limit_test.go
+++ b/internal/safety/limit_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/safety"
@@ -127,6 +129,89 @@ func TestMaybeInjectLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMaybeInjectLimitParsed pins the parsed-input contract directly,
+// rather than only through the string-input wrapper. The wrapper
+// masks no-injection by returning the original SQL string, so a
+// parsed-variant regression that returned ("", false) for an
+// injectable bare SELECT would be invisible to wrapper-only tests
+// (the wrapper would silently swap back to the original input and
+// look like a deliberate no-op). Direct coverage of the *Parsed
+// entry point keeps the empty-string-on-no-injection contract
+// regression-tested.
+func TestMaybeInjectLimitParsed(t *testing.T) {
+	tests := []struct {
+		name             string
+		sql              string
+		max              int
+		expectedInjected bool
+		expectedContains string
+	}{
+		{
+			name:             "bare select gets limit",
+			sql:              "SELECT * FROM t",
+			max:              250,
+			expectedInjected: true,
+			expectedContains: "LIMIT 250",
+		},
+		{
+			name: "non-select returns empty no-injection",
+			sql:  "INSERT INTO t VALUES (1)",
+			max:  100,
+		},
+		{
+			name: "already-bounded select returns empty no-injection",
+			sql:  "SELECT * FROM t LIMIT 5",
+			max:  100,
+		},
+		{
+			name: "max zero returns empty no-injection",
+			sql:  "SELECT * FROM t",
+			max:  0,
+		},
+		{
+			name: "multi-statement returns empty no-injection",
+			sql:  "SELECT 1; SELECT 2",
+			max:  100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmts, err := parser.Parse(tc.sql)
+			require.NoError(t, err)
+
+			out, injected := safety.MaybeInjectLimitParsed(stmts, tc.max)
+			require.Equal(t, tc.expectedInjected, injected)
+			if !tc.expectedInjected {
+				require.Empty(t, out,
+					"no-injection contract: parsed variant returns empty string, not the original SQL")
+				return
+			}
+			require.Contains(t, strings.ToUpper(out), tc.expectedContains)
+		})
+	}
+}
+
+// TestMaybeInjectLimitParsedMutatesAST pins the documented ownership
+// contract: when injection fires, stmts[0].AST is mutated in place so
+// downstream consumers of the same Statements slice see the new
+// LIMIT. A regression that built a fresh AST and serialized it would
+// pass the in/out string assertion but break the documented "captures
+// stmts by reference" contract that exec.go and execute.go rely on.
+func TestMaybeInjectLimitParsedMutatesAST(t *testing.T) {
+	stmts, err := parser.Parse("SELECT * FROM t")
+	require.NoError(t, err)
+
+	sel, ok := stmts[0].AST.(*tree.Select)
+	require.True(t, ok)
+	require.Nil(t, sel.Limit, "precondition: bare SELECT has no Limit node")
+
+	_, injected := safety.MaybeInjectLimitParsed(stmts, 42)
+	require.True(t, injected)
+	require.NotNil(t, sel.Limit, "AST must be mutated in place to reflect the injected LIMIT")
+	require.NotNil(t, sel.Limit.Count)
 }
 
 func TestMaybeInjectLimitParseError(t *testing.T) {


### PR DESCRIPTION
## Summary

Wires `version.Inspect` into `crdb-sql exec` and the `execute_sql` MCP
tool so that opting into `--target-version` / `target_version` on the
cluster-execution path emits the same `feature_not_yet_introduced`
WARNING entries that `parse`/`validate` (#84) and
`summarize`/`format`/`risk` (#116) already produce. Warnings stay
advisory — the statement still executes (or fails) on its existing
path; only the envelope grows a WARNING entry.

Both surfaces parse the SQL once, append `version.Inspect(parsed,
target, nil)` to the envelope's `Errors`, and reuse the same parsed
AST for the safety pass and the LIMIT injector — no double client-side
parse. To enable that, `internal/safety` grows `CheckParsed` and
`MaybeInjectLimitParsed` parsed-input variants alongside the existing
string-input entry points (which now delegate after parsing). The MCP
handler's failure branches switch from `env.Errors = []…{…}`
assignments to `append` so a pre-stamped warning from
`connectedEnvelope` (e.g. `target_version_mismatch`) survives any
downstream parse / safety / cluster failure.

## Demo

```
crdb-sql exec --target-version 23.2 --mode full_access \
  --dsn $CRDB_DSN --output json \
  -e "CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL \
       AS \$\$ BEGIN RETURN 1; END \$\$"
```

The envelope's `errors[]` carries a `feature_not_yet_introduced`
WARNING with `context.feature_tag = "plpgsql_function_body"`,
`context.target = "23.2"`, `context.introduced = "24.1"` — and the
statement still executes.

Resolves: #143