### PR TITLE
cockroachtest: fail loudly when no cluster is reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
   ci:
     name: build / lint / test
     runs-on: ubuntu-latest
+    # The CI runner does not install a cockroach binary, so any
+    # integration-tagged test reaching cockroachtest.Shared would
+    # otherwise t.Fatalf. Setting CRDB_INTEGRATION_OPTIONAL converts
+    # that fatal back into a skip — only here, never on dev machines.
+    env:
+      CRDB_INTEGRATION_OPTIONAL: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ All workflows go through the Makefile:
 
 - `make build` — compile to `bin/crdb-sql`
 - `make test` — run the Go test suite (`go test ./...`)
+- `make test-integration` — run the `integration`-tagged suite. Requires a reachable cluster (install `cockroach` or set `CRDB_TEST_DSN`); fails loudly if neither is available.
 - `make fmt` — auto-format sources with gofmt
 - `make fmt-check` — fail if any file is not gofmt-clean
 - `make vet` — run `go vet ./...`

--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,13 @@ test: ## Run the Go test suite.
 	go test $(GO_PKGS)
 
 # Integration tests are gated behind the `integration` build tag and
-# require a real cockroach binary. Set COCKROACH_BIN to override the
-# default $PATH lookup. With neither COCKROACH_BIN nor CRDB_TEST_DSN
-# set, the tests t.Skip cleanly so this target is safe to run on
-# machines that have not installed cockroach.
-test-integration: ## Run integration tests (requires cockroach binary; set COCKROACH_BIN to override).
+# require a reachable cluster. Resolution order: CRDB_TEST_DSN (point
+# at an existing cluster) -> COCKROACH_BIN (path to a binary) ->
+# `cockroach` on $PATH. With none of those available the suite now
+# fails loudly instead of silently skipping; the prior skip behavior
+# is reserved for the GitHub Actions CI job, which sets
+# CRDB_INTEGRATION_OPTIONAL=1 in .github/workflows/ci.yml.
+test-integration: ## Run integration tests (requires reachable cluster; install cockroach or set CRDB_TEST_DSN).
 	go test -tags integration -count=1 -timeout 180s $(GO_PKGS)
 
 fmt: ## Auto-format sources with gofmt.

--- a/internal/testutil/cockroachtest/cluster.go
+++ b/internal/testutil/cockroachtest/cluster.go
@@ -21,6 +21,8 @@
 //   - Shared and RunTests provide the per-test-binary pattern used by
 //     integration test packages: one cluster is started on the first
 //     Shared call and torn down by RunTests when the test binary exits.
+//     Shared fails the test (rather than skipping) when no cluster is
+//     reachable; see "Binary resolution" below for the opt-out.
 //
 // Binary resolution (in order):
 //
@@ -28,8 +30,11 @@
 //  2. `cockroach` on $PATH.
 //
 // If neither resolves to an executable file, Start returns
-// ErrBinaryNotFound and Shared translates that into t.Skip so CI
-// machines without a cockroach binary stay green.
+// ErrBinaryNotFound. Shared turns that into t.Fatalf by default so a
+// silent skip can never masquerade as a passing integration test;
+// environments that legitimately lack a cockroach binary (today: the
+// GitHub Actions CI job) opt back into the old skip behavior by
+// setting CRDB_INTEGRATION_OPTIONAL=1.
 //
 // CRDB_TEST_DSN bypass: when CRDB_TEST_DSN is set, Shared returns a
 // Cluster with only DSN populated and a no-op Stop. This lets a
@@ -45,6 +50,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -62,9 +68,14 @@ const (
 )
 
 // ErrBinaryNotFound is returned by Start when no cockroach binary can
-// be located via COCKROACH_BIN or $PATH. Callers (typically Shared)
-// translate this into t.Skipf with a message explaining how to enable
-// the integration tests.
+// be located via COCKROACH_BIN or $PATH. Shared turns this into
+// t.Fatalf by default so missing-binary cases fail loudly, or into
+// t.Skipf when CRDB_INTEGRATION_OPTIONAL holds a strconv.ParseBool-truthy
+// value (the CI escape hatch — falsy or unparseable values still Fatal,
+// so a typo can't accidentally enable skipping). Shared callers also
+// have CRDB_TEST_DSN as a third option (point at an already-running
+// cluster); Start itself does not honor that var because its job is
+// to spawn a process, not to wrap an existing one.
 var ErrBinaryNotFound = errors.New(
 	"cockroach binary not found (set COCKROACH_BIN or put cockroach on PATH)")
 
@@ -407,15 +418,61 @@ var (
 	sharedStarted bool
 )
 
+// integrationOptionalEnv is the opt-in env var that converts Shared's
+// missing-binary fatal into a skip. It exists for one reason: the
+// GitHub Actions CI job does not install cockroach and would otherwise
+// fail every integration-tagged test. Anywhere else (developer
+// laptops, fresh checkouts, ad-hoc CI), leaving it unset means missing
+// binaries surface as loud test failures instead of invisible skips.
+//
+// The value is parsed by strconv.ParseBool — see that function for the
+// full grammar. Truthy values (e.g. "1", "true") enable the skip;
+// falsy ones (e.g. "0", "false") disable it. An unparseable value
+// (e.g. "yes", "on", "1\n") is itself a Fatal — silently treating an
+// unrecognized value as "off" would just relocate the silent-skip
+// footgun this package is trying to remove.
+const integrationOptionalEnv = "CRDB_INTEGRATION_OPTIONAL"
+
+// missingBinaryMsg is the message Shared uses when it cannot reach a
+// cluster and CRDB_INTEGRATION_OPTIONAL is unset. It enumerates every
+// knob that would make the test runnable so a developer hitting the
+// failure for the first time has a complete recovery menu in front of
+// them.
+const missingBinaryMsg = "cockroachtest: no cockroach binary found and CRDB_TEST_DSN unset; " +
+	"install cockroach on $PATH, set COCKROACH_BIN, set CRDB_TEST_DSN=postgresql://..., " +
+	"or export CRDB_INTEGRATION_OPTIONAL=1 to skip"
+
 // Shared returns the per-test-binary cluster, starting one on the
-// first call. CRDB_TEST_DSN takes precedence: if set, Shared returns a
-// Cluster whose DSN is the env value and whose Stop is a no-op.
+// first call. CRDB_TEST_DSN takes precedence: if set at first-call
+// time, Shared returns a Cluster whose DSN is the env value and
+// whose Stop is a no-op.
+//
+// Env-read timing: CRDB_TEST_DSN and the binary-resolution variables
+// (COCKROACH_BIN, $PATH) are read only on the first call; the result
+// is cached. CRDB_INTEGRATION_OPTIONAL is the exception — it is
+// re-read on every call so a test that flips the opt-in mid-run gets
+// the new behavior on subsequent calls, not the value captured at
+// first-call time.
 //
 // Behavior on missing binary: when neither CRDB_TEST_DSN nor a
-// resolvable cockroach binary is available, Shared calls t.Skipf and
-// returns nil. On a real *testing.T, Skipf invokes runtime.Goexit, so
-// the nil return is only observable to test doubles that override
-// Skipf (e.g. the recordingTB used in cluster_test.go). Production
+// resolvable cockroach binary is available, Shared calls t.Fatalf by
+// default. Setting CRDB_INTEGRATION_OPTIONAL to a strconv.ParseBool
+// truthy value (e.g. "1", "true") converts the failure into t.Skipf —
+// this is the escape hatch for environments (today: the GitHub
+// Actions job) that legitimately have no cockroach installed. A
+// falsy or unparseable value Fatals just like the unset case, so a
+// typo can't accidentally enable skipping.
+//
+// Behavior on cached failure: a Shared call that follows a failed
+// Shared call replays the Skip/Fatal decision against the *current*
+// CRDB_INTEGRATION_OPTIONAL value, but only for ErrBinaryNotFound. A
+// generic Start failure cached on the first call always Fatals —
+// never skips — because CRDB_INTEGRATION_OPTIONAL is meant only for
+// the missing-binary case.
+//
+// On a real *testing.T, both Fatalf and Skipf invoke runtime.Goexit,
+// so the nil return is only observable to test doubles that override
+// them (e.g. the recordingTB used in cluster_test.go). Production
 // callers can rely on Shared either returning a usable *Cluster or
 // never returning.
 //
@@ -428,7 +485,7 @@ func Shared(t testing.TB) *Cluster {
 
 	if sharedStarted {
 		if sharedErr != nil {
-			t.Skipf("cockroachtest: shared cluster unavailable: %v", sharedErr)
+			reportCachedErr(t, sharedErr)
 			return nil
 		}
 		return sharedCluster
@@ -443,7 +500,7 @@ func Shared(t testing.TB) *Cluster {
 	c, err := Start(context.Background())
 	if errors.Is(err, ErrBinaryNotFound) {
 		sharedErr = err
-		t.Skipf("cockroachtest: %v; set COCKROACH_BIN or CRDB_TEST_DSN to enable integration tests", err)
+		reportMissingBinary(t, err)
 		return nil
 	}
 	if err != nil {
@@ -453,6 +510,50 @@ func Shared(t testing.TB) *Cluster {
 	}
 	sharedCluster = c
 	return sharedCluster
+}
+
+// reportMissingBinary handles the ErrBinaryNotFound outcome at the
+// first Shared call. It honors the CRDB_INTEGRATION_OPTIONAL escape
+// hatch (skip) on parseable-truthy values and Fatalf otherwise. An
+// unparseable value is itself a Fatal — relaying "I don't know what
+// you meant" as a skip would just re-introduce the silent-skip
+// footgun this package is trying to eliminate.
+func reportMissingBinary(t testing.TB, err error) {
+	t.Helper()
+	raw := os.Getenv(integrationOptionalEnv)
+	if raw == "" {
+		t.Fatalf("%s (underlying: %v)", missingBinaryMsg, err)
+		return
+	}
+	optIn, perr := strconv.ParseBool(raw)
+	if perr != nil {
+		t.Fatalf("%s=%q is not a boolean (%v); %s",
+			integrationOptionalEnv, raw, perr, missingBinaryMsg)
+		return
+	}
+	if !optIn {
+		t.Fatalf("%s (underlying: %v)", missingBinaryMsg, err)
+		return
+	}
+	t.Skipf("cockroachtest: %v; %s=%q set, skipping", err, integrationOptionalEnv, raw)
+}
+
+// reportCachedErr handles a Shared call that follows an earlier
+// Shared call which already failed. It discriminates by error type:
+// ErrBinaryNotFound flows back through reportMissingBinary so the CI
+// escape hatch still applies, but a generic Start failure (port
+// collision, premature exit, tempdir trouble, etc.) is always Fatal.
+// Routing every cached error through the missing-binary helper would
+// make CRDB_INTEGRATION_OPTIONAL=1 silently skip real startup
+// failures on every test after the first — the exact pattern this
+// commit set out to eliminate.
+func reportCachedErr(t testing.TB, err error) {
+	t.Helper()
+	if errors.Is(err, ErrBinaryNotFound) {
+		reportMissingBinary(t, err)
+		return
+	}
+	t.Fatalf("cockroachtest: failed to start cluster: %v", err)
 }
 
 // RunTests is the TestMain helper for integration test packages. It

--- a/internal/testutil/cockroachtest/cluster_test.go
+++ b/internal/testutil/cockroachtest/cluster_test.go
@@ -77,20 +77,139 @@ func TestStartDetectsPrematureExit(t *testing.T) {
 		"premature-exit detection should be near-instant, not wait for the timeout")
 }
 
-// TestSharedSkipsWhenNoBinary verifies Shared's t.Skipf path. The
-// shared-state reset keeps the test independent of execution order
-// inside this package.
-func TestSharedSkipsWhenNoBinary(t *testing.T) {
+// TestSharedReportsMissingBinary covers Shared's missing-binary
+// behavior across the full CRDB_INTEGRATION_OPTIONAL contract. Unset
+// and falsy values must Fatal (with a message naming every recovery
+// knob); strconv.ParseBool-truthy values must Skip; and an
+// unparseable value must Fatal rather than silently default to "off",
+// because a typo here is exactly the silent-skip footgun the package
+// is trying to remove.
+func TestSharedReportsMissingBinary(t *testing.T) {
+	tests := []struct {
+		name             string
+		optionalEnv      string
+		expectedSkipped  bool
+		expectedFailed   bool
+		expectedMsgParts []string
+	}{
+		{
+			name:           "fatal by default (unset)",
+			optionalEnv:    "",
+			expectedFailed: true,
+			expectedMsgParts: []string{
+				"$PATH", "COCKROACH_BIN", "CRDB_TEST_DSN", "CRDB_INTEGRATION_OPTIONAL=1",
+			},
+		},
+		{
+			name:           "fatal when explicitly disabled",
+			optionalEnv:    "0",
+			expectedFailed: true,
+			expectedMsgParts: []string{
+				"$PATH", "COCKROACH_BIN", "CRDB_TEST_DSN", "CRDB_INTEGRATION_OPTIONAL=1",
+			},
+		},
+		{
+			name:             "fatal on unparseable value",
+			optionalEnv:      "please",
+			expectedFailed:   true,
+			expectedMsgParts: []string{`CRDB_INTEGRATION_OPTIONAL="please"`, "not a boolean"},
+		},
+		{
+			name:             "skip when opt-in set to 1",
+			optionalEnv:      "1",
+			expectedSkipped:  true,
+			expectedMsgParts: []string{"binary not found", `CRDB_INTEGRATION_OPTIONAL="1"`},
+		},
+		{
+			name:             "skip when opt-in set to true",
+			optionalEnv:      "true",
+			expectedSkipped:  true,
+			expectedMsgParts: []string{"binary not found", `CRDB_INTEGRATION_OPTIONAL="true"`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("COCKROACH_BIN", "/definitely/not/a/real/path/cockroach")
+			t.Setenv("PATH", "")
+			t.Setenv("CRDB_TEST_DSN", "")
+			t.Setenv("CRDB_INTEGRATION_OPTIONAL", tc.optionalEnv)
+			resetSharedState()
+
+			rec := &recordingTB{TB: t}
+			c := Shared(rec)
+			require.Nil(t, c)
+			require.Equal(t, tc.expectedSkipped, rec.skipped, "skip outcome")
+			require.Equal(t, tc.expectedFailed, rec.failed, "fatal outcome")
+
+			msg := rec.skipMsg
+			if rec.failed {
+				msg = rec.failMsg
+			}
+			for _, part := range tc.expectedMsgParts {
+				require.Contains(t, msg, part)
+			}
+		})
+	}
+}
+
+// TestSharedCachedFailureReplaysContract pins the regression-prevention
+// claim of the centralized error reporter: once a Shared call has
+// failed and cached an error, every subsequent Shared call in the
+// same test binary replays the same Skip-vs-Fatal decision against
+// the current CRDB_INTEGRATION_OPTIONAL setting. Without this, a
+// future refactor could let test #1 fatal while test #2 silently
+// returns nil — the original bug.
+func TestSharedCachedFailureReplaysContract(t *testing.T) {
 	t.Setenv("COCKROACH_BIN", "/definitely/not/a/real/path/cockroach")
 	t.Setenv("PATH", "")
 	t.Setenv("CRDB_TEST_DSN", "")
+	t.Setenv("CRDB_INTEGRATION_OPTIONAL", "")
 	resetSharedState()
 
-	rec := &recordingTB{TB: t}
-	c := Shared(rec)
-	require.Nil(t, c)
-	require.True(t, rec.skipped, "expected Shared to call Skipf when binary is absent")
-	require.Contains(t, rec.skipMsg, "binary not found")
+	first := &recordingTB{TB: t}
+	require.Nil(t, Shared(first))
+	require.True(t, first.failed, "first call must Fatal when opt-in is unset")
+
+	second := &recordingTB{TB: t}
+	require.Nil(t, Shared(second))
+	require.True(t, second.failed, "cached failure must Fatal again on the second call")
+
+	t.Setenv("CRDB_INTEGRATION_OPTIONAL", "1")
+	third := &recordingTB{TB: t}
+	require.Nil(t, Shared(third))
+	require.True(t, third.skipped, "cached failure must honor a now-set opt-in on later calls")
+	require.False(t, third.failed, "cached failure must not Fatal once opt-in is set")
+}
+
+// TestSharedCachedGenericFailureAlwaysFatals pins the second
+// regression-prevention claim: a generic Start failure (anything
+// other than ErrBinaryNotFound) cached on the first call must always
+// Fatal on subsequent calls — never Skip — even when
+// CRDB_INTEGRATION_OPTIONAL=1 is set. The CI escape hatch is for
+// missing-binary cases only; a real cluster-startup bug would
+// otherwise silently skip on every test after the first.
+func TestSharedCachedGenericFailureAlwaysFatals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary harness uses /bin/sh; not portable to Windows")
+	}
+	fake := writeShellBinary(t, "exit 0")
+	t.Setenv("COCKROACH_BIN", fake)
+	t.Setenv("CRDB_TEST_DSN", "")
+	t.Setenv("CRDB_INTEGRATION_OPTIONAL", "1")
+	resetSharedState()
+
+	first := &recordingTB{TB: t}
+	require.Nil(t, Shared(first))
+	require.True(t, first.failed, "first call must Fatal on generic Start failure")
+	require.Contains(t, first.failMsg, "failed to start cluster")
+
+	second := &recordingTB{TB: t}
+	require.Nil(t, Shared(second))
+	require.True(t, second.failed,
+		"cached generic failure must Fatal even with opt-in set; otherwise CI silently skips real bugs")
+	require.False(t, second.skipped)
+	require.Contains(t, second.failMsg, "failed to start cluster")
 }
 
 // TestSharedHonorsCRDBTestDSN pins the documented escape hatch: when
@@ -108,6 +227,7 @@ func TestSharedHonorsCRDBTestDSN(t *testing.T) {
 	c := Shared(rec)
 	require.NotNil(t, c)
 	require.False(t, rec.skipped, "Shared must not Skip when CRDB_TEST_DSN is set")
+	require.False(t, rec.failed, "Shared must not Fatal when CRDB_TEST_DSN is set")
 	require.Equal(t, dsn, c.DSN)
 	require.Empty(t, c.Logs(), "bypass cluster has no subprocess to capture from")
 	require.NoError(t, c.Stop(), "Stop on a CRDB_TEST_DSN cluster must be a no-op")
@@ -174,18 +294,31 @@ func resetSharedState() {
 	sharedStarted = false
 }
 
-// recordingTB wraps a testing.TB and intercepts Skipf so a unit test
-// can assert on the skip outcome without actually skipping itself.
-// All other testing.TB methods delegate to the embedded value.
+// recordingTB wraps a testing.TB and intercepts Skipf, Fatalf, and
+// Helper so a unit test can assert on Shared's outcome without
+// actually skipping or failing itself. Skipf/Fatalf record the
+// message and return instead of invoking runtime.Goexit, so the
+// caller can keep inspecting the recorder after Shared returns nil
+// (production callers never observe that nil — the standard
+// *testing.T halts before the return). Helper is a no-op so the
+// embedded TB does not record this wrapper's call frame as the
+// helper boundary. Everything else delegates to the embedded value.
 type recordingTB struct {
 	testing.TB
 	skipped bool
 	skipMsg string
+	failed  bool
+	failMsg string
 }
 
 func (r *recordingTB) Skipf(format string, args ...any) {
 	r.skipped = true
 	r.skipMsg = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingTB) Fatalf(format string, args ...any) {
+	r.failed = true
+	r.failMsg = fmt.Sprintf(format, args...)
 }
 
 func (r *recordingTB) Helper() {}


### PR DESCRIPTION
Shared previously called t.Skipf whenever neither COCKROACH_BIN, CRDB_TEST_DSN, nor a cockroach binary on PATH could be resolved. Because go test reports `ok` for packages whose tests all skip and the `--- SKIP` line is invisible without `-v`, that default produced false confidence — most recently when #137's fix appeared verified end-to-end while every integration test had silently skipped.

Invert the default: missing-binary now routes through a new `reportMissingBinary` helper that calls `t.Fatalf` with a message naming every recovery knob (install cockroach on $PATH, COCKROACH_BIN, CRDB_TEST_DSN, CRDB_INTEGRATION_OPTIONAL=1). The opt-in env var is parsed by `strconv.ParseBool` so a falsy or unparseable value Fatals just like the unset case — a typo can't accidentally enable skipping.

A separate `reportCachedErr` handles subsequent Shared calls in the same test binary: ErrBinaryNotFound replays through `reportMissingBinary` so a later opt-in still skips, but a generic Start failure (port collision, premature exit, etc.) always Fatals. Routing every cached error through the missing-binary helper would let `CRDB_INTEGRATION_OPTIONAL=1` silently skip real startup failures on every test after the first — exactly the failure mode this commit is trying to eliminate.

`CRDB_INTEGRATION_OPTIONAL` is the single escape hatch and is intentionally not advertised on developer-facing surfaces (Makefile help, CLAUDE.md). It is set on the GitHub Actions job, which does not install cockroach, so that environment's existing behavior is preserved without needing per-developer configuration.

Resolves: #138