### PR TITLE
tls: surface TLS-DSN support in CLI flags and MCP tool schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,53 @@ explain-ddl` is the planned schema-change-impact tool, but it cannot
 run today — its per-mode rules are still follow-up work and every
 input is rejected.
 
+### Connecting to a secure cluster
+
+`crdb-sql` talks to TLS-only clusters with no extra setup: pgx accepts
+the standard libpq URI parameters (`sslmode`, `sslrootcert`, `sslcert`,
+`sslkey`) inside the DSN, and the same four are also exposed as
+top-level `--ssl*` flags for the CLI and as input fields on every
+connected MCP tool.
+
+Password-based auth with a CA cert (typical for a managed cluster):
+
+```bash
+crdb-sql ping --dsn "postgresql://root@host:26257/defaultdb?sslmode=verify-full&sslrootcert=/path/ca.crt"
+```
+
+Client-certificate auth (typical for a self-managed cluster's `root`
+user):
+
+```bash
+crdb-sql ping --dsn "postgresql://root@host:26257/defaultdb?sslmode=verify-full&sslrootcert=/path/ca.crt&sslcert=/path/client.root.crt&sslkey=/path/client.root.key"
+```
+
+Equivalent invocation using the per-knob flags (the flag values are
+merged into the DSN before connect, and the merge fails loudly if the
+same parameter is supplied on both sides):
+
+```bash
+crdb-sql ping \
+  --dsn "postgresql://root@host:26257/defaultdb" \
+  --sslmode verify-full \
+  --sslrootcert /path/ca.crt \
+  --sslcert /path/client.root.crt \
+  --sslkey /path/client.root.key
+```
+
+The same fields appear on the MCP tool input schemas, so an agent
+configuring `explain_sql` (or any other connected tool) can supply
+TLS knobs without knowing the libpq URI form:
+
+```json
+{
+  "sql": "SELECT 1",
+  "dsn": "postgresql://root@host:26257/defaultdb",
+  "sslmode": "verify-full",
+  "sslrootcert": "/path/ca.crt"
+}
+```
+
 ## Use as an MCP server
 
 `crdb-sql mcp` runs the binary as a Model Context Protocol server over

--- a/cmd/ping_tls_integration_test.go
+++ b/cmd/ping_tls_integration_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// TLS-mode integration tests for `crdb-sql ping`. These tests cannot
+// reuse the shared cluster fixture (it is insecure), so they spin up
+// their own short-lived secure demo cluster via cockroachtest.WithSecure.
+//
+// Two sub-tests:
+//
+//   - the URI-only path: hand the secure DSN (with sslmode + cert
+//     paths embedded) straight to ping and confirm it connects.
+//   - the flag-merge path: strip the CA path out of the URI, pass it
+//     back through --sslrootcert, and confirm ping still connects.
+//     This is the canary for cmd/root.go's MergeTLSParams wiring; if
+//     a regression dropped the flag layer, the second sub-test would
+//     fail with a TLS handshake error while the first still passed.
+//
+// Note on auth flavor: `cockroach demo` uses password auth, so its
+// DSN does not carry sslcert/sslkey — the merge canary uses
+// sslrootcert (which the demo does publish) instead. The merge logic
+// is field-agnostic, so this still pins all four flag wires.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/testutil/cockroachtest"
+)
+
+func TestIntegrationPingTLS(t *testing.T) {
+	cluster, err := cockroachtest.Start(context.Background(), cockroachtest.WithSecure())
+	if errors.Is(err, cockroachtest.ErrBinaryNotFound) {
+		// Mirror the harness's Shared() policy: a missing binary is
+		// Fatal by default; skip only when CRDB_INTEGRATION_OPTIONAL
+		// is set to a truthy value (the CI opt-out). The harness
+		// helper is unexported, so the policy is reimplemented here.
+		raw := os.Getenv("CRDB_INTEGRATION_OPTIONAL")
+		optIn, perr := strconv.ParseBool(raw)
+		if raw == "" || perr != nil || !optIn {
+			t.Fatalf("cockroachtest: %v; install cockroach on $PATH, set COCKROACH_BIN, or export CRDB_INTEGRATION_OPTIONAL=1 to skip", err)
+		}
+		t.Skipf("cockroachtest: %v; CRDB_INTEGRATION_OPTIONAL=%q set, skipping", err, raw)
+	}
+	if err != nil {
+		t.Fatalf("start secure cluster: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cluster.Stop(); err != nil {
+			t.Logf("teardown: %v", err)
+		}
+	})
+	t.Setenv("CRDB_DSN", "")
+
+	t.Run("dsn carries TLS params", func(t *testing.T) {
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs([]string{"ping", "--dsn", cluster.DSN})
+
+		require.NoError(t, root.Execute(),
+			"ping against secure demo cluster must connect via the demo-issued TLS DSN")
+		require.Contains(t, stdout.String(), "connection_status: connected")
+	})
+
+	t.Run("flags merge into dsn", func(t *testing.T) {
+		strippedDSN, sslrootcert := stripParam(t, cluster.DSN, "sslrootcert")
+		require.NotEmpty(t, sslrootcert, "demo cluster must publish sslrootcert in its DSN")
+
+		root := newRootCmd()
+		var stdout bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&bytes.Buffer{})
+		root.SetArgs([]string{
+			"ping",
+			"--dsn", strippedDSN,
+			"--sslrootcert", sslrootcert,
+		})
+
+		require.NoError(t, root.Execute(),
+			"ping must reconstruct a working TLS DSN from --sslrootcert; got DSN=%s", strippedDSN)
+		require.Contains(t, stdout.String(), "connection_status: connected")
+	})
+}
+
+// stripParam removes a single query parameter from dsn and returns
+// both the remaining DSN and the stripped value. Used to fabricate
+// the "user moved a TLS knob from URI to flag" scenario without
+// hardcoding cert paths the demo harness picks at random.
+func stripParam(t *testing.T, dsn, key string) (string, string) {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	q := u.Query()
+	val := q.Get(key)
+	q.Del(key)
+	u.RawQuery = q.Encode()
+	return u.String(), val
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spilchen/sql-ai-tools/internal/catalog"
 	"github.com/spilchen/sql-ai-tools/internal/config"
+	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/diag"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/schemawarn"
@@ -78,7 +79,12 @@ func newRootCmd() *cobra.Command {
 		Long: `crdb-sql exposes CockroachDB's parser, type system, and structured
 error infrastructure as a CLI and MCP server so that
 AI agents can validate, format, and reason about CockroachDB SQL without
-round-tripping through a live cluster.`,
+round-tripping through a live cluster.
+
+Secure clusters are supported transparently: TLS parameters can ride
+inside --dsn as libpq URI params (sslmode, sslrootcert, sslcert, sslkey)
+or be supplied via the matching --ssl* flags. See the README "Connecting
+to a secure cluster" section for examples.`,
 		// Both silences are deliberate: cobra should neither print the
 		// usage dump on a runtime error (noisy) nor print the error
 		// itself (we want a single source of truth). The Execute caller
@@ -105,6 +111,23 @@ round-tripping through a live cluster.`,
 				state.dsn = dsn
 			} else {
 				state.dsn = os.Getenv("CRDB_DSN")
+			}
+
+			tls, err := readTLSFlags(cmd)
+			if err != nil {
+				return err
+			}
+			if !tls.IsZero() {
+				// MergeTLSParams enforces the form policy (URI required)
+				// and the conflict policy (no silent overrides). Both
+				// are returned as plain errors so the caller surfaces
+				// them via the standard exit-1 path used for missing or
+				// malformed --dsn input.
+				merged, err := conn.MergeTLSParams(state.dsn, tls)
+				if err != nil {
+					return err
+				}
+				state.dsn = merged
 			}
 
 			cfgPath, err := cmd.Flags().GetString(configFlag)
@@ -134,11 +157,19 @@ round-tripping through a live cluster.`,
 	root.PersistentFlags().StringP(outputFlag, "o", string(output.FormatText),
 		`output format: "text" or "json"`)
 	root.PersistentFlags().String(dsnFlag, "",
-		"CockroachDB connection string (overrides CRDB_DSN env var)")
+		"CockroachDB connection string (overrides CRDB_DSN env var); TLS params can ride inside as libpq URI params (sslmode/sslrootcert/sslcert/sslkey) or via the --ssl* flags below")
 	root.PersistentFlags().String(configFlag, "",
 		"path to crdb-sql.yaml (default: auto-discover in CWD)")
 	root.PersistentFlags().String(targetVersionFlag, "",
 		"Target CockroachDB version (e.g. 25.4.0); reported in the response envelope")
+	root.PersistentFlags().String(sslModeFlag, "",
+		`TLS verification mode (e.g. "verify-full", "require"); merged into --dsn as ?sslmode=`)
+	root.PersistentFlags().String(sslRootCertFlag, "",
+		"path to the trusted CA certificate; merged into --dsn as ?sslrootcert=")
+	root.PersistentFlags().String(sslCertFlag, "",
+		"path to the client certificate (cert-based auth); merged into --dsn as ?sslcert=")
+	root.PersistentFlags().String(sslKeyFlag, "",
+		"path to the client private key (cert-based auth); merged into --dsn as ?sslkey=")
 	root.AddCommand(newVersionCmd(state))
 	root.AddCommand(newVersionsCmd(state))
 	root.AddCommand(newPingCmd(state))
@@ -165,7 +196,41 @@ const (
 	dsnFlag           = "dsn"
 	configFlag        = "config"
 	targetVersionFlag = "target-version"
+	sslModeFlag       = "sslmode"
+	sslRootCertFlag   = "sslrootcert"
+	sslCertFlag       = "sslcert"
+	sslKeyFlag        = "sslkey"
 )
+
+// readTLSFlags reads the four --ssl* persistent flags into a
+// conn.TLSParams. Any GetString failure is propagated unchanged so the
+// caller can surface it the same way it would surface an unknown
+// --output value (cobra returns these only when the flag is not
+// registered, which is a programming error).
+func readTLSFlags(cmd *cobra.Command) (conn.TLSParams, error) {
+	mode, err := cmd.Flags().GetString(sslModeFlag)
+	if err != nil {
+		return conn.TLSParams{}, err
+	}
+	rootCert, err := cmd.Flags().GetString(sslRootCertFlag)
+	if err != nil {
+		return conn.TLSParams{}, err
+	}
+	cert, err := cmd.Flags().GetString(sslCertFlag)
+	if err != nil {
+		return conn.TLSParams{}, err
+	}
+	key, err := cmd.Flags().GetString(sslKeyFlag)
+	if err != nil {
+		return conn.TLSParams{}, err
+	}
+	return conn.TLSParams{
+		SSLMode:     mode,
+		SSLRootCert: rootCert,
+		SSLCert:     cert,
+		SSLKey:      key,
+	}, nil
+}
 
 // loadConfig resolves the project YAML config. When path is non-empty,
 // the file at that path must exist and parse cleanly (explicit user

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRootTLSFlagsMergeIntoDSN drives the PersistentPreRunE merge by
+// invoking `ping` with an --ssl* flag plus a URI --dsn. The merge runs
+// before ping's RunE; we drive it through ping (rather than a fake
+// subcommand) so the test exercises the same wiring the user does.
+//
+// "Closed port" is the canary: if the merge silently dropped the
+// flag, ping would fail with a transport error against the URI's
+// real port. With the merge, it tries TLS against port 1 and fails
+// at the connect step — that's enough to confirm the merge happened
+// without needing a real cluster.
+func TestRootTLSFlagsMergeIntoDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"ping",
+		"--dsn", "postgres://root@127.0.0.1:1/defaultdb",
+		"--sslmode", "verify-full",
+		"--sslrootcert", "/nonexistent/ca.crt",
+	})
+
+	err := root.Execute()
+	// The connect attempt must fail (no cluster on port 1), but the
+	// failure must come from the ping path, not from PreRunE — the
+	// merge succeeded if we reach a connect-time error.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect to CockroachDB",
+		"merged DSN must reach the ping connect step; got %v", err)
+}
+
+// TestRootTLSFlagConflictFailsLoud pins the fail-loud contract: when
+// both --dsn and a --ssl* flag supply the same key, PreRunE returns
+// the conflict error rather than silently overriding either source.
+func TestRootTLSFlagConflictFailsLoud(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"ping",
+		"--dsn", "postgres://root@h:26257/db?sslmode=require",
+		"--sslmode", "verify-full",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sslmode")
+	require.Contains(t, err.Error(), "already present")
+}
+
+// TestRootTLSFlagRejectsKeywordDSN verifies the form policy is wired
+// through PreRunE: a TLS flag combined with a keyword/value --dsn
+// errors before any subcommand runs, so the user gets a clear "URI
+// required" message instead of a downstream pgx parse error.
+func TestRootTLSFlagRejectsKeywordDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"ping",
+		"--dsn", "host=h port=26257 user=root",
+		"--sslmode", "verify-full",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "URI DSN")
+}
+
+// TestRootTLSFlagsMergeWithEnvDSN pins that the merge sees the DSN
+// resolved from CRDB_DSN, not just from --dsn. The PreRunE order is
+// "--dsn beats env, then merge"; a regression that re-ordered the
+// merge before the env-var fallback would silently bypass the form
+// policy when only env was set.
+func TestRootTLSFlagsMergeWithEnvDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "postgres://root@127.0.0.1:1/defaultdb")
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"ping",
+		"--sslmode", "verify-full",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect to CockroachDB",
+		"merge must apply to the env-resolved DSN; got %v", err)
+}
+
+// TestRootTLSFlagsRejectMissingDSN pins the most likely first-time
+// user error: a --ssl* flag with no DSN (neither --dsn nor CRDB_DSN).
+// The merge must fail loudly with a clear "require a DSN" message
+// rather than fall through to a downstream "no connection string"
+// error from the subcommand.
+func TestRootTLSFlagsRejectMissingDSN(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"ping",
+		"--sslmode", "verify-full",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "require a DSN")
+}
+
+// TestRootTLSFlagsAbsentNoOp verifies the no-op path: when no --ssl*
+// flag is set, PreRunE leaves --dsn untouched. We assert this by
+// supplying a closed-port URI DSN with no merge inputs and confirming
+// the failure still comes from the ping connect step (rather than a
+// MergeTLSParams error).
+func TestRootTLSFlagsAbsentNoOp(t *testing.T) {
+	t.Setenv("CRDB_DSN", "")
+
+	root := newRootCmd()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{
+		"ping",
+		"--dsn", "postgres://root@127.0.0.1:1/defaultdb",
+	})
+
+	err := root.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connect to CockroachDB")
+}

--- a/internal/conn/tls.go
+++ b/internal/conn/tls.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// TLSParams holds the four libpq TLS knobs that callers may supply
+// through CLI flags or MCP tool inputs separately from the DSN. All
+// fields are optional; an empty TLSParams is a no-op when merged.
+//
+// The field names shadow libpq URI parameters of the same spelling
+// (sslmode / sslrootcert / sslcert / sslkey); pgx honors them via the
+// standard `?sslmode=...&sslrootcert=...` query syntax, so
+// MergeTLSParams' only job is to splice non-empty fields into the
+// DSN's query string and detect conflicts with values already present.
+type TLSParams struct {
+	SSLMode     string
+	SSLRootCert string
+	SSLCert     string
+	SSLKey      string
+}
+
+// IsZero reports whether p has no fields set. Provided so callers can
+// skip MergeTLSParams' parse step when no TLS knobs were supplied
+// without duplicating the field-by-field check.
+func (p TLSParams) IsZero() bool {
+	return p.SSLMode == "" && p.SSLRootCert == "" && p.SSLCert == "" && p.SSLKey == ""
+}
+
+// MergeTLSParams returns dsn with non-empty TLSParams fields applied
+// as URI query parameters. Returns dsn unchanged when p is zero.
+//
+// Pairing policy: SSLCert and SSLKey must be supplied together. A
+// half-pair (only one of the two) is a libpq misconfiguration that
+// otherwise surfaces as an opaque pgx connect error several frames
+// later, so the merge fails up front instead.
+//
+// Conflict policy: it is an error for the same parameter to be
+// supplied via both the DSN's query string and TLSParams when the
+// DSN's value is non-empty, so a typo cannot silently win. An empty
+// DSN-side value (e.g. `?sslmode=`) is treated as absent.
+//
+// Form policy: when any TLS field is set, the DSN must be in URI form
+// (`postgres://` or `postgresql://`). pgx also accepts the keyword/value
+// form ("host=... user=..."), but splicing flag-sourced URI params into
+// it would require non-trivial reconstruction; the keyword form is
+// rejected with a clear error so the user can switch forms or move the
+// TLS knobs into the DSN itself.
+func MergeTLSParams(dsn string, p TLSParams) (string, error) {
+	if p.IsZero() {
+		return dsn, nil
+	}
+	if (p.SSLCert == "") != (p.SSLKey == "") {
+		return "", errors.New("sslcert and sslkey must be supplied together")
+	}
+	trimmed := strings.TrimSpace(dsn)
+	if trimmed == "" {
+		return "", errors.New("TLS parameters require a DSN")
+	}
+	if !strings.HasPrefix(trimmed, "postgres://") && !strings.HasPrefix(trimmed, "postgresql://") {
+		return "", errors.New("TLS parameters require a postgres:// URI DSN; the keyword/value form is not supported")
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse dsn: %w", err)
+	}
+	q := u.Query()
+
+	// The slice (rather than a map) makes the conflict-error order
+	// deterministic, which keeps tests stable and the diagnostic
+	// reproducible across Go versions.
+	fields := []struct {
+		name string
+		val  string
+	}{
+		{"sslmode", p.SSLMode},
+		{"sslrootcert", p.SSLRootCert},
+		{"sslcert", p.SSLCert},
+		{"sslkey", p.SSLKey},
+	}
+	for _, f := range fields {
+		if f.val == "" {
+			continue
+		}
+		if existing := q.Get(f.name); existing != "" {
+			return "", fmt.Errorf(
+				"TLS parameter %q already present in DSN (=%q); remove the flag or the DSN param",
+				f.name, existing)
+		}
+		q.Set(f.name, f.val)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/internal/conn/tls_test.go
+++ b/internal/conn/tls_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package conn
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTLSParamsIsZero pins the field-by-field zero check that callers
+// use to short-circuit MergeTLSParams. A regression that drops one of
+// the four fields would let a stray flag silently bypass conflict
+// detection on subsequent calls.
+func TestTLSParamsIsZero(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          TLSParams
+		expectedIsZero bool
+	}{
+		{name: "fully empty", input: TLSParams{}, expectedIsZero: true},
+		{name: "sslmode set", input: TLSParams{SSLMode: "verify-full"}},
+		{name: "sslrootcert set", input: TLSParams{SSLRootCert: "/p/ca.crt"}},
+		{name: "sslcert set", input: TLSParams{SSLCert: "/p/client.crt"}},
+		{name: "sslkey set", input: TLSParams{SSLKey: "/p/client.key"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedIsZero, tc.input.IsZero())
+		})
+	}
+}
+
+// TestMergeTLSParamsNoOp verifies the fast path: when no TLS knobs
+// are supplied, the DSN flows through verbatim — even pathological
+// inputs that the URI parser would reject. Pre-existing TLS params in
+// the DSN must be left alone (they belong to the user, not to the
+// merger).
+func TestMergeTLSParamsNoOp(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "URI form", input: "postgres://root@h:26257/db"},
+		{name: "URI with existing TLS params", input: "postgres://root@h:26257/db?sslmode=verify-full&sslrootcert=/p/ca.crt"},
+		{name: "keyword/value form", input: "host=h port=26257 user=root sslmode=require"},
+		{name: "empty", input: ""},
+		{name: "garbage", input: "not a dsn at all"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := MergeTLSParams(tc.input, TLSParams{})
+			require.NoError(t, err)
+			require.Equal(t, tc.input, out)
+		})
+	}
+}
+
+// TestMergeTLSParamsAppliesFields verifies the round-trip: each
+// non-empty TLSParams field appears as a query parameter on the
+// returned DSN with the supplied value. Asserting through url.Parse
+// (rather than substring matching) guards against a regression that
+// double-encodes a value or appends to RawQuery without re-encoding.
+func TestMergeTLSParamsAppliesFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		dsn            string
+		params         TLSParams
+		expectedParams map[string]string
+	}{
+		{
+			name: "all four on bare URI",
+			dsn:  "postgres://root@h:26257/db",
+			params: TLSParams{
+				SSLMode:     "verify-full",
+				SSLRootCert: "/p/ca.crt",
+				SSLCert:     "/p/client.crt",
+				SSLKey:      "/p/client.key",
+			},
+			expectedParams: map[string]string{
+				"sslmode":     "verify-full",
+				"sslrootcert": "/p/ca.crt",
+				"sslcert":     "/p/client.crt",
+				"sslkey":      "/p/client.key",
+			},
+		},
+		{
+			name:           "single field only",
+			dsn:            "postgres://root@h:26257/db",
+			params:         TLSParams{SSLMode: "require"},
+			expectedParams: map[string]string{"sslmode": "require"},
+		},
+		{
+			name:   "preserves non-TLS query params",
+			dsn:    "postgres://root@h:26257/db?application_name=crdb-sql",
+			params: TLSParams{SSLMode: "verify-full"},
+			expectedParams: map[string]string{
+				"application_name": "crdb-sql",
+				"sslmode":          "verify-full",
+			},
+		},
+		{
+			name:           "value with spaces is URL-encoded",
+			dsn:            "postgres://root@h:26257/db",
+			params:         TLSParams{SSLRootCert: "/path with spaces/ca.crt"},
+			expectedParams: map[string]string{"sslrootcert": "/path with spaces/ca.crt"},
+		},
+		{
+			name:           "postgresql:// scheme accepted",
+			dsn:            "postgresql://root@h:26257/db",
+			params:         TLSParams{SSLMode: "require"},
+			expectedParams: map[string]string{"sslmode": "require"},
+		},
+		{
+			name:           "DSN-side empty value is overwritten",
+			dsn:            "postgres://root@h:26257/db?sslmode=",
+			params:         TLSParams{SSLMode: "verify-full"},
+			expectedParams: map[string]string{"sslmode": "verify-full"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := MergeTLSParams(tc.dsn, tc.params)
+			require.NoError(t, err)
+
+			u, err := url.Parse(out)
+			require.NoError(t, err)
+			q := u.Query()
+			for k, want := range tc.expectedParams {
+				require.Equal(t, want, q.Get(k), "param %q", k)
+			}
+		})
+	}
+}
+
+// TestMergeTLSParamsConflict pins the fail-loud contract: when both
+// the DSN and TLSParams supply a non-empty value for the same key,
+// the merge errors rather than silently picking one. The error names
+// the parameter so the user can fix it without guesswork.
+func TestMergeTLSParamsConflict(t *testing.T) {
+	tests := []struct {
+		name           string
+		dsn            string
+		params         TLSParams
+		expectedErrSub string
+	}{
+		{
+			name:           "sslmode conflict",
+			dsn:            "postgres://h/db?sslmode=require",
+			params:         TLSParams{SSLMode: "verify-full"},
+			expectedErrSub: `"sslmode"`,
+		},
+		{
+			name:           "sslrootcert conflict reports its own name",
+			dsn:            "postgres://h/db?sslrootcert=/a.crt",
+			params:         TLSParams{SSLRootCert: "/b.crt"},
+			expectedErrSub: `"sslrootcert"`,
+		},
+		{
+			name: "first conflicting field is reported",
+			dsn:  "postgres://h/db?sslmode=require&sslcert=/a.crt&sslkey=/a.key",
+			params: TLSParams{
+				SSLMode: "verify-full",
+				SSLCert: "/b.crt",
+				SSLKey:  "/b.key",
+			},
+			// The fields slice in MergeTLSParams orders sslmode before
+			// sslcert; pinning that order keeps the diagnostic
+			// reproducible across Go versions. SSLKey is supplied
+			// alongside SSLCert to satisfy the pairing rule so this
+			// case reaches the conflict-detection step.
+			expectedErrSub: `"sslmode"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := MergeTLSParams(tc.dsn, tc.params)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErrSub)
+		})
+	}
+}
+
+// TestMergeTLSParamsRejectsNonURIDSN pins the form policy: keyword/
+// value DSNs and empty DSNs are rejected when any TLS knob is
+// supplied, because splicing flag-sourced URI params into them would
+// be ambiguous. The no-op path (TLSParams{}) keeps these inputs
+// flowing through unchanged — that contract is covered separately by
+// TestMergeTLSParamsNoOp.
+func TestMergeTLSParamsRejectsNonURIDSN(t *testing.T) {
+	tests := []struct {
+		name           string
+		dsn            string
+		expectedErrSub string
+	}{
+		{
+			name:           "keyword/value form",
+			dsn:            "host=h port=26257 user=root",
+			expectedErrSub: "URI DSN",
+		},
+		{
+			name:           "empty dsn",
+			dsn:            "",
+			expectedErrSub: "require a DSN",
+		},
+		{
+			name:           "whitespace-only dsn",
+			dsn:            "   ",
+			expectedErrSub: "require a DSN",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := MergeTLSParams(tc.dsn, TLSParams{SSLMode: "verify-full"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErrSub)
+		})
+	}
+}
+
+// TestMergeTLSParamsRejectsHalfCertPair pins the pairing rule:
+// SSLCert and SSLKey must travel together. A half-pair is a libpq
+// misconfiguration whose pgx error message is unhelpfully far from
+// the cause, so the merge rejects it at the boundary.
+func TestMergeTLSParamsRejectsHalfCertPair(t *testing.T) {
+	tests := []struct {
+		name   string
+		params TLSParams
+	}{
+		{name: "sslcert without sslkey", params: TLSParams{SSLCert: "/p/client.crt"}},
+		{name: "sslkey without sslcert", params: TLSParams{SSLKey: "/p/client.key"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := MergeTLSParams("postgres://h/db", tc.params)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "sslcert and sslkey")
+		})
+	}
+}
+
+// TestMergeTLSParamsMalformedURI exercises the parse-error path. A
+// DSN whose scheme passes the prefix gate but whose body is malformed
+// must surface a wrapped parser error rather than silently producing
+// a half-merged DSN.
+func TestMergeTLSParamsMalformedURI(t *testing.T) {
+	// A control character in the host triggers url.Parse to fail; the
+	// scheme check still passes so the parse step is reached.
+	_, err := MergeTLSParams("postgres://h\x7fost/db", TLSParams{SSLMode: "require"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse dsn")
+}

--- a/internal/mcp/tools/catalog.go
+++ b/internal/mcp/tools/catalog.go
@@ -85,11 +85,15 @@ func ListTablesTool() mcp.Tool {
 			mcp.Items(schemasItemSchema()),
 		),
 		mcp.WithString(dsnParam,
-			mcp.Description("CockroachDB connection string (postgres:// URI). Mutually exclusive with schemas; when supplied, list-tables falls back to live information_schema introspection in the DSN's database."),
+			mcp.Description("CockroachDB connection string (postgres:// URI). Mutually exclusive with schemas; when supplied, list-tables falls back to live information_schema introspection in the DSN's database. For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below."),
 		),
 		mcp.WithBoolean(includeSystemParam,
 			mcp.Description("On the live (dsn) path, broaden the listing to every relation visible in information_schema (system schemas, views, sequences). Ignored on the schemas path. Default false."),
 		),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription+" Ignored on the schemas path.")),
 	)
 }
 
@@ -110,8 +114,12 @@ func DescribeTableTool() mcp.Tool {
 			mcp.Items(schemasItemSchema()),
 		),
 		mcp.WithString(dsnParam,
-			mcp.Description("CockroachDB connection string (postgres:// URI). Mutually exclusive with schemas; when supplied, describe_table runs SHOW CREATE TABLE against the cluster."),
+			mcp.Description("CockroachDB connection string (postgres:// URI). Mutually exclusive with schemas; when supplied, describe_table runs SHOW CREATE TABLE against the cluster. For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below."),
 		),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription+" Ignored on the schemas path.")),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription+" Ignored on the schemas path.")),
 	)
 }
 
@@ -137,7 +145,7 @@ func ListTablesHandler(parserVersion string) server.ToolHandlerFunc {
 			if toolErr != nil {
 				return toolErr, nil
 			}
-			return listTablesLive(ctx, parserVersion, dsn, includeSystem)
+			return listTablesLive(ctx, parserVersion, req, dsn, includeSystem)
 		}
 		return listTablesFromSchemas(parserVersion, sources)
 	}
@@ -177,10 +185,15 @@ func listTablesFromSchemas(parserVersion string, sources []catalog.SchemaSource)
 // connected only after a successful round-trip; pre-flight errors
 // keep the disconnected status so the envelope reflects what
 // happened.
-func listTablesLive(ctx context.Context, parserVersion, dsn string, includeSystem bool) (*mcp.CallToolResult, error) {
+func listTablesLive(ctx context.Context, parserVersion string, req mcp.CallToolRequest, dsn string, includeSystem bool) (*mcp.CallToolResult, error) {
 	env := connectedEnvelope(parserVersion, "" /* targetVersion */)
 
-	mgr := conn.NewManager(dsn)
+	mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	mgr := conn.NewManager(mergedDSN)
 	defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 	tables, err := mgr.ListTablesFromCluster(ctx, conn.ListOptions{IncludeSystem: includeSystem})
@@ -223,7 +236,7 @@ func DescribeTableHandler(parserVersion string) server.ToolHandlerFunc {
 		}
 
 		if dsn != "" {
-			return describeTableLive(ctx, parserVersion, dsn, tableName)
+			return describeTableLive(ctx, parserVersion, req, dsn, tableName)
 		}
 		return describeTableFromSchemas(parserVersion, sources, tableName)
 	}
@@ -253,10 +266,15 @@ func describeTableFromSchemas(parserVersion string, sources []catalog.SchemaSour
 	return envelopeResult(env)
 }
 
-func describeTableLive(ctx context.Context, parserVersion, dsn, tableName string) (*mcp.CallToolResult, error) {
+func describeTableLive(ctx context.Context, parserVersion string, req mcp.CallToolRequest, dsn, tableName string) (*mcp.CallToolResult, error) {
 	env := connectedEnvelope(parserVersion, "" /* targetVersion */)
 
-	mgr := conn.NewManager(dsn)
+	mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	mgr := conn.NewManager(mergedDSN)
 	defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 	tbl, err := mgr.DescribeTableFromCluster(ctx, tableName)

--- a/internal/mcp/tools/execute.go
+++ b/internal/mcp/tools/execute.go
@@ -36,11 +36,15 @@ func ExecuteSQLTool() mcp.Tool {
 		ExecuteSQLToolName,
 		mcp.WithDescription(`Execute SQL against a CockroachDB cluster with safety guardrails. Returns rows, columns, and the command tag in a structured envelope. The mode parameter selects the safety policy: read_only (default) admits non-mutating statements only; safe_write also admits INSERT/UPDATE/DELETE; full_access admits any parsed statement. For read_only SELECTs without a LIMIT, max_rows is injected so the cluster does not stream an unbounded result.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement to execute")),
-		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
 		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
 		mcp.WithNumber(MaxRowsParamName, mcp.Description(MaxRowsParamDescription)),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription)),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription)),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription)),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription)),
 	)
 }
 
@@ -114,7 +118,12 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 			}
 		}
 
-		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.Execute(ctx, rewritten, conn.ExecuteOptions{

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -28,10 +28,14 @@ func ExplainSQLTool() mcp.Tool {
 		ExplainSQLToolName,
 		mcp.WithDescription(`Run EXPLAIN against a CockroachDB cluster and return the plan as structured JSON. The wrapped statement is not executed (this is plain EXPLAIN, not EXPLAIN ANALYZE). Returns the operator tree, header (distribution/vectorized), and the raw tabular rows.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL DML statement to explain")),
-		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
 		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription)),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription)),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription)),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription)),
 	)
 }
 
@@ -87,7 +91,12 @@ func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 			return envelopeResult(env)
 		}
 
-		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.Explain(ctx, sql)

--- a/internal/mcp/tools/explain_schema_change.go
+++ b/internal/mcp/tools/explain_schema_change.go
@@ -34,10 +34,14 @@ func ExplainSchemaChangeTool() mcp.Tool {
 		ExplainSchemaChangeToolName,
 		mcp.WithDescription(`Run EXPLAIN (DDL, SHAPE) against a CockroachDB cluster and return the declarative schema-changer plan as structured JSON. The wrapped DDL is not executed — the schema changer only compiles a plan. Returns the operations list (with backfill / merge / validate steps), the canonicalized statement, and the raw text the cluster returned.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("DDL statement to plan (e.g. ALTER TABLE ... ADD COLUMN ...)")),
-		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
 		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription)),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription)),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription)),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription)),
 	)
 }
 
@@ -87,7 +91,12 @@ func ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion string) serv
 			return envelopeResult(env)
 		}
 
-		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.ExplainDDL(ctx, sql)

--- a/internal/mcp/tools/simulate.go
+++ b/internal/mcp/tools/simulate.go
@@ -32,10 +32,14 @@ func SimulateSQLTool() mcp.Tool {
 		SimulateSQLToolName,
 		mcp.WithDescription(`Simulate one or more SQL statements without applying them. Each parsed statement is dispatched to a non-executing EXPLAIN flavor: SELECT runs through EXPLAIN ANALYZE (real runtime stats; reads have no side effects), INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN (planner estimates only — the write is never applied), and DDL runs through EXPLAIN (DDL, SHAPE) plus a SHOW STATISTICS row-count annotation per affected table. Multi-statement input returns one entry per statement in parse order.`),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement(s) to simulate. Multi-statement input is split per ';' and each statement is dispatched independently.")),
-		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI)")),
+		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithString(ModeParamName, mcp.Description(ModeParamDescription)),
 		mcp.WithNumber(StatementTimeoutParamName, mcp.Description(StatementTimeoutParamDescription)),
+		mcp.WithString(SSLModeParamName, mcp.Description(SSLModeParamDescription)),
+		mcp.WithString(SSLRootCertParamName, mcp.Description(SSLRootCertParamDescription)),
+		mcp.WithString(SSLCertParamName, mcp.Description(SSLCertParamDescription)),
+		mcp.WithString(SSLKeyParamName, mcp.Description(SSLKeyParamDescription)),
 	)
 }
 
@@ -92,7 +96,12 @@ func SimulateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 			return envelopeResult(env)
 		}
 
-		mgr := conn.NewManager(dsn, conn.WithStatementTimeout(timeout))
+		mergedDSN, toolErr := mergeDSNWithTLS(req, &env, dsn)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+
+		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
 		result, err := mgr.Simulate(ctx, sql)

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -93,6 +93,33 @@ const StatementTimeoutParamName = "statement_timeout_ms"
 // applies.
 const StatementTimeoutParamDescription = "Optional statement_timeout (milliseconds) applied inside the cluster-side transaction wrapper. Default 30000 (30s). Non-positive values fall back to the default."
 
+// SSLModeParamName / SSLRootCertParamName / SSLCertParamName /
+// SSLKeyParamName are the optional MCP tool parameter names that let
+// a client supply libpq TLS knobs alongside the dsn. They are merged
+// into the dsn via conn.MergeTLSParams, which fails loudly if the
+// dsn already carries a non-empty value for the same key. Names match
+// libpq spelling so an agent that already knows the URI form can
+// reach for them by the same identifier.
+const (
+	SSLModeParamName     = "sslmode"
+	SSLRootCertParamName = "sslrootcert"
+	SSLCertParamName     = "sslcert"
+	SSLKeyParamName      = "sslkey"
+)
+
+// SSL*ParamDescription strings document each TLS knob in the wire
+// schema. Per-field rather than a single shared blurb because the
+// agent picks them individually; a generic description would not tell
+// it which field controls verification depth vs. CA path vs. client
+// auth. The conflict policy is named in each one so a caller reading
+// just one description still sees the failure mode.
+const (
+	SSLModeParamDescription     = `Optional libpq TLS verification mode (e.g. "verify-full", "require"). Merged into dsn as ?sslmode=. Errors if dsn already supplies a non-empty sslmode.`
+	SSLRootCertParamDescription = "Optional path to the trusted CA certificate. Merged into dsn as ?sslrootcert=. Errors if dsn already supplies a non-empty sslrootcert."
+	SSLCertParamDescription     = "Optional path to the client certificate (cert-based auth). Merged into dsn as ?sslcert=. Errors if dsn already supplies a non-empty sslcert."
+	SSLKeyParamDescription      = "Optional path to the client private key (cert-based auth). Merged into dsn as ?sslkey=. Errors if dsn already supplies a non-empty sslkey."
+)
+
 // extractRequiredString validates and returns a required string
 // parameter from an MCP tool request. Leading and trailing whitespace
 // is trimmed so all handlers behave consistently. On success, the
@@ -325,4 +352,96 @@ func envelopeResult(env output.Envelope) (*mcp.CallToolResult, error) {
 		return mcp.NewToolResultError(fmt.Sprintf("encode result: %v", err)), nil
 	}
 	return mcp.NewToolResultText(string(body)), nil
+}
+
+// resolveTLSParams reads the four optional sslmode/sslrootcert/sslcert/
+// sslkey arguments from req and returns a conn.TLSParams. Each field
+// is independently optional; absence yields an empty string, and any
+// non-string value is a tool-level error (no reasonable interpretation).
+//
+// On success the returned *mcp.CallToolResult is nil. On a malformed
+// argument it is a pre-built tool error so the caller can return
+// immediately rather than producing a misleading envelope.
+func resolveTLSParams(req mcp.CallToolRequest) (conn.TLSParams, *mcp.CallToolResult) {
+	mode, toolErr := tlsStringParam(req, SSLModeParamName)
+	if toolErr != nil {
+		return conn.TLSParams{}, toolErr
+	}
+	rootCert, toolErr := tlsStringParam(req, SSLRootCertParamName)
+	if toolErr != nil {
+		return conn.TLSParams{}, toolErr
+	}
+	cert, toolErr := tlsStringParam(req, SSLCertParamName)
+	if toolErr != nil {
+		return conn.TLSParams{}, toolErr
+	}
+	key, toolErr := tlsStringParam(req, SSLKeyParamName)
+	if toolErr != nil {
+		return conn.TLSParams{}, toolErr
+	}
+	return conn.TLSParams{
+		SSLMode:     mode,
+		SSLRootCert: rootCert,
+		SSLCert:     cert,
+		SSLKey:      key,
+	}, nil
+}
+
+// tlsStringParam is the per-field reader behind resolveTLSParams. It
+// is a private sibling of catalog.go's extractOptionalString; kept
+// separate so the absent-vs-empty contract stays colocated with the
+// TLS-merge code that depends on it (an empty value here flows through
+// IsZero and short-circuits the merge, which is contract-relevant).
+func tlsStringParam(req mcp.CallToolRequest, name string) (string, *mcp.CallToolResult) {
+	raw, exists := req.GetArguments()[name]
+	if !exists || raw == nil {
+		return "", nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", mcp.NewToolResultError(fmt.Sprintf("%s parameter must be a string, got %T", name, raw))
+	}
+	return strings.TrimSpace(s), nil
+}
+
+// mergeDSNWithTLS is the shared connect-prep step for Tier 3 tools.
+// It reads the four optional TLS params and folds them into dsn via
+// conn.MergeTLSParams. Two failure modes, both surfaced through the
+// returned *mcp.CallToolResult:
+//
+//   - Param-shape errors (non-string TLS field) come back as
+//     mcp.NewToolResultError because the request is malformed at the
+//     schema layer; the tool itself never ran.
+//
+//   - Merge errors (DSN-side conflict, non-URI form) are appended to
+//     env.Errors as a tls_param_error and the envelope is returned as
+//     a successful tool result. This preserves any warnings already
+//     accumulated on env (target_version mismatch, etc.); routing the
+//     merge error through mcp.NewToolResultError would discard them,
+//     because that constructor builds a fresh result that never
+//     references the envelope.
+//
+// On success the merged DSN is returned and *mcp.CallToolResult is
+// nil. On either failure the caller returns the result verbatim.
+func mergeDSNWithTLS(req mcp.CallToolRequest, env *output.Envelope, dsn string) (string, *mcp.CallToolResult) {
+	tls, toolErr := resolveTLSParams(req)
+	if toolErr != nil {
+		return "", toolErr
+	}
+	merged, err := conn.MergeTLSParams(dsn, tls)
+	if err != nil {
+		env.Errors = append(env.Errors, output.Error{
+			Code:     "tls_param_error",
+			Severity: output.SeverityError,
+			Message:  err.Error(),
+			Category: "connect",
+		})
+		// envelopeResult only errs on json.Marshal of output.Envelope,
+		// which is statically marshalable — the error return is unreachable
+		// today and a future field that breaks marshalling would surface
+		// in every Tier 3 tool's success path long before reaching here.
+		envResult, _ := envelopeResult(*env)
+		return "", envResult
+	}
+	return merged, nil
 }

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/builtinstubs"
+	"github.com/spilchen/sql-ai-tools/internal/conn"
 	"github.com/spilchen/sql-ai-tools/internal/output"
 	"github.com/spilchen/sql-ai-tools/internal/risk"
 	"github.com/spilchen/sql-ai-tools/internal/sqlparse"
@@ -1544,4 +1545,142 @@ func TestDetectRiskyQueryHandler_VersionWarning(t *testing.T) {
 			require.Equal(t, tc.targetVersion, featWarn.Context["target"])
 		})
 	}
+}
+
+// TestResolveTLSParams pins the absent-vs-set contract for the four
+// optional TLS arguments. Absent / nil yields an empty TLSParams;
+// non-string values are rejected as tool errors so a caller cannot
+// silently bypass the merge by sending a number.
+func TestResolveTLSParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]any
+		expectedParams conn.TLSParams
+		expectedErr    bool
+	}{
+		{
+			name:           "all absent",
+			args:           map[string]any{},
+			expectedParams: conn.TLSParams{},
+		},
+		{
+			name: "all four populated",
+			args: map[string]any{
+				"sslmode":     "verify-full",
+				"sslrootcert": "/p/ca.crt",
+				"sslcert":     "/p/client.crt",
+				"sslkey":      "/p/client.key",
+			},
+			expectedParams: conn.TLSParams{
+				SSLMode:     "verify-full",
+				SSLRootCert: "/p/ca.crt",
+				SSLCert:     "/p/client.crt",
+				SSLKey:      "/p/client.key",
+			},
+		},
+		{
+			name:           "whitespace trimmed",
+			args:           map[string]any{"sslmode": "  require  "},
+			expectedParams: conn.TLSParams{SSLMode: "require"},
+		},
+		{
+			name:        "non-string sslmode rejected",
+			args:        map[string]any{"sslmode": 1},
+			expectedErr: true,
+		},
+		{
+			name:        "non-string sslcert rejected",
+			args:        map[string]any{"sslcert": true},
+			expectedErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = tc.args
+			got, toolErr := resolveTLSParams(req)
+			if tc.expectedErr {
+				require.NotNil(t, toolErr)
+				return
+			}
+			require.Nil(t, toolErr)
+			require.Equal(t, tc.expectedParams, got)
+		})
+	}
+}
+
+// TestExplainSQLToolAdvertisesTLSParams pins the discoverability
+// contract: the four TLS knobs appear as top-level properties on the
+// tool schema. Without this, an agent inspecting the schema for
+// available parameters would not know TLS could be configured outside
+// the dsn URI string.
+func TestExplainSQLToolAdvertisesTLSParams(t *testing.T) {
+	tools := map[string]mcpgo.Tool{
+		"explain_sql":           ExplainSQLTool(),
+		"explain_schema_change": ExplainSchemaChangeTool(),
+		"execute_sql":           ExecuteSQLTool(),
+		"simulate_sql":          SimulateSQLTool(),
+		"list_tables":           ListTablesTool(),
+		"describe_table":        DescribeTableTool(),
+	}
+	for name, tool := range tools {
+		t.Run(name, func(t *testing.T) {
+			props := tool.InputSchema.Properties
+			for _, param := range []string{
+				SSLModeParamName,
+				SSLRootCertParamName,
+				SSLCertParamName,
+				SSLKeyParamName,
+			} {
+				require.Contains(t, props, param,
+					"%s schema must advertise the %s property", name, param)
+			}
+		})
+	}
+}
+
+// TestExplainSQLHandlerTLSConflictSurfacesEnvelopeError pins the
+// load-bearing routing rule from mergeDSNWithTLS: a DSN/flag conflict
+// is *not* a tool-level error — it is appended to env.Errors as
+// tls_param_error so any earlier envelope warnings (target_version
+// mismatch etc.) are preserved.
+//
+// Picking explain_sql for coverage; the helper is shared so all five
+// connected tools follow the same path. A regression that flipped
+// merge errors back to mcp.NewToolResultError would silently drop
+// envelope state and is exactly the bug this test exists to catch.
+func TestExplainSQLHandlerTLSConflictSurfacesEnvelopeError(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":     "SELECT 1",
+		"dsn":     "postgres://h:26257/db?sslmode=require",
+		"sslmode": "verify-full",
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	env := requireEnvelope(t, res)
+	require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+	require.Len(t, env.Errors, 1)
+	require.Equal(t, "tls_param_error", env.Errors[0].Code)
+	require.Contains(t, env.Errors[0].Message, "sslmode")
+}
+
+// TestExplainSQLHandlerTLSWrongTypeIsToolError pins the
+// schema-validation routing: a non-string TLS argument is malformed
+// at the request layer (the tool never ran), so it surfaces as a
+// tool-level error rather than an envelope entry.
+func TestExplainSQLHandlerTLSWrongTypeIsToolError(t *testing.T) {
+	handler := ExplainSQLHandler(testParserVersion, "" /* defaultTargetVersion */)
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql":     "SELECT 1",
+		"dsn":     "postgres://h:26257/db",
+		"sslmode": 1,
+	}
+
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, res.IsError, "non-string sslmode must surface as a tool-level error")
 }

--- a/internal/testutil/cockroachtest/cluster.go
+++ b/internal/testutil/cockroachtest/cluster.go
@@ -150,6 +150,7 @@ func (l *lockedBuf) String() string {
 type startOpts struct {
 	startTimeout time.Duration
 	extraArgs    []string
+	secure       bool
 }
 
 // Option configures Start.
@@ -183,6 +184,21 @@ func WithExtraArgs(args ...string) Option {
 	})
 }
 
+// WithSecure drops `--insecure` from the cockroach demo invocation.
+// In secure mode demo provisions a self-signed CA and a node
+// certificate into a tempdir, then writes a TLS-enabled DSN whose
+// query string includes at least `sslmode` and `sslrootcert` pointing
+// at the demo-issued CA. Demo authenticates the SQL session with a
+// generated password rather than a client certificate, so the DSN
+// does not carry `sslcert`/`sslkey` — tests exercising the client-cert
+// auth path need their own `cockroach cert create-*` setup.
+//
+// Secure clusters cannot be served by Shared, which caches an
+// insecure cluster — call Start directly and Stop in defer/cleanup.
+func WithSecure() Option {
+	return optionFunc(func(o *startOpts) { o.secure = true })
+}
+
 // Start launches an in-memory single-node demo cluster in the
 // background. It blocks until the cluster has written its listening
 // URL to a private temp file (default 30s timeout, configurable via
@@ -214,11 +230,13 @@ func Start(ctx context.Context, opts ...Option) (*Cluster, error) {
 		"demo",
 		"--background",
 		"--no-example-database",
-		"--insecure",
 		"--disable-demo-license",
 		"--listening-url-file=" + urlPath,
 		"--sql-port=0",
 		"--http-port=0",
+	}
+	if !resolved.secure {
+		args = append(args, "--insecure")
 	}
 	args = append(args, resolved.extraArgs...)
 

--- a/internal/testutil/cockroachtest/cluster_test.go
+++ b/internal/testutil/cockroachtest/cluster_test.go
@@ -322,3 +322,14 @@ func (r *recordingTB) Fatalf(format string, args ...any) {
 }
 
 func (r *recordingTB) Helper() {}
+
+// TestWithSecureSetsSecureFlag pins the option-plumbing for WithSecure
+// without spawning a subprocess. A regression that dropped the field
+// assignment (e.g. an option-pattern refactor) would cause Start to
+// keep emitting --insecure even with WithSecure() applied; this test
+// catches that without depending on a cockroach binary.
+func TestWithSecureSetsSecureFlag(t *testing.T) {
+	var opts startOpts
+	WithSecure().apply(&opts)
+	require.True(t, opts.secure, "WithSecure() must set startOpts.secure")
+}


### PR DESCRIPTION
TLS-secured CockroachDB connections already worked end-to-end because
internal/conn/manager.go hands the DSN verbatim to pgx.Connect, which
honors libpq URI params (sslmode, sslrootcert, sslcert, sslkey). The
gap was UX/discoverability: --help and the README gave no hint that
secure clusters were supported, and the MCP tool input schemas
advertised a single opaque dsn string, so an LLM caller had no signal
that TLS knobs existed or how to spell them.

This adds a single conn.MergeTLSParams helper (shared between CLI and
MCP) that splices non-empty TLSParams fields into a postgres:// URI
and fails loud on conflicts with values already present in the DSN.
The keyword/value DSN form is rejected when any TLS flag is set —
splicing flag-sourced URI params into it would be ambiguous.

Per surface:

  - CLI: --sslmode/--sslrootcert/--sslcert/--sslkey persistent flags
    on the root command, merged into the resolved DSN inside
    PersistentPreRunE before any subcommand runs.

  - MCP: every connected tool (explain_sql, explain_schema_change,
    execute_sql, simulate_sql, list_tables, describe_table) now
    advertises the four TLS fields in its input schema. Param-shape
    errors (non-string TLS field) surface as tool-level errors;
    merge errors (DSN/flag conflict, non-URI form) are appended to
    env.Errors as a tls_param_error so any prior envelope warnings
    (target_version mismatch etc.) are preserved.

  - Harness: cockroachtest.WithSecure() drops --insecure from the
    `cockroach demo` invocation so integration tests can boot a
    TLS-required cluster without standing up a separate
    `cockroach cert create-*` pipeline.

  - Tests: TLS unit coverage for MergeTLSParams (round-trip,
    conflict, non-URI rejection, malformed parse), CLI wiring tests
    for the four flag-merge paths, MCP schema-advertisement and
    routing tests, and a build-tagged ping integration test that
    verifies both the URI-only path and the flag-merge path against
    a real secure demo cluster.

  - Docs: a "Connecting to a secure cluster" subsection in the
    README quickstart with worked examples for password+CA auth,
    client-cert auth, the equivalent --ssl* flag form, and the
    structured MCP input shape.

Resolves: #144