### PR TITLE
mcp: route per-call target_version to matching sibling backend

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	internalmcp "github.com/spilchen/sql-ai-tools/internal/mcp"
+	"github.com/spilchen/sql-ai-tools/internal/mcp/proxy"
 )
 
 // newMCPCmd builds the `crdb-sql mcp` subcommand. It launches an MCP
@@ -30,7 +31,14 @@ func newMCPCmd(state *rootState) *cobra.Command {
 		Short: "Run the crdb-sql MCP server on stdio",
 		Long: `Start an MCP (Model Context Protocol) server that speaks JSON-RPC
 over stdio. Intended to be launched by an MCP client (e.g. Claude Code
-via "claude mcp add"); the process exits when the client closes stdin.`,
+via "claude mcp add"); the process exits when the client closes stdin.
+
+Per-call target_version routing: any tool call whose target_version
+maps to a different parser quarter than this binary's bundled parser
+is forwarded to the matching sibling backend (crdb-sql-vXXX) on
+$PATH. The first cut spawns one sibling subprocess per routed call;
+expect ~tens-of-ms overhead per call vs. local handlers (benchmark
+tracked in #146; warm pooling in #145).`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			// Resolve the parser version up front so a stamped release
@@ -41,7 +49,10 @@ via "claude mcp add"); the process exits when the client closes stdin.`,
 			if err != nil {
 				return err
 			}
-			s := internalmcp.NewServer(Version, parserVer, state.targetVersion)
+			s := internalmcp.NewServer(
+				Version, parserVer, state.targetVersion,
+				internalmcp.WithRouter(proxy.NewSpawnRouter()),
+			)
 			// Wrap the transport error so a failure in the stdio loop
 			// surfaces through cobra's "Error:" line as obviously
 			// transport-layer rather than as an opaque message from

--- a/internal/mcp/cross_version_mcp_integration_test.go
+++ b/internal/mcp/cross_version_mcp_integration_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build integration
+
+// End-to-end test for issue #129: a single long-lived `crdb-sql mcp`
+// server forwards each tool call to the sibling backend whose parser
+// quarter matches the call's target_version. Builds both the latest
+// crdb-sql (v262) and the crdb-sql-v261 sibling into a tempdir, then
+// spawns one MCP server and issues two parse_sql calls — one for
+// each quarter — within the same session. The envelope's
+// parser_version field on each response proves which sibling
+// actually executed the call. Integration-tagged because it pays
+// the `go build` cost twice; run via `make test-integration`.
+
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// crossVersionParserDivergentStmt is a statement whose grammar
+// landed in cockroachdb-parser v0.26.2; v0.26.1 rejects it with a
+// SQLSTATE 42601 syntax error. The CLI-side mirror in
+// internal/versionroute/cross_version_integration_test.go uses the
+// same statement so a future grammar change that erases the
+// divergence breaks both tests in lockstep — preventing a silent
+// "both quarters now accept it" green-but-meaningless outcome.
+const crossVersionParserDivergentStmt = "ALTER TABLE t ENABLE TRIGGER tr"
+
+// TestPerCallMCPTargetVersionRouting is the demo for issue #129.
+// One MCP server, two tool calls in the same session, two different
+// parsers exercised — proven by the envelope's parser_version field.
+func TestPerCallMCPTargetVersionRouting(t *testing.T) {
+	repoRoot := findMCPRepoRoot(t)
+	binDir := t.TempDir()
+	latest := filepath.Join(binDir, "crdb-sql")
+	sibling := filepath.Join(binDir, "crdb-sql-v261")
+
+	buildCrdbSQLBin(t, repoRoot, latest, "v262", "")
+	buildCrdbSQLBin(t, repoRoot, sibling, "v261", "build/go.v261.mod")
+
+	// Prepend the build dir so the latest binary's per-call router
+	// finds crdb-sql-v261 via versionroute.FindBackend ($PATH walk).
+	pathWithBin := binDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	env := append([]string(nil), os.Environ()...)
+	env = append(env, "PATH="+pathWithBin)
+
+	c, err := client.NewStdioMCPClient(latest, env, "mcp")
+	require.NoError(t, err, "spawn crdb-sql mcp")
+	t.Cleanup(func() {
+		// A close error here typically signals the sibling crashed
+		// or hung mid-session — exactly the regression the
+		// integration test exists to catch — so promote it from a
+		// log line to a failure.
+		if err := c.Close(); err != nil {
+			t.Errorf("close MCP client: %v", err)
+		}
+	})
+
+	initCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var initReq mcp.InitializeRequest
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "crdb-sql-cross-version-test", Version: "0.0.0"}
+	_, err = c.Initialize(initCtx, initReq)
+	require.NoError(t, err, "MCP initialize handshake")
+
+	tests := []struct {
+		name                  string
+		targetVersion         string
+		expectedParserVersion string
+		expectSyntaxError     bool
+	}{
+		{
+			name:                  "latest quarter handled locally",
+			targetVersion:         "26.2.0",
+			expectedParserVersion: "v0.26.2",
+		},
+		{
+			name:                  "older quarter routed to sibling",
+			targetVersion:         "26.1.0",
+			expectedParserVersion: "v0.26.1",
+			expectSyntaxError:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			callCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			var req mcp.CallToolRequest
+			req.Params.Name = "parse_sql"
+			req.Params.Arguments = map[string]any{
+				"sql":            crossVersionParserDivergentStmt,
+				"target_version": tc.targetVersion,
+			}
+			res, err := c.CallTool(callCtx, req)
+			require.NoError(t, err, "tools/call parse_sql")
+			require.False(t, res.IsError, "expected envelope-shaped success result")
+
+			require.Len(t, res.Content, 1)
+			tcText, ok := res.Content[0].(mcp.TextContent)
+			require.True(t, ok, "expected TextContent, got %T", res.Content[0])
+
+			var env output.Envelope
+			require.NoError(t, json.Unmarshal([]byte(tcText.Text), &env), "decode envelope: %s", tcText.Text)
+
+			require.Equal(t, tc.expectedParserVersion, env.ParserVersion,
+				"parser_version on the envelope is the routing proof; mismatch means the call hit the wrong sibling")
+
+			if tc.expectSyntaxError {
+				// The v261 parser does not know ENABLE TRIGGER; the
+				// envelope must surface the parse error rather than
+				// silently producing a successful AST.
+				var sawSyntaxErr bool
+				for _, e := range env.Errors {
+					if e.Code == "42601" {
+						sawSyntaxErr = true
+						break
+					}
+				}
+				require.True(t, sawSyntaxErr,
+					"expected SQLSTATE 42601 in envelope errors for v26.1 parse of v26.2-only syntax: %+v", env.Errors)
+			}
+		})
+	}
+
+	t.Run("missing sibling produces tool error with discovery hint", func(t *testing.T) {
+		// target_version=25.4.0 needs crdb-sql-v254, which we
+		// never built. Two things must hold end-to-end:
+		//   1. the result is an MCP tool error (IsError=true), not
+		//      a JSON-RPC transport error — proves SpawnRouter is
+		//      wired (NoopRouter would also produce an error here,
+		//      but its message would say "routing not enabled"
+		//      rather than "not installed");
+		//   2. the message names the missing backend and lists
+		//      the v261 sibling we did install — proves the
+		//      writeMissingBackendError-style discovery hint
+		//      survived the proxy → wrapper → MCP transport hop.
+		callCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		var req mcp.CallToolRequest
+		req.Params.Name = "parse_sql"
+		req.Params.Arguments = map[string]any{
+			"sql":            "SELECT 1",
+			"target_version": "25.4.0",
+		}
+		res, err := c.CallTool(callCtx, req)
+		require.NoError(t, err, "missing sibling must surface as a tool error, not a JSON-RPC transport error")
+		require.True(t, res.IsError, "missing sibling must be a tool-level error")
+
+		require.Len(t, res.Content, 1)
+		tcText, ok := res.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		require.Contains(t, tcText.Text, "crdb-sql-v254",
+			"missing-backend message must name the requested sibling")
+		require.Contains(t, tcText.Text, "not installed",
+			"missing-backend message must say the backend is not installed (proves SpawnRouter, not NoopRouter)")
+		require.Contains(t, tcText.Text, "crdb-sql-v261",
+			"missing-backend message must list the discovered v261 sibling under 'Available backends'")
+	})
+}
+
+// findMCPRepoRoot returns the directory containing the worktree's
+// go.mod. Mirrors the CLI-side helper in
+// internal/versionroute/cross_version_integration_test.go; duplicated
+// rather than shared because cross-package test helpers would
+// require an internal/testutil shim that exists for one caller.
+func findMCPRepoRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOMOD").Output()
+	require.NoError(t, err)
+	gomod := strings.TrimSpace(string(out))
+	require.NotEmpty(t, gomod, "go env GOMOD returned empty; not inside a module?")
+	return filepath.Dir(gomod)
+}
+
+// buildCrdbSQLBin compiles the crdb-sql binary at outputPath,
+// stamping the supplied quarter into versionroute.builtQuarterStamp.
+// When modfile is non-empty, builds against build/<modfile> (the
+// per-quarter sibling's go.mod replace directive); otherwise uses
+// the worktree's top-level go.mod. Mirrors the helper in
+// internal/versionroute/cross_version_integration_test.go.
+func buildCrdbSQLBin(t *testing.T, repoRoot, outputPath, quarter, modfile string) {
+	t.Helper()
+	args := []string{"build"}
+	if modfile != "" {
+		args = append(args, "-modfile="+modfile)
+	}
+	args = append(args,
+		"-ldflags=-X github.com/spilchen/sql-ai-tools/internal/versionroute.builtQuarterStamp="+quarter,
+		"-o", outputPath, "./cmd/crdb-sql")
+	cmd := exec.Command("go", args...)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build (quarter=%s, modfile=%s) failed: %s", quarter, modfile, out)
+}

--- a/internal/mcp/proxy/proxy.go
+++ b/internal/mcp/proxy/proxy.go
@@ -1,0 +1,227 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Package proxy implements per-call routing of MCP tool calls from a
+// long-lived `crdb-sql mcp` server to a sibling crdb-sql-vXXX backend
+// whose parser quarter matches the caller's requested target_version.
+//
+// The router lives next to internal/mcp/routing.go: the wrapper
+// decides whether routing is needed (resolved target_version's
+// quarter differs from the running binary's), and on a positive
+// answer hands off to a Router here. Sibling discovery reuses
+// internal/versionroute (FindBackend, Discover, Quarter), so the
+// CLI's startup-time MaybeReexec and the MCP server's per-call
+// dispatch share one source of truth for "where do my siblings
+// live?" and "what backend do I need for v26.1?".
+//
+// SpawnRouter is the first cut from issue #129: spawn the sibling
+// per call, run the MCP initialize handshake, forward one tools/call,
+// tear it down. The latency cost (process startup + handshake on
+// every routed call) is documented; warm pooling is tracked in #145.
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// Router dispatches an MCP tool call to a sibling crdb-sql backend
+// whose parser quarter matches the caller's requested
+// target_version. A successful Dispatch returns the sibling's
+// *mcp.CallToolResult verbatim — including the sibling's
+// parser_version stamp on the envelope, which is the visible signal
+// that routing actually happened.
+//
+// Error contract: implementations distinguish two failure modes
+// because the wrapper layer surfaces them differently to the
+// caller.
+//   - Transport failures (cannot spawn the sibling, broken pipe,
+//     JSON-RPC framing error, initialize timeout, any error
+//     returned by the sibling's MCP client other than an
+//     IsError=true result) are returned as a non-nil Go error. The
+//     wrapper propagates these as Go errors from the tool handler
+//     so the MCP server reports a transport-layer failure rather
+//     than fabricating an envelope.
+//   - Tool-level failures (sibling answered with IsError=true, or
+//     the requested sibling is not installed) are returned as a
+//     non-nil *mcp.CallToolResult with IsError=true and a nil
+//     error. The wrapper forwards these verbatim so the client
+//     sees the same shape it would for a local tool error.
+//
+// SpawnRouter (and any future Router that constructs results
+// itself) must NOT touch output.Envelope — those results bypass
+// the local handler's envelope stamping entirely, so the saved
+// "preserve env.Errors" rule does not apply here.
+type Router interface {
+	Dispatch(
+		ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
+	) (*mcp.CallToolResult, error)
+}
+
+// NoopRouter is the default Router used when per-call routing has
+// not been wired into a server (e.g. unit tests for the wrapper that
+// only care about the local-handler path, or a future build that
+// disables routing). Every Dispatch returns a tool-error result
+// rather than silently falling through to the local handler — silent
+// fallback would mask the wiring bug this issue exists to prevent.
+type NoopRouter struct{}
+
+// Dispatch always returns a tool-error result naming the requested
+// sibling. Returning IsError=true (rather than a Go error) lets the
+// wrapper distinguish "no router configured" from "router blew up".
+func (NoopRouter) Dispatch(
+	_ context.Context, want versionroute.Quarter, _ mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultError(fmt.Sprintf(
+		"per-call target_version routing is not enabled in this MCP server; "+
+			"cannot serve %s", want.BackendName())), nil
+}
+
+// defaultInitTimeout caps the MCP initialize handshake on the
+// child. Cold-process startup plus initialize can be noticeably
+// slower than steady-state calls on loaded CI, so this is generous.
+// Match the integration test's initTimeout in
+// internal/mcp/integration_test.go so the two surfaces have the
+// same flake floor.
+const defaultInitTimeout = 10 * time.Second
+
+// SpawnRouter implements Router by spawning a sibling backend as a
+// child MCP server over stdio per call: locate the backend via
+// versionroute.FindBackend, exec it with `mcp` as the subcommand,
+// run the MCP initialize handshake, forward the single tools/call,
+// and tear the child down via client.Close.
+//
+// This is the spawn-per-call first cut described in issue #129. The
+// per-call cost is one process spawn plus one MCP handshake on top
+// of the actual tool work; warm pooling that amortizes both is
+// tracked in #145, with a benchmark in #146.
+type SpawnRouter struct {
+	// initTimeout caps the MCP initialize handshake on each spawned
+	// child. The per-tool-call timeout flows from the ctx the
+	// caller supplies to Dispatch.
+	initTimeout time.Duration
+}
+
+// NewSpawnRouter returns a SpawnRouter with the package's default
+// init timeout. Production callers (cmd/mcp.go) use this; tests that
+// need a tighter handshake budget can construct SpawnRouter
+// directly.
+func NewSpawnRouter() *SpawnRouter {
+	return &SpawnRouter{initTimeout: defaultInitTimeout}
+}
+
+// Dispatch spawns the sibling matching want, performs the MCP
+// initialize handshake, forwards req, and returns the sibling's
+// CallToolResult. See the Router interface comment for the
+// transport-vs-tool error distinction.
+func (r *SpawnRouter) Dispatch(
+	ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	path, found := versionroute.FindBackend(want)
+	if !found {
+		return missingBackendResult(want), nil
+	}
+
+	// nil env hands the parent's full environment to the child so any
+	// per-tool environment knobs (DSNs, COCKROACH_BIN for explain_sql,
+	// etc.) reach the sibling unchanged. The child also inherits
+	// stderr, so its diagnostics are visible alongside the parent's —
+	// load-bearing for debugging routed-call failures. Same reasoning
+	// as internal/mcp/integration_test.go newMCPClient.
+	c, err := client.NewStdioMCPClient(path, nil /* env */, "mcp")
+	if err != nil {
+		return nil, fmt.Errorf("spawn %s: %w", path, err)
+	}
+	defer func() {
+		// Surface close errors to stderr rather than swallow them:
+		// a Close failure typically means the sibling crashed or
+		// hung mid-call, and silently dropping that signal hides
+		// process-leak regressions. Use stderr (not the envelope)
+		// because Dispatch has already returned its result by the
+		// time this fires.
+		if err := c.Close(); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"crdb-sql mcp proxy: close sibling %s (%s): %v\n",
+				want.BackendName(), path, err)
+		}
+	}()
+
+	initCtx, cancel := context.WithTimeout(ctx, r.initTimeout)
+	defer cancel()
+	var initReq mcp.InitializeRequest
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{
+		Name:    "crdb-sql-mcp-proxy",
+		Version: "0.0.0",
+	}
+	if _, err := c.Initialize(initCtx, initReq); err != nil {
+		// Distinguish "init budget exhausted" from "init failed for
+		// some other reason" so the operator-facing message names
+		// the budget rather than leaving the cause as a generic
+		// "context deadline exceeded".
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf(
+				"initialize %s (%s): exceeded init timeout %s: %w",
+				want.BackendName(), path, r.initTimeout, err)
+		}
+		return nil, fmt.Errorf("initialize %s (%s): %w",
+			want.BackendName(), path, err)
+	}
+
+	res, err := c.CallTool(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("forward tools/call to %s (%s): %w",
+			want.BackendName(), path, err)
+	}
+	return res, nil
+}
+
+// missingBackendResult builds a tool-error CallToolResult whose
+// message mirrors versionroute.writeMissingBackendError on the CLI:
+// names the requested backend, reports what this binary is, and
+// lists every discovered backend. The agent reading the result can
+// then decide whether to install the missing sibling or drop the
+// target_version override. Returning a tool-error result (rather
+// than a Go transport error) keeps the failure visible at the same
+// layer as a local handler's parameter validation error.
+func missingBackendResult(want versionroute.Quarter) *mcp.CallToolResult {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "target_version requires the %s backend, which is not installed "+
+		"alongside this binary or in $PATH.\n", want.BackendName())
+	if built, ok := versionroute.Built(); ok {
+		fmt.Fprintf(&sb, "This MCP server is %s.\n", built.BackendName())
+	} else {
+		sb.WriteString("This MCP server's quarter is unknown.\n")
+	}
+	backends := versionroute.Discover()
+	if len(backends) == 0 {
+		sb.WriteString("No backends discovered.\n")
+	} else {
+		sb.WriteString("Available backends:\n")
+		for _, b := range backends {
+			label := b.Path
+			if b.IsSelf {
+				label = "(this binary)"
+			}
+			name := b.Quarter.BackendName()
+			if b.Quarter.IsZero() {
+				name = "crdb-sql (unknown quarter)"
+			}
+			fmt.Fprintf(&sb, "  %-18s %s\n", name, label)
+		}
+	}
+	fmt.Fprintf(&sb, "Install the %s backend from the GitHub release, or omit "+
+		"target_version to use the bundled parser.", want.Tag())
+	return mcp.NewToolResultError(sb.String())
+}

--- a/internal/mcp/proxy/proxy_test.go
+++ b/internal/mcp/proxy/proxy_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// fakeQuarter is a Year.Quarter combination that is extremely
+// unlikely to be installed on any developer machine. SpawnRouter's
+// missing-backend tests target it so the test does not depend on the
+// host having (or not having) any specific sibling binary.
+var fakeQuarter = versionroute.Quarter{Year: 99, Q: 4}
+
+// requireToolError asserts that res is a tool-level error and
+// returns the concatenated text of every TextContent block so the
+// caller can run substring assertions.
+func requireToolError(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, res, "expected a result, got nil")
+	require.True(t, res.IsError, "expected tool-level error result")
+	var text string
+	for _, c := range res.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			text += tc.Text
+		}
+	}
+	require.NotEmpty(t, text, "tool error result must carry a message")
+	return text
+}
+
+// TestNoopRouterReturnsToolError pins that the default Router does
+// not silently fall through. A wiring regression that left NoopRouter
+// in place where SpawnRouter was intended must surface as a clear
+// "routing not enabled" message rather than a confusing "answered
+// with the wrong parser" envelope.
+func TestNoopRouterReturnsToolError(t *testing.T) {
+	res, err := NoopRouter{}.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
+	require.NoError(t, err)
+	text := requireToolError(t, res)
+	require.Contains(t, text, "not enabled")
+	require.Contains(t, text, fakeQuarter.BackendName())
+}
+
+// TestSpawnRouterMissingBackendReportsDiscoveryHint pins the user-
+// facing missing-backend message. The wording deliberately mirrors
+// the CLI's writeMissingBackendError so an operator hitting either
+// surface sees the same diagnostic shape: which backend was needed,
+// what the running binary is, what alternatives exist, and the
+// install hint.
+func TestSpawnRouterMissingBackendReportsDiscoveryHint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics + 0o755 perm bits differ on Windows; covered by integration test")
+	}
+	// Empty PATH so the only place FindBackend looks is the test
+	// binary's directory, which never contains a crdb-sql-v994.
+	t.Setenv("PATH", t.TempDir())
+
+	r := NewSpawnRouter()
+	res, err := r.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
+	require.NoError(t, err, "missing-backend must be a tool error, not a transport error")
+	text := requireToolError(t, res)
+	require.Contains(t, text, fakeQuarter.BackendName(),
+		"message must name the requested backend")
+	require.Contains(t, text, "not installed",
+		"message must explicitly state the backend is missing")
+	require.Contains(t, text, "Install the "+fakeQuarter.Tag()+" backend",
+		"message must give the install hint with the backend tag")
+}
+
+// TestSpawnRouterMissingBackendListsDiscoveredAlternatives covers
+// the missing-backend message's "Available backends" branch by
+// dropping a fake sibling into a tempdir on PATH. Without this
+// test the discovery-list formatting (column widths, IsSelf
+// rendering, BackendName for each entry) is uncovered, and a
+// regression that breaks operator-facing diagnostics — e.g.
+// rendering paths without their backend names — would slip past
+// TestSpawnRouterMissingBackendReportsDiscoveryHint, which
+// exercises only the no-backends branch.
+func TestSpawnRouterMissingBackendListsDiscoveredAlternatives(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics + 0o755 perm bits differ on Windows; covered by integration test")
+	}
+	dir := t.TempDir()
+	// Drop a fake sibling for v26.1 so Discover finds it. Empty
+	// file with the executable bit set is enough — isExecutable
+	// keys on the bit, not the contents.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "crdb-sql-v261"), []byte{}, 0o755))
+	t.Setenv("PATH", dir)
+
+	r := NewSpawnRouter()
+	res, err := r.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
+	require.NoError(t, err)
+	text := requireToolError(t, res)
+	require.Contains(t, text, "Available backends:",
+		"discovered backends must be listed under the Available backends header")
+	require.Contains(t, text, "crdb-sql-v261",
+		"the v261 sibling we planted must appear in the discovered list")
+	require.Contains(t, text, fakeQuarter.BackendName(),
+		"the missing backend's name must still appear so the operator knows what's needed")
+}

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/spilchen/sql-ai-tools/internal/mcp/proxy"
+	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// withRouting wraps h so that any tool call whose resolved
+// target_version maps to a different versionroute.Quarter than the
+// running binary's `built` is forwarded to router instead of
+// executed locally. Tools that do not accept target_version (ping,
+// list_tables, describe_table) must not be wrapped — wrapping them
+// would silently drop the parameter.
+//
+// The wrapper preserves the exact error contract callers depend on:
+//   - Parameter validation errors from the target_version field
+//     surface as tool-level errors (IsError=true) just as they would
+//     from the local handler. Routing must not eat a parameter
+//     validation problem.
+//   - When the router returns (nil, error), the wrapper propagates
+//     the Go error so the MCP server reports it as transport-layer.
+//   - When the router returns a result, the wrapper returns it
+//     verbatim so the sibling's parser_version reaches the client.
+//
+// When built is the zero Quarter (an unstamped local build with no
+// parser dep in BuildInfo, or a `go test` binary), the wrapper
+// always falls through to the local handler. There is no meaningful
+// quarter to compare against, and per-handler stamping
+// (output.VersionMismatchWarning via stampTargetVersion) still
+// informs the client of the skew. A malformed builtQuarterStamp
+// that turns Built() into the zero Quarter is surfaced separately
+// at process startup by versionroute.MaybeReexec, which prints
+// versionroute.StampDiagnostic to stderr — so the operator sees
+// the build defect even when the MCP server itself stays quiet.
+//
+// The double-call to tools.ResolveTargetVersion (once here, once
+// inside the local handler when routing falls through) is benign
+// today because the function is idempotent. If a future change
+// introduces a side effect there, the local handler should accept
+// a pre-resolved target_version instead of re-resolving.
+func withRouting(
+	h server.ToolHandlerFunc,
+	defaultTargetVersion string,
+	built versionroute.Quarter,
+	router proxy.Router,
+) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		target, toolErr := tools.ResolveTargetVersion(req, defaultTargetVersion)
+		if toolErr != nil {
+			return toolErr, nil
+		}
+		if want, ok := routeTarget(built, target); ok {
+			return router.Dispatch(ctx, want, req)
+		}
+		return h(ctx, req)
+	}
+}
+
+// routeTarget decides whether a call with the given resolved target
+// must be forwarded to a sibling, and on a positive answer returns
+// the parsed want Quarter so the caller does not re-parse. Folding
+// the parse and the decision into one function eliminates the
+// structural-coincidence hazard of having shouldRoute promise
+// "parseable" while a separate ParseFromTarget call discards the
+// ok bool.
+//
+// Returns (zero, false) — handle locally — for any of:
+//   - empty target (no version requested)
+//   - unparseable target (let the local handler's existing
+//     validation produce the diagnostic)
+//   - built quarter is unknown (no comparison possible)
+//   - built quarter equals want quarter (same parser)
+func routeTarget(built versionroute.Quarter, target string) (versionroute.Quarter, bool) {
+	if target == "" {
+		return versionroute.Quarter{}, false
+	}
+	want, ok := versionroute.ParseFromTarget(target)
+	if !ok {
+		return versionroute.Quarter{}, false
+	}
+	if built.IsZero() {
+		return versionroute.Quarter{}, false
+	}
+	if built == want {
+		return versionroute.Quarter{}, false
+	}
+	return want, true
+}

--- a/internal/mcp/routing_test.go
+++ b/internal/mcp/routing_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/mcp/proxy"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// fakeRouter records each Dispatch call and returns canned
+// responses. Tests use it to verify the wrapper's routing decision
+// without spawning a real subprocess.
+type fakeRouter struct {
+	dispatched []dispatchCall
+	result     *mcp.CallToolResult
+	err        error
+}
+
+type dispatchCall struct {
+	want versionroute.Quarter
+	req  mcp.CallToolRequest
+}
+
+func (f *fakeRouter) Dispatch(
+	_ context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	f.dispatched = append(f.dispatched, dispatchCall{want: want, req: req})
+	return f.result, f.err
+}
+
+// localHandlerSentinel is the response the recordingHandler returns
+// to the wrapper. Tests assert on its identity to confirm the local
+// path was taken (vs. a proxied response from fakeRouter).
+var localHandlerSentinel = mcp.NewToolResultText(`{"local":true}`)
+
+// recordingHandler is the inner handler the wrapper decorates. It
+// records each call and returns a fixed sentinel result so tests
+// can distinguish "local handler ran" from "router ran".
+type recordingHandler struct {
+	calls int
+}
+
+func (r *recordingHandler) handle(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	r.calls++
+	return localHandlerSentinel, nil
+}
+
+// builtV262 and builtV261 are the canonical "running binary's
+// quarter" fixtures used across the tests. v262 mirrors the
+// production latest binary; v261 mirrors the sibling installed for
+// cross-version routing.
+var (
+	builtV262 = versionroute.Quarter{Year: 26, Q: 2}
+	builtV261 = versionroute.Quarter{Year: 26, Q: 1}
+)
+
+// callRequest builds a tools/call request from a flat argument map.
+// The wrapper does not care about the tool name field, so tests
+// leave it unset.
+func callRequest(args map[string]any) mcp.CallToolRequest {
+	var req mcp.CallToolRequest
+	req.Params.Arguments = args
+	return req
+}
+
+func TestWithRoutingDispatchDecision(t *testing.T) {
+	tests := []struct {
+		name                  string
+		built                 versionroute.Quarter
+		defaultTargetVersion  string
+		args                  map[string]any
+		expectRouted          bool
+		expectLocalCalls      int
+		expectRouterCalls     int
+		expectRouterWantQuart versionroute.Quarter
+	}{
+		{
+			name:             "no target_version uses local handler",
+			built:            builtV262,
+			args:             map[string]any{"sql": "SELECT 1"},
+			expectLocalCalls: 1,
+		},
+		{
+			name:                 "matching default uses local handler",
+			built:                builtV262,
+			defaultTargetVersion: "26.2.0",
+			args:                 map[string]any{"sql": "SELECT 1"},
+			expectLocalCalls:     1,
+		},
+		{
+			name:             "matching per-call target uses local handler",
+			built:            builtV262,
+			args:             map[string]any{"sql": "SELECT 1", "target_version": "26.2.0"},
+			expectLocalCalls: 1,
+		},
+		{
+			name:                  "different per-call target routes to sibling",
+			built:                 builtV262,
+			args:                  map[string]any{"sql": "SELECT 1", "target_version": "26.1.0"},
+			expectRouted:          true,
+			expectRouterCalls:     1,
+			expectRouterWantQuart: builtV261,
+		},
+		{
+			name:                  "different default routes to sibling",
+			built:                 builtV262,
+			defaultTargetVersion:  "26.1.0",
+			args:                  map[string]any{"sql": "SELECT 1"},
+			expectRouted:          true,
+			expectRouterCalls:     1,
+			expectRouterWantQuart: builtV261,
+		},
+		{
+			name:                  "per-call beats default and routes to per-call quarter",
+			built:                 builtV262,
+			defaultTargetVersion:  "26.2.0",
+			args:                  map[string]any{"sql": "SELECT 1", "target_version": "26.1.0"},
+			expectRouted:          true,
+			expectRouterCalls:     1,
+			expectRouterWantQuart: builtV261,
+		},
+		{
+			name:             "unknown built quarter falls through to local",
+			built:            versionroute.Quarter{},
+			args:             map[string]any{"sql": "SELECT 1", "target_version": "26.1.0"},
+			expectLocalCalls: 1,
+		},
+		{
+			name:             "leading v on per-call target normalizes to same quarter",
+			built:            builtV262,
+			args:             map[string]any{"sql": "SELECT 1", "target_version": "v26.2.0"},
+			expectLocalCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rh := &recordingHandler{}
+			fr := &fakeRouter{result: mcp.NewToolResultText(`{"routed":true}`)}
+
+			wrapped := withRouting(rh.handle, tc.defaultTargetVersion, tc.built, fr)
+			res, err := wrapped(context.Background(), callRequest(tc.args))
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			require.Equal(t, tc.expectLocalCalls, rh.calls, "local handler invocation count")
+			require.Len(t, fr.dispatched, tc.expectRouterCalls, "router invocation count")
+			if tc.expectRouted {
+				require.Equal(t, tc.expectRouterWantQuart, fr.dispatched[0].want,
+					"router was dispatched with the wrong quarter")
+				require.Same(t, fr.result, res,
+					"wrapper must return the router's result verbatim")
+			} else {
+				require.Same(t, localHandlerSentinel, res,
+					"wrapper must return the local handler's result on the local path")
+			}
+		})
+	}
+}
+
+// TestWithRoutingMalformedTargetVersionPreservesValidationError pins
+// that a per-call target_version that fails ResolveTargetVersion's
+// validation surfaces as a tool error from the wrapper, identical to
+// what the local handler would have produced. Routing must not eat a
+// parameter validation problem just because it intercepts the
+// resolution step.
+func TestWithRoutingMalformedTargetVersionPreservesValidationError(t *testing.T) {
+	rh := &recordingHandler{}
+	fr := &fakeRouter{result: mcp.NewToolResultText(`{"routed":true}`)}
+
+	wrapped := withRouting(rh.handle, "" /* defaultTargetVersion */, builtV262, fr)
+	res, err := wrapped(context.Background(), callRequest(map[string]any{
+		"sql":            "SELECT 1",
+		"target_version": "garbage",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError, "malformed target_version must surface as a tool error")
+	require.Zero(t, rh.calls, "local handler must not run when validation fails")
+	require.Empty(t, fr.dispatched, "router must not run when validation fails")
+}
+
+// TestWithRoutingTransportErrorPropagates pins that a Go-error
+// return from the router (a transport failure: spawn failed, broken
+// pipe, framing error) propagates as the wrapper's Go-error return.
+// The MCP server treats this as a transport-layer failure rather
+// than fabricating an envelope.
+func TestWithRoutingTransportErrorPropagates(t *testing.T) {
+	rh := &recordingHandler{}
+	transportErr := errors.New("spawn failed")
+	fr := &fakeRouter{err: transportErr}
+
+	wrapped := withRouting(rh.handle, "", builtV262, fr)
+	res, err := wrapped(context.Background(), callRequest(map[string]any{
+		"sql":            "SELECT 1",
+		"target_version": "26.1.0",
+	}))
+	require.ErrorIs(t, err, transportErr, "wrapper must propagate transport errors")
+	require.Nil(t, res, "no result on transport failure")
+	require.Zero(t, rh.calls, "local handler must not run on transport failure")
+}
+
+// TestWithRoutingToolErrorPropagatesAsResult pins that an
+// IsError=true result from the router (e.g. NoopRouter or
+// missing-backend) reaches the client unchanged. The wrapper must
+// not coerce it into a Go error; that would lose the user-facing
+// message.
+func TestWithRoutingToolErrorPropagatesAsResult(t *testing.T) {
+	rh := &recordingHandler{}
+	toolErrResult := mcp.NewToolResultError("missing backend")
+	fr := &fakeRouter{result: toolErrResult}
+
+	wrapped := withRouting(rh.handle, "", builtV262, fr)
+	res, err := wrapped(context.Background(), callRequest(map[string]any{
+		"sql":            "SELECT 1",
+		"target_version": "26.1.0",
+	}))
+	require.NoError(t, err, "tool errors must not surface as Go errors")
+	require.Same(t, toolErrResult, res, "tool error result must reach the client unchanged")
+	require.Zero(t, rh.calls, "local handler must not run when routing fires")
+}
+
+// TestWithRoutingNoopRouterReturnsToolError sanity-checks the
+// wrapper + NoopRouter composition end-to-end: a different-quarter
+// call against an unrouted server produces NoopRouter's "not
+// enabled" message.
+func TestWithRoutingNoopRouterReturnsToolError(t *testing.T) {
+	rh := &recordingHandler{}
+	wrapped := withRouting(rh.handle, "", builtV262, proxy.NoopRouter{})
+	res, err := wrapped(context.Background(), callRequest(map[string]any{
+		"sql":            "SELECT 1",
+		"target_version": "26.1.0",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.True(t, res.IsError)
+	require.Zero(t, rh.calls)
+}
+
+func TestRouteTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		built        versionroute.Quarter
+		target       string
+		expectedWant versionroute.Quarter
+		expectedOK   bool
+	}{
+		{name: "empty target", built: builtV262, target: ""},
+		{name: "unparseable target", built: builtV262, target: "garbage"},
+		{name: "unknown built quarter", built: versionroute.Quarter{}, target: "26.1.0"},
+		{name: "matching quarter", built: builtV262, target: "26.2.0"},
+		{name: "matching quarter with leading v", built: builtV262, target: "v26.2"},
+		{
+			name:  "different quarter routes and returns parsed quarter",
+			built: builtV262, target: "26.1.0",
+			expectedWant: builtV261, expectedOK: true,
+		},
+		{
+			name:  "different year routes",
+			built: builtV262, target: "25.4.0",
+			expectedWant: versionroute.Quarter{Year: 25, Q: 4}, expectedOK: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			want, ok := routeTarget(tc.built, tc.target)
+			require.Equal(t, tc.expectedOK, ok)
+			require.Equal(t, tc.expectedWant, want)
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -31,12 +31,63 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/spilchen/sql-ai-tools/internal/mcp/proxy"
 	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
 )
 
 // PingToolName is the registered MCP tool name for the health-check tool.
 // All other tool name constants live in the tools subpackage.
 const PingToolName = "ping"
+
+// Option configures NewServer. The pattern matches CockroachDB's
+// functional-options convention: each Option mutates a
+// serverOptions holder so the public NewServer signature stays
+// stable going forward as new knobs arrive. Today the configurable
+// knobs are the per-call target_version Router (issue #129) and
+// the built-quarter override used by tests; the same shape extends
+// naturally to future server-wide options.
+type Option interface {
+	apply(*serverOptions)
+}
+
+// serverOptions is the internal config aggregator the Option
+// constructors mutate.
+//
+//   - router is the per-call target_version Router used to forward
+//     tool calls whose quarter does not match the running binary.
+//   - builtOverride, when non-zero, replaces versionroute.Built()
+//     for the purpose of routing decisions. Production callers
+//     leave this unset; tests set it to drive the wrapper into a
+//     known routing decision without having to fake the binary
+//     filename or set builtQuarterStamp at link time.
+type serverOptions struct {
+	router        proxy.Router
+	builtOverride versionroute.Quarter
+}
+
+type optionFunc func(*serverOptions)
+
+func (f optionFunc) apply(o *serverOptions) { f(o) }
+
+// WithRouter installs the per-call target_version Router used by
+// every parser-dependent tool handler. When omitted, NewServer wires
+// proxy.NoopRouter, which returns a clear "routing not enabled" tool
+// error rather than silently answering with the wrong parser. The
+// production binary (cmd/mcp.go) installs proxy.NewSpawnRouter().
+func WithRouter(r proxy.Router) Option {
+	return optionFunc(func(o *serverOptions) { o.router = r })
+}
+
+// WithBuiltQuarter overrides the built quarter used for routing
+// decisions. Production callers must not use this — versionroute.Built()
+// is the source of truth for which sibling backend "this binary"
+// is. Tests use it to construct a server with a known built
+// quarter without having to fiddle with link-time stamps or fake
+// the executable path.
+func WithBuiltQuarter(q versionroute.Quarter) Option {
+	return optionFunc(func(o *serverOptions) { o.builtOverride = q })
+}
 
 // NewServer constructs an MCP server for crdb-sql. The three string
 // arguments name distinct concepts that flow through every tool
@@ -55,9 +106,36 @@ const PingToolName = "ping"
 //     for every tool call; per-call target_version arguments override
 //     it.
 //
-// The returned server has no transport bound; callers wire it to stdio
+// The variadic Option values configure cross-cutting behavior — most
+// notably the per-call target_version Router (see WithRouter). The
+// returned server has no transport bound; callers wire it to stdio
 // (or, in the future, sse/http) themselves.
-func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *server.MCPServer {
+//
+// Per-call routing wiring: the nine parser-dependent tool handlers
+// (parse_sql, validate_sql, format_sql, detect_risky_query,
+// summarize_sql, explain_sql, explain_schema_change, simulate_sql,
+// execute_sql) are wrapped with withRouting so a target_version
+// whose quarter differs from the running binary forwards to a
+// sibling backend. The three tools that don't take target_version
+// (ping, list_tables, describe_table) are registered unwrapped.
+func NewServer(
+	crdbSQLVersion, parserVersion, defaultTargetVersion string, opts ...Option,
+) *server.MCPServer {
+	cfg := serverOptions{router: proxy.NoopRouter{}}
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	// Built() returning (zero, false) — unstamped binary with no
+	// parser dep recorded in BuildInfo — is treated by withRouting
+	// as "no routing"; an operator hitting that case sees
+	// versionroute.StampDiagnostic on stderr at process startup
+	// (emitted by versionroute.MaybeReexec), so silent failure here
+	// is bounded.
+	built, _ := versionroute.Built()
+	if !cfg.builtOverride.IsZero() {
+		built = cfg.builtOverride
+	}
+
 	s := server.NewMCPServer(
 		"crdb-sql",
 		crdbSQLVersion,
@@ -70,15 +148,21 @@ func NewServer(crdbSQLVersion, parserVersion, defaultTargetVersion string) *serv
 		),
 		pingHandler(parserVersion),
 	)
-	s.AddTool(tools.ParseSQLTool(), tools.ParseSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.ValidateSQLTool(), tools.ValidateSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.FormatSQLTool(), tools.FormatSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.DetectRiskyQueryTool(), tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.SummarizeSQLTool(), tools.SummarizeSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.ExplainSQLTool(), tools.ExplainSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.ExplainSchemaChangeTool(), tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.SimulateSQLTool(), tools.SimulateSQLHandler(parserVersion, defaultTargetVersion))
-	s.AddTool(tools.ExecuteSQLTool(), tools.ExecuteSQLHandler(parserVersion, defaultTargetVersion))
+	// route wraps a parser-dependent handler with the per-call
+	// target_version router. Defined as a closure so the per-tool
+	// AddTool calls below stay one-liners.
+	route := func(h server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return withRouting(h, defaultTargetVersion, built, cfg.router)
+	}
+	s.AddTool(tools.ParseSQLTool(), route(tools.ParseSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.ValidateSQLTool(), route(tools.ValidateSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.FormatSQLTool(), route(tools.FormatSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.DetectRiskyQueryTool(), route(tools.DetectRiskyQueryHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.SummarizeSQLTool(), route(tools.SummarizeSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.ExplainSQLTool(), route(tools.ExplainSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.ExplainSchemaChangeTool(), route(tools.ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.SimulateSQLTool(), route(tools.SimulateSQLHandler(parserVersion, defaultTargetVersion)))
+	s.AddTool(tools.ExecuteSQLTool(), route(tools.ExecuteSQLHandler(parserVersion, defaultTargetVersion)))
 	s.AddTool(tools.ListTablesTool(), tools.ListTablesHandler(parserVersion))
 	s.AddTool(tools.DescribeTableTool(), tools.DescribeTableHandler(parserVersion))
 	return s

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spilchen/sql-ai-tools/internal/mcp/tools"
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
 )
 
 // TestPingHandler exercises the ping tool handler directly, bypassing
@@ -65,6 +66,107 @@ func TestPingHandler(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.JSONEq(t, string(expectedJSON), text.Text)
+		})
+	}
+}
+
+// spyRouter is a test-only proxy.Router that records every Dispatch
+// call so server-wiring tests can assert that the routing wrapper
+// fired (or did not fire) for a given tool.
+type spyRouter struct {
+	calls int
+}
+
+func (s *spyRouter) Dispatch(
+	_ context.Context, _ versionroute.Quarter, _ mcpgo.CallToolRequest,
+) (*mcpgo.CallToolResult, error) {
+	s.calls++
+	// Return a benign success result so the wrapper has something
+	// to forward; the test only cares that Dispatch was called.
+	return mcpgo.NewToolResultText(`{"routed":true}`), nil
+}
+
+// TestNewServerRoutesAllParserDependentToolsAndOnlyThem pins the
+// wiring contract from server.go's doc: the nine parser-dependent
+// handlers must be wrapped with withRouting, and the three that do
+// not take target_version must NOT be wrapped. A future refactor
+// that drops `route(...)` from one AddTool line — or wraps a tool
+// that does not accept target_version — would silently break the
+// per-call routing contract from issue #129. This test catches both
+// shapes.
+func TestNewServerRoutesAllParserDependentToolsAndOnlyThem(t *testing.T) {
+	const (
+		serverQuarter = "26.2.0"
+		routedTarget  = "26.1.0"
+	)
+	built := versionroute.Quarter{Year: 26, Q: 2}
+
+	wrapped := []string{
+		tools.ParseSQLToolName,
+		tools.ValidateSQLToolName,
+		tools.FormatSQLToolName,
+		tools.DetectRiskyQueryToolName,
+		tools.SummarizeSQLToolName,
+		tools.ExplainSQLToolName,
+		tools.ExplainSchemaChangeToolName,
+		tools.SimulateSQLToolName,
+		tools.ExecuteSQLToolName,
+	}
+	unwrapped := []string{
+		PingToolName,
+		tools.ListTablesToolName,
+		tools.DescribeTableToolName,
+	}
+
+	// One CallToolRequest per tool — handlers reject missing
+	// required params even when the wrapper would have routed, so
+	// the test passes plausible-but-unused values for required
+	// arguments. The router-spy fires before any local-handler
+	// validation runs, so for the wrapped set we never reach the
+	// local handler at all.
+	args := map[string]any{
+		"sql":            "SELECT 1",
+		"dsn":            "postgres://nope:1/db?connect_timeout=1",
+		"target_version": routedTarget,
+		"table":          "t",
+		"schemas":        []any{},
+	}
+
+	for _, name := range wrapped {
+		t.Run("wrapped/"+name, func(t *testing.T) {
+			spy := &spyRouter{}
+			s := NewServer("v1.2.3", "v0.26.2", serverQuarter,
+				WithRouter(spy), WithBuiltQuarter(built))
+			handler := s.ListTools()[name].Handler
+			require.NotNil(t, handler)
+
+			req := mcpgo.CallToolRequest{}
+			req.Params.Name = name
+			req.Params.Arguments = args
+			_, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			require.Equal(t, 1, spy.calls,
+				"%s must route to the sibling on a different-quarter target_version", name)
+		})
+	}
+
+	for _, name := range unwrapped {
+		t.Run("unwrapped/"+name, func(t *testing.T) {
+			spy := &spyRouter{}
+			s := NewServer("v1.2.3", "v0.26.2", serverQuarter,
+				WithRouter(spy), WithBuiltQuarter(built))
+			handler := s.ListTools()[name].Handler
+			require.NotNil(t, handler)
+
+			req := mcpgo.CallToolRequest{}
+			req.Params.Name = name
+			req.Params.Arguments = args
+			// Some unwrapped handlers (list_tables, describe_table)
+			// require their own arguments; we only care here that
+			// they do NOT route, not that they succeed.
+			_, _ = handler(context.Background(), req)
+			require.Zero(t, spy.calls,
+				"%s must NOT be wrapped — it does not accept target_version", name)
 		})
 	}
 }

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -224,6 +224,17 @@ func stampTargetVersion(env *output.Envelope, parserVersion, targetVersion strin
 	}
 }
 
+// ResolveTargetVersion is the exported entry point used by the MCP
+// per-call routing wrapper (internal/mcp/routing.go) to resolve the
+// effective target_version for a single tool call without
+// re-implementing the parameter-extraction contract. Handlers inside
+// this package call the unexported resolveTargetVersion directly;
+// keeping a thin wrapper means the wire-level contract — precedence,
+// canonicalization, error messages — has exactly one definition.
+func ResolveTargetVersion(req mcp.CallToolRequest, defaultTargetVersion string) (string, *mcp.CallToolResult) {
+	return resolveTargetVersion(req, defaultTargetVersion)
+}
+
 // resolveTargetVersion picks the target version to stamp onto the
 // envelope for a single tool call. The per-call target_version
 // argument wins over defaultTargetVersion when it is present, a


### PR DESCRIPTION
## Summary

Closes the gap from issue #129: a long-lived `crdb-sql mcp` server now forwards each tool call to the matching sibling backend (`crdb-sql-vXXX`) when the call's `target_version` resolves to a different parser quarter than the running binary. The sibling's `parser_version` reaches the client unchanged on the envelope — that's the visible signal that routing actually happened.

Two commits on this PR (mirrors the #122 split: implementation + cross-version integration test).

### Commit 1 — `mcp: route per-call target_version to matching sibling backend`

- New `internal/mcp/proxy/` package with `Router` interface and `SpawnRouter` (spawn-per-call first cut; warm pooling tracked in #145).
- New `internal/mcp/routing.go` decorator that wraps each parser-dependent tool handler at registration time.
- `NewServer` gains functional `WithRouter` / `WithBuiltQuarter` options.
- `cmd/mcp.go` wires `proxy.NewSpawnRouter()` for the production binary.
- `tools.ResolveTargetVersion` exported so the wrapper reuses the existing parameter validation.
- Missing-sibling surface: tool-error result whose message mirrors the CLI's `versionroute.writeMissingBackendError` discovery hint.
- Error contract: transport failures (spawn, broken pipe, framing, init timeout, sibling-CallTool errors) propagate as Go errors; sibling tool errors and missing-backend pass through as `IsError=true` results.
- Tests: `routing_test.go` (8-case dispatch decision matrix + transport/tool-error propagation + malformed target preservation), `proxy_test.go` (NoopRouter behavior + SpawnRouter missing-backend with and without discovered alternatives), and `server_test.go` (`TestNewServerRoutesAllParserDependentToolsAndOnlyThem` proves all 9 wrapped + 3 unwrapped).

### Commit 2 — `mcp: integration test for per-call target_version routing`

- Builds v262 latest + v261 sibling into a tempdir, spawns one MCP server, issues `parse_sql` with `target_version=26.2.0` and `26.1.0` in the same session.
- Asserts each envelope's `parser_version` reflects the sibling that actually ran (v0.26.2 vs v0.26.1).
- Third subtest with `target_version=25.4.0` (no sibling) confirms the missing-backend discovery hint reaches the client end-to-end and proves `SpawnRouter` (not `NoopRouter`) is wired by `cmd/mcp.go`.
- Mirrors the CLI-side `cross_version_integration_test.go` (same divergent statement: `ALTER TABLE t ENABLE TRIGGER tr`).

## Follow-ons (already filed)

- #145 — Warm sibling-process pool keyed by Quarter
- #146 — Benchmark spawn-per-call vs pooled

🤖 Generated with [Claude Code](https://claude.com/claude-code)