### PR TITLE
mcp/proxy: pool warm sibling children per target_version quarter

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -36,11 +37,14 @@ via "claude mcp add"); the process exits when the client closes stdin.
 Per-call target_version routing: any tool call whose target_version
 maps to a different parser quarter than this binary's bundled parser
 is forwarded to the matching sibling backend (crdb-sql-vXXX) on
-$PATH. The first cut spawns one sibling subprocess per routed call;
-expect ~tens-of-ms overhead per call vs. local handlers (benchmark
-tracked in #146; warm pooling in #145).`,
+$PATH. Routed calls go through a warm sibling-process pool — the
+first call to a target version pays one process spawn plus the MCP
+initialize handshake; subsequent calls reuse the warm child until it
+has been idle for ~5 minutes. The pool drains cleanly when the MCP
+client closes stdin (the normal exit path); SIGTERM/SIGKILL of the
+parent skips the drain and orphans any warm sibling children.`,
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) (retErr error) {
 			// Resolve the parser version up front so a stamped release
 			// build with a missing dep fails fast — same hard-fail
 			// behavior the version subcommand uses, rather than letting
@@ -49,9 +53,23 @@ tracked in #146; warm pooling in #145).`,
 			if err != nil {
 				return err
 			}
+			pool := proxy.NewPoolRouter()
+			// Defer pool shutdown so warm sibling children get their
+			// stdin closed (clean exit) when the MCP client closes
+			// our stdin and ServeStdio unwinds. Without this every
+			// pooled sibling would survive the parent. Join any
+			// shutdown error onto the named return so cobra's exit
+			// code reflects "siblings refused to drain" — silently
+			// logging to stderr would let an orphan-process problem
+			// escape with exit 0.
+			defer func() {
+				if cerr := pool.Close(); cerr != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("pool shutdown: %w", cerr))
+				}
+			}()
 			s := internalmcp.NewServer(
 				Version, parserVer, state.targetVersion,
-				internalmcp.WithRouter(proxy.NewSpawnRouter()),
+				internalmcp.WithRouter(pool),
 			)
 			// Wrap the transport error so a failure in the stdio loop
 			// surfaces through cobra's "Error:" line as obviously

--- a/internal/mcp/cross_version_mcp_integration_test.go
+++ b/internal/mcp/cross_version_mcp_integration_test.go
@@ -5,15 +5,18 @@
 
 //go:build integration
 
-// End-to-end test for issue #129: a single long-lived `crdb-sql mcp`
-// server forwards each tool call to the sibling backend whose parser
-// quarter matches the call's target_version. Builds both the latest
-// crdb-sql (v262) and the crdb-sql-v261 sibling into a tempdir, then
-// spawns one MCP server and issues two parse_sql calls — one for
-// each quarter — within the same session. The envelope's
-// parser_version field on each response proves which sibling
-// actually executed the call. Integration-tagged because it pays
-// the `go build` cost twice; run via `make test-integration`.
+// End-to-end test for issues #129 and #145: a single long-lived
+// `crdb-sql mcp` server forwards each tool call to the sibling
+// backend whose parser quarter matches the call's target_version,
+// reusing a warm pooled child for repeated calls to the same
+// target. Builds both the latest crdb-sql (v262) and the
+// crdb-sql-v261 sibling into a tempdir, then spawns one MCP server
+// and issues parse_sql calls — one for each quarter, plus a repeat
+// of the routed (v261) call to exercise the pool's warm-reuse
+// path. The envelope's parser_version field on each response proves
+// which sibling actually executed the call. Integration-tagged
+// because it pays the `go build` cost twice; run via
+// `make test-integration`.
 
 package mcp_test
 
@@ -43,9 +46,12 @@ import (
 // "both quarters now accept it" green-but-meaningless outcome.
 const crossVersionParserDivergentStmt = "ALTER TABLE t ENABLE TRIGGER tr"
 
-// TestPerCallMCPTargetVersionRouting is the demo for issue #129.
-// One MCP server, two tool calls in the same session, two different
-// parsers exercised — proven by the envelope's parser_version field.
+// TestPerCallMCPTargetVersionRouting is the demo for issues #129
+// and #145. One MCP server, multiple tool calls in the same
+// session, two different parsers exercised — proven by the
+// envelope's parser_version field. The routed-call case runs twice
+// back-to-back to exercise the pool's warm-reuse path: the second
+// call must hit the same warm sibling and produce identical output.
 func TestPerCallMCPTargetVersionRouting(t *testing.T) {
 	repoRoot := findMCPRepoRoot(t)
 	binDir := t.TempDir()
@@ -141,11 +147,51 @@ func TestPerCallMCPTargetVersionRouting(t *testing.T) {
 		})
 	}
 
+	t.Run("warm pool reuses sibling for repeat routed call", func(t *testing.T) {
+		// Issue #145: a second routed call to the same target_version
+		// must reuse the warm pooled child rather than spawning a
+		// fresh sibling. This subtest runs after the first routed
+		// call above has already populated the pool with the v261
+		// child, so the reuse path is the only way it can succeed.
+		// We assert on output equivalence (same parser_version, same
+		// SQLSTATE) — not on timing — because timing assertions are
+		// flake-prone on CI. A regression that broke pool reuse
+		// (e.g. spawn-per-call resurrected) would still produce the
+		// right output, but TestPoolWarmReuse pins that case at the
+		// unit level.
+		callCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		var req mcp.CallToolRequest
+		req.Params.Name = "parse_sql"
+		req.Params.Arguments = map[string]any{
+			"sql":            crossVersionParserDivergentStmt,
+			"target_version": "26.1.0",
+		}
+		res, err := c.CallTool(callCtx, req)
+		require.NoError(t, err, "warm-reuse routed call must succeed")
+		require.False(t, res.IsError, "expected envelope-shaped success result")
+		require.Len(t, res.Content, 1)
+		tcText, ok := res.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		var env output.Envelope
+		require.NoError(t, json.Unmarshal([]byte(tcText.Text), &env))
+		require.Equal(t, "v0.26.1", env.ParserVersion,
+			"warm-reuse call must still hit the v261 sibling")
+		var sawSyntaxErr bool
+		for _, e := range env.Errors {
+			if e.Code == "42601" {
+				sawSyntaxErr = true
+				break
+			}
+		}
+		require.True(t, sawSyntaxErr, "warm-reuse call must surface the same v261 parse error")
+	})
+
 	t.Run("missing sibling produces tool error with discovery hint", func(t *testing.T) {
 		// target_version=25.4.0 needs crdb-sql-v254, which we
 		// never built. Two things must hold end-to-end:
 		//   1. the result is an MCP tool error (IsError=true), not
-		//      a JSON-RPC transport error — proves SpawnRouter is
+		//      a JSON-RPC transport error — proves PoolRouter is
 		//      wired (NoopRouter would also produce an error here,
 		//      but its message would say "routing not enabled"
 		//      rather than "not installed");
@@ -171,7 +217,7 @@ func TestPerCallMCPTargetVersionRouting(t *testing.T) {
 		require.Contains(t, tcText.Text, "crdb-sql-v254",
 			"missing-backend message must name the requested sibling")
 		require.Contains(t, tcText.Text, "not installed",
-			"missing-backend message must say the backend is not installed (proves SpawnRouter, not NoopRouter)")
+			"missing-backend message must say the backend is not installed (proves PoolRouter, not NoopRouter)")
 		require.Contains(t, tcText.Text, "crdb-sql-v261",
 			"missing-backend message must list the discovered v261 sibling under 'Available backends'")
 	})

--- a/internal/mcp/proxy/pool.go
+++ b/internal/mcp/proxy/pool.go
@@ -1,0 +1,596 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// Production defaults. Pulled out as named constants so the docs in
+// PoolRouter, the help text in cmd/mcp.go, and the tests all
+// reference one source of truth.
+const (
+	// defaultIdleTimeout is the upper bound on how long a warm
+	// sibling sits unused before the janitor closes it. 5 minutes is
+	// long enough to amortize spawn cost across a typical Claude
+	// Code session and short enough that switching to a different
+	// quarter does not pin the previous sibling's RAM for an hour.
+	defaultIdleTimeout = 5 * time.Minute
+
+	// defaultJanitorTick controls how often the janitor sweeps for
+	// idle entries. Coarse relative to defaultIdleTimeout because
+	// being a minute late on eviction is harmless; the cost of a
+	// shorter tick is goroutine wakeups for nothing.
+	defaultJanitorTick = 1 * time.Minute
+)
+
+// mcpClient is the slice of mark3labs/mcp-go's *client.Client that
+// the pool actually uses. Pulling it behind an interface lets
+// pool_test.go drive deterministic scenarios (transport error on
+// CallTool, slow CallTool, Close error) without spawning real
+// processes. The production spawn function (defaultSpawnFunc) wraps
+// *client.Client to satisfy this interface.
+type mcpClient interface {
+	CallTool(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	Close() error
+}
+
+// spawnFunc launches a sibling at path, runs the MCP initialize
+// handshake under initTimeout, and returns the connected client.
+// want is used only to compose error messages. The pool's
+// production constructor wires defaultSpawnFunc; tests inject a
+// fake.
+type spawnFunc func(
+	ctx context.Context, want versionroute.Quarter, path string, initTimeout time.Duration,
+) (mcpClient, error)
+
+// defaultSpawnFunc is the production spawnFunc: thin shim around
+// spawnAndInit so tests can swap the whole spawn path.
+func defaultSpawnFunc(
+	ctx context.Context, want versionroute.Quarter, path string, initTimeout time.Duration,
+) (mcpClient, error) {
+	c, err := spawnAndInit(ctx, want, path, initTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return clientAdapter{c}, nil
+}
+
+// clientAdapter narrows *client.Client (which has many MCP-protocol
+// methods) to the mcpClient interface the pool depends on.
+type clientAdapter struct{ c *client.Client }
+
+func (a clientAdapter) CallTool(
+	ctx context.Context, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	return a.c.CallTool(ctx, req)
+}
+
+func (a clientAdapter) Close() error { return a.c.Close() }
+
+// PoolRouter implements Router by keeping at most one warm sibling
+// child per Quarter for the life of the parent `crdb-sql mcp`
+// process. The first Dispatch for a Quarter spawns the child and
+// runs the MCP initialize handshake; subsequent Dispatch calls reuse
+// the warm child, amortizing spawn + handshake cost across calls.
+//
+// Lifecycle:
+//   - Lazy spawn: a Quarter's child is only started on the first
+//     Dispatch for that Quarter.
+//   - Bounded concurrency per Quarter: one child, serialized by the
+//     entry's mutex. mark3labs/mcp-go's stdio Client is not safe
+//     for concurrent CallTool, so per-quarter requests queue.
+//   - Idle eviction: the janitor goroutine sweeps every
+//     janitorTick; entries unused for longer than idleTimeout are
+//     closed. The next Dispatch re-spawns transparently.
+//   - Dead-child recovery: if CallTool returns a transport-layer
+//     error, the entry is evicted and closed before Dispatch
+//     returns. The next Dispatch re-spawns transparently.
+//   - Graceful shutdown: Close stops the janitor and closes every
+//     pooled child. cmd/mcp.go defers it after server.ServeStdio
+//     returns so a clean parent exit propagates to all children.
+//
+// The error contract is the same as the package-level Router doc:
+// transport failures (spawn, init, broken pipe) propagate as Go
+// errors; missing-sibling and tool-level failures come back as
+// IsError=true *mcp.CallToolResult with a nil error.
+type PoolRouter struct {
+	// initTimeout caps the MCP initialize handshake on each spawned
+	// child. Per-tool-call timeouts flow from the ctx the caller
+	// supplies to Dispatch.
+	initTimeout time.Duration
+
+	// idleTimeout is the upper bound on how long a warm child sits
+	// unused before the janitor closes it.
+	idleTimeout time.Duration
+
+	// janitorTick is the period of the eviction sweep. Coarser than
+	// idleTimeout — eviction is best-effort, not a hard deadline.
+	janitorTick time.Duration
+
+	// spawn launches and initializes a sibling. Replaceable for
+	// tests; production wiring uses defaultSpawnFunc.
+	spawn spawnFunc
+
+	// nowFn returns the current time. Replaceable for tests so
+	// idle-eviction can be exercised without sleeping.
+	nowFn func() time.Time
+
+	// dispatchAfterCheckout, when non-nil, is called inside
+	// Dispatch after checkout returns and before the entry's mutex
+	// is acquired. Test-only hook (set via withDispatchAfterCheckout)
+	// for deterministically forcing the eviction-race retry path —
+	// without it, that path is timing-dependent and impossible to
+	// exercise without sleeping. nil in production.
+	dispatchAfterCheckout func(versionroute.Quarter, *pooledEntry)
+
+	// mu protects entries, closed, and each entry's lastUsed/dead
+	// fields. It does NOT protect entry.client or the entry's
+	// embedded Mutex — those are owned by the entry itself so a
+	// long-running CallTool against one quarter does not block
+	// lookups for another.
+	//
+	// Lock ordering: when both mu and an entry's mutex are needed,
+	// mu is taken first OR released before the entry's mutex is
+	// acquired. The reverse order — holding an entry's mutex and
+	// then taking mu — is permitted only for the brief, leaf-level
+	// updates in markUsed and evict, where mu is released before
+	// any further work. Sweep and Close always release mu before
+	// taking an entry's mutex; that asymmetry, plus the
+	// release-before-work rule, prevents a cycle.
+	mu      sync.Mutex
+	entries map[versionroute.Quarter]*pooledEntry
+	closed  bool
+
+	// stopJanitor cancels the janitor goroutine's context. Set in
+	// NewPoolRouter; nil after Close.
+	stopJanitor context.CancelFunc
+
+	// janitorDone is closed when the janitor goroutine exits, so
+	// Close can wait for it before returning. Nil if the janitor
+	// was never started (idleTimeout <= 0).
+	janitorDone chan struct{}
+}
+
+// pooledEntry holds one warm sibling child for one Quarter.
+//
+// Lifecycle: created by Dispatch on first call for the quarter
+// (with client = nil), initialized under the entry's mutex by the
+// same Dispatch (or a later one if init failed), reused by
+// subsequent Dispatch calls under the same mutex, evicted by the
+// janitor after idleTimeout or on the spot when CallTool returns a
+// transport error. After eviction the entry is dropped from
+// PoolRouter.entries and the next Dispatch for the quarter creates
+// a fresh entry.
+//
+// Embedded sync.Mutex serializes both lazy initialization and
+// CallTool against client. mark3labs/mcp-go's stdio Client is not
+// concurrency-safe for CallTool, so per-quarter requests queue
+// here.
+//
+// quarter and path are immutable after construction (set in
+// PoolRouter.checkout, never written again).
+type pooledEntry struct {
+	sync.Mutex
+	quarter versionroute.Quarter
+	path    string
+
+	// client is nil until the first successful spawn-and-init,
+	// reset to nil by the eviction or Close paths after the
+	// underlying client is closed. Read and written under the
+	// embedded Mutex.
+	client mcpClient
+
+	// lastUsed tracks the wall-clock time of the last successful
+	// Dispatch interaction with this entry. Written by checkout
+	// (when reusing a warm entry) and by markUsed (after a
+	// successful CallTool). Transport errors do not update
+	// lastUsed — they evict the entry instead. Read by the janitor
+	// under PoolRouter.mu, so it can scan idleness without blocking
+	// on an in-flight CallTool.
+	lastUsed time.Time
+
+	// dead, when true, marks the entry as evicted from
+	// PoolRouter.entries; a Dispatch goroutine that won the entry's
+	// mutex on a stale pointer must retry checkout rather than
+	// re-spawning into a slot no future caller can find. Always
+	// read and written under PoolRouter.mu (evict, sweepIdle, and
+	// Close all set it under that lock).
+	dead bool
+}
+
+// PoolOption configures NewPoolRouter. Matches the project's
+// functional-options convention (.claude/rules/go-conventions.md).
+type PoolOption interface {
+	apply(*PoolRouter)
+}
+
+type poolOptionFunc func(*PoolRouter)
+
+func (f poolOptionFunc) apply(p *PoolRouter) { f(p) }
+
+// WithIdleTimeout overrides the default idle-eviction window. A
+// non-positive value disables idle eviction entirely (warm children
+// live until Close).
+func WithIdleTimeout(d time.Duration) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.idleTimeout = d })
+}
+
+// WithInitTimeout overrides the default MCP initialize handshake
+// budget. Must be positive.
+func WithInitTimeout(d time.Duration) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.initTimeout = d })
+}
+
+// withJanitorTick overrides the janitor sweep interval. Test-only;
+// production callers want the default. Exported lowercase so the
+// test file in the same package can use it.
+func withJanitorTick(d time.Duration) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.janitorTick = d })
+}
+
+// withSpawn replaces the spawn function. Test-only.
+func withSpawn(s spawnFunc) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.spawn = s })
+}
+
+// withClock replaces the time source. Test-only.
+func withClock(now func() time.Time) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.nowFn = now })
+}
+
+// withDispatchAfterCheckout installs a hook that runs in Dispatch
+// after checkout returns and before the entry's mutex is acquired.
+// Test-only — lets a test deterministically evict an entry inside
+// that window to exercise Dispatch's dead-entry retry loop.
+func withDispatchAfterCheckout(fn func(versionroute.Quarter, *pooledEntry)) PoolOption {
+	return poolOptionFunc(func(p *PoolRouter) { p.dispatchAfterCheckout = fn })
+}
+
+// NewPoolRouter returns a pool with production defaults: 10s init
+// timeout, 5m idle window, 1m janitor tick. The janitor goroutine
+// starts immediately and stops on Close. Pass options to override
+// any default.
+func NewPoolRouter(opts ...PoolOption) *PoolRouter {
+	p := &PoolRouter{
+		initTimeout: defaultInitTimeout,
+		idleTimeout: defaultIdleTimeout,
+		janitorTick: defaultJanitorTick,
+		spawn:       defaultSpawnFunc,
+		nowFn:       time.Now,
+		entries:     map[versionroute.Quarter]*pooledEntry{},
+	}
+	for _, opt := range opts {
+		opt.apply(p)
+	}
+	if p.idleTimeout > 0 && p.janitorTick > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		p.stopJanitor = cancel
+		p.janitorDone = make(chan struct{})
+		go p.runJanitor(ctx)
+	}
+	return p
+}
+
+// Dispatch implements Router. See PoolRouter's doc for the
+// lifecycle and the package-level Router doc for the error
+// contract. After Close, every Dispatch returns a transport error
+// naming the closed pool — not a tool-error result, because the
+// caller's per-call timeout is irrelevant at that point and the
+// shape matches "the connection is gone".
+func (p *PoolRouter) Dispatch(
+	ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	// Retry loop handles the narrow window where a goroutine has
+	// checked out an entry but, before acquiring the entry's mutex,
+	// the janitor or a sibling Dispatch evicted it. Without the
+	// retry, a re-spawn here would write a brand-new client into a
+	// dead entry that no future caller can find — leaking the
+	// child. The bound is the count of consecutive evictions we
+	// race with, which is in practice 1 or 2.
+	for attempt := 0; ; attempt++ {
+		entry, err := p.checkout(want)
+		if err != nil {
+			return nil, err
+		}
+		if entry == nil {
+			// FindBackend reported the sibling is not installed.
+			// Tool-level error, no entry created.
+			return missingBackendResult(want), nil
+		}
+
+		// Test-only hook: lets the C1 retry-path test force an
+		// eviction inside the checkout-to-Lock window so the
+		// `if entry.dead` branch below is observably reached.
+		// nil in production.
+		if hook := p.dispatchAfterCheckout; hook != nil {
+			hook(want, entry)
+		}
+
+		// Take the entry's mutex before touching client so concurrent
+		// Dispatch calls for the same quarter serialize. Any goroutine
+		// that wins the lock first does the lazy init; the rest see a
+		// non-nil client and skip straight to CallTool.
+		entry.Lock()
+		if entry.dead {
+			// Lost the race with eviction. Release the mutex
+			// (under which dead is now safe to re-read alongside
+			// pool.mu's writers) and start over with a fresh
+			// checkout.
+			entry.Unlock()
+			if attempt > 16 {
+				// Defensive: the retry loop should converge in
+				// 1-2 attempts in any realistic scenario.
+				// Surface a transport error rather than spin.
+				return nil, fmt.Errorf("dispatch %s: pool churn — gave up after %d eviction races",
+					want.BackendName(), attempt)
+			}
+			continue
+		}
+		return p.dispatchLocked(ctx, want, req, entry)
+	}
+}
+
+// dispatchLocked runs the spawn-or-reuse + CallTool path with
+// entry's mutex held. It is responsible for releasing the mutex
+// before any slow Close on the transport-error path so the caller
+// is not pinned by mark3labs/mcp-go's shutdown grace (~8s worst
+// case). Returns the same (result, error) shape as Dispatch.
+func (p *PoolRouter) dispatchLocked(
+	ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest, entry *pooledEntry,
+) (*mcp.CallToolResult, error) {
+	if entry.client == nil {
+		c, err := p.spawn(ctx, want, entry.path, p.initTimeout)
+		if err != nil {
+			// Init failed — drop the empty entry so the next
+			// Dispatch can retry with a fresh one rather than
+			// re-using a poisoned slot. There is no client to
+			// close yet (spawnAndInit tears down on failure).
+			entry.Unlock()
+			_ = p.evict(want, entry, nil /* clientToClose */)
+			return nil, err
+		}
+		entry.client = c
+	}
+
+	res, callErr := entry.client.CallTool(ctx, req)
+	if callErr != nil {
+		// Transport-layer failure (broken pipe, framing error,
+		// child exited): the connection is unusable. Capture the
+		// client locally, nil it out under the mutex, then release
+		// the mutex BEFORE closing — mcp-go's Client.Close can
+		// take several seconds (stdin EOF + SIGTERM + SIGKILL with
+		// grace windows), and holding the mutex through that would
+		// pin every queued Dispatch on this Quarter for the same
+		// duration even though they all need a fresh entry.
+		dead := entry.client
+		entry.client = nil
+		entry.Unlock()
+		closeErr := p.evict(want, entry, dead)
+		wrapped := fmt.Errorf("forward tools/call to %s (%s): %w",
+			want.BackendName(), entry.path, callErr)
+		if closeErr != nil {
+			// Surface the close-time failure alongside the
+			// transport error so the operator sees both signals
+			// in one message rather than a clean error here plus
+			// a stderr line nobody reads.
+			return nil, errors.Join(wrapped, fmt.Errorf("close after transport error: %w", closeErr))
+		}
+		return nil, wrapped
+	}
+
+	entry.Unlock()
+	p.markUsed(entry)
+	return res, nil
+}
+
+// checkout returns the pooled entry for want, creating it lazily.
+// Returns (nil, nil) when the sibling is not installed (caller
+// must surface a missing-backend result). Returns (nil, err) when
+// the pool is closed.
+func (p *PoolRouter) checkout(want versionroute.Quarter) (*pooledEntry, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil, errors.New("crdb-sql mcp pool: closed")
+	}
+	if entry, ok := p.entries[want]; ok && !entry.dead {
+		entry.lastUsed = p.nowFn()
+		return entry, nil
+	}
+	path, found := versionroute.FindBackend(want)
+	if !found {
+		return nil, nil
+	}
+	entry := &pooledEntry{
+		quarter:  want,
+		path:     path,
+		lastUsed: p.nowFn(),
+	}
+	p.entries[want] = entry
+	return entry, nil
+}
+
+// markUsed updates an entry's lastUsed timestamp so the janitor
+// resets its idle clock. Skips dead entries — a successful
+// CallTool can race with eviction; updating lastUsed on an entry
+// that no future caller can find would silently mutate dead state
+// and make debugging confusing.
+func (p *PoolRouter) markUsed(entry *pooledEntry) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if entry.dead {
+		return
+	}
+	entry.lastUsed = p.nowFn()
+}
+
+// evict removes entry from the pool's map and, if clientToClose is
+// non-nil, closes it. The close error is returned so the caller
+// (Dispatch's transport-error path) can join it onto the user-
+// visible error rather than only logging to stderr. The janitor
+// path (sweepIdle) does not call evict; it does its own
+// remove-then-close because its caller has nowhere to surface
+// errors except stderr.
+func (p *PoolRouter) evict(
+	want versionroute.Quarter, entry *pooledEntry, clientToClose mcpClient,
+) error {
+	p.mu.Lock()
+	if cur, ok := p.entries[want]; ok && cur == entry {
+		delete(p.entries, want)
+	}
+	entry.dead = true
+	p.mu.Unlock()
+	if clientToClose == nil {
+		return nil
+	}
+	if err := clientToClose.Close(); err != nil {
+		return fmt.Errorf("close evicted sibling %s (%s): %w",
+			want.BackendName(), entry.path, err)
+	}
+	return nil
+}
+
+// runJanitor sweeps for idle entries every janitorTick and closes
+// any whose lastUsed is older than idleTimeout. Exits when ctx is
+// cancelled (Close). The sweep removes idle entries from
+// PoolRouter.entries under pool.mu first (so no future Dispatch
+// can find them), then takes each victim's mutex outside pool.mu
+// to wait for any in-flight CallTool to finish before closing the
+// underlying pipe. Worst-case wait per victim is one in-flight
+// CallTool's remaining ctx deadline plus mcp-go's Close grace
+// (~8s — see Close's doc).
+func (p *PoolRouter) runJanitor(ctx context.Context) {
+	defer close(p.janitorDone)
+	t := time.NewTicker(p.janitorTick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			p.sweepIdle()
+		}
+	}
+}
+
+// sweepIdle is the body of one janitor tick. Pulled out so tests
+// can drive an eviction without depending on real-time tickers.
+// A non-positive idleTimeout disables eviction entirely — the
+// production NewPoolRouter never starts the janitor in that case,
+// but a test that calls sweepIdle directly must still be a no-op
+// so WithIdleTimeout(0) means "warm forever."
+func (p *PoolRouter) sweepIdle() {
+	if p.idleTimeout <= 0 {
+		return
+	}
+	now := p.nowFn()
+	p.mu.Lock()
+	type victim struct {
+		want  versionroute.Quarter
+		entry *pooledEntry
+	}
+	var victims []victim
+	for want, entry := range p.entries {
+		if now.Sub(entry.lastUsed) >= p.idleTimeout {
+			entry.dead = true
+			delete(p.entries, want)
+			victims = append(victims, victim{want, entry})
+		}
+	}
+	p.mu.Unlock()
+
+	// Close victims outside pool.mu so a slow Close (child not
+	// exiting promptly) does not block lookups for other quarters.
+	// Each victim's mutex must be taken to wait for any in-flight
+	// CallTool to finish before closing the underlying pipe;
+	// otherwise we'd close stdout out from under a goroutine
+	// reading the response. Stderr is the only sink available — the
+	// janitor has no caller to surface errors to.
+	for _, v := range victims {
+		v.entry.Lock()
+		c := v.entry.client
+		v.entry.client = nil
+		v.entry.Unlock()
+		if c == nil {
+			continue
+		}
+		if err := c.Close(); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"crdb-sql mcp pool: close idle sibling %s (%s): %v\n",
+				v.want.BackendName(), v.entry.path, err)
+		}
+	}
+}
+
+// Close stops the janitor and closes every pooled child. The
+// first call returns the joined Close errors from any pooled
+// children (nil when every child closed cleanly); subsequent calls
+// are no-ops that return nil. After Close, every Dispatch returns
+// a transport-level "pool: closed" error.
+//
+// Close holds each entry's mutex briefly to wait for any in-flight
+// CallTool. A misbehaving sibling that ignores stdin EOF is killed
+// by mark3labs/mcp-go's Client.Close, which escalates stdin EOF →
+// SIGTERM (after ~2s) → SIGKILL (after a further ~3s) with another
+// ~3s grace, so a single hung child can stall Close for up to ~8s.
+// We do not add a second timer on top of that.
+func (p *PoolRouter) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	stop := p.stopJanitor
+	done := p.janitorDone
+	entries := p.entries
+	p.entries = nil
+	// Mark every entry dead while still under pool.mu. A Dispatch
+	// goroutine that finished CallTool concurrently with Close may
+	// be waiting to enter markUsed (which takes pool.mu); doing
+	// the dead-write here ensures markUsed observes dead==true
+	// under the same lock and skips its update — which is the
+	// race the detector catches if the dead-write moves outside
+	// pool.mu.
+	for _, entry := range entries {
+		entry.dead = true
+	}
+	p.mu.Unlock()
+
+	if stop != nil {
+		stop()
+	}
+	if done != nil {
+		<-done
+	}
+
+	var errs []error
+	for want, entry := range entries {
+		entry.Lock()
+		c := entry.client
+		entry.client = nil
+		entry.Unlock()
+		if c == nil {
+			continue
+		}
+		if err := c.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close %s (%s): %w",
+				want.BackendName(), entry.path, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/mcp/proxy/pool_test.go
+++ b/internal/mcp/proxy/pool_test.go
@@ -1,0 +1,861 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/versionroute"
+)
+
+// fakeMCPClient is the test double for mcp-go's *client.Client.
+// Each instance represents one warm sibling. The fake records every
+// CallTool entry/exit so tests can assert on serialization, and
+// surfaces errors injected by the test for the transport-failure
+// and broken-Close branches of PoolRouter.
+type fakeMCPClient struct {
+	// callErr, when non-nil, is returned from every CallTool —
+	// drives the dead-child recovery test.
+	callErr error
+
+	// callDelay, when non-zero, blocks CallTool for this long so the
+	// serialization test can prove that two concurrent Dispatches
+	// queue rather than overlap.
+	callDelay time.Duration
+
+	// callEntered, when non-nil, is closed exactly once when
+	// CallTool first enters. Lets tests prove "this point was
+	// reached" without timing assumptions.
+	callEntered chan struct{}
+
+	// callRelease, when non-nil, blocks CallTool until something
+	// is sent on (or the channel is closed). Lets tests pin a
+	// CallTool in flight while they perform another action and
+	// then deterministically release it.
+	callRelease chan struct{}
+
+	// closeErr, when non-nil, is returned from Close.
+	closeErr error
+
+	mu          sync.Mutex
+	calls       int
+	inFlight    int
+	maxInFlight int
+	closed      bool
+	closeCount  int
+}
+
+func (f *fakeMCPClient) CallTool(
+	ctx context.Context, _ mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	f.mu.Lock()
+	f.calls++
+	f.inFlight++
+	if f.inFlight > f.maxInFlight {
+		f.maxInFlight = f.inFlight
+	}
+	delay := f.callDelay
+	entered := f.callEntered
+	release := f.callRelease
+	f.mu.Unlock()
+	if entered != nil {
+		// Signal exactly once across the lifetime of the fake;
+		// guard against repeat entry (would panic on close).
+		f.mu.Lock()
+		if f.callEntered == entered {
+			close(entered)
+			f.callEntered = nil
+		}
+		f.mu.Unlock()
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			f.mu.Lock()
+			f.inFlight--
+			f.mu.Unlock()
+			return nil, ctx.Err()
+		}
+	}
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			f.mu.Lock()
+			f.inFlight--
+			f.mu.Unlock()
+			return nil, ctx.Err()
+		}
+	}
+	f.mu.Lock()
+	f.inFlight--
+	err := f.callErr
+	f.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.CallToolResult{}, nil
+}
+
+func (f *fakeMCPClient) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closeCount++
+	f.closed = true
+	return f.closeErr
+}
+
+func (f *fakeMCPClient) snapshot() (calls int, maxInFlight int, closes int, closed bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, f.maxInFlight, f.closeCount, f.closed
+}
+
+// fakeSpawner returns a spawnFunc that hands out fakeMCPClients per
+// quarter. Use makeFakeSpawner to construct one with a controlled
+// roster; the returned function records every spawn so tests can
+// assert spawn counts.
+type spawnRecord struct {
+	mu      sync.Mutex
+	clients map[versionroute.Quarter][]*fakeMCPClient
+	errs    map[versionroute.Quarter]error
+}
+
+func newSpawnRecord() *spawnRecord {
+	return &spawnRecord{
+		clients: map[versionroute.Quarter][]*fakeMCPClient{},
+		errs:    map[versionroute.Quarter]error{},
+	}
+}
+
+// failNext arms the next spawn for want to return err exactly once.
+func (r *spawnRecord) failNext(want versionroute.Quarter, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errs[want] = err
+}
+
+// spawned returns the slice of clients handed out for want, in
+// spawn order.
+func (r *spawnRecord) spawned(want versionroute.Quarter) []*fakeMCPClient {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*fakeMCPClient, len(r.clients[want]))
+	copy(out, r.clients[want])
+	return out
+}
+
+// allSpawned returns the flat list of every client ever spawned,
+// across all quarters. Useful for "did Close get called on every
+// child" assertions.
+func (r *spawnRecord) allSpawned() []*fakeMCPClient {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*fakeMCPClient
+	for _, cs := range r.clients {
+		out = append(out, cs...)
+	}
+	return out
+}
+
+// asSpawnFunc returns a spawnFunc that, on each call, either fires
+// a queued failNext error or hands out a fresh fakeMCPClient
+// constructed by builder. builder lets tests pre-configure the
+// fake's callErr/callDelay/closeErr without touching the spawn
+// plumbing.
+func (r *spawnRecord) asSpawnFunc(builder func(versionroute.Quarter) *fakeMCPClient) spawnFunc {
+	return func(_ context.Context, want versionroute.Quarter, _ string, _ time.Duration) (mcpClient, error) {
+		r.mu.Lock()
+		if err, ok := r.errs[want]; ok {
+			delete(r.errs, want)
+			r.mu.Unlock()
+			return nil, err
+		}
+		c := builder(want)
+		r.clients[want] = append(r.clients[want], c)
+		r.mu.Unlock()
+		return c, nil
+	}
+}
+
+// installFakeSibling drops an empty 0o755 file named for want's
+// backend into a tempdir and prepends it to PATH so
+// versionroute.FindBackend can locate it. Returns the path. The
+// fake never actually runs — the pool's spawnFunc is replaced via
+// withSpawn — but FindBackend's stat-and-PATH walk needs a real
+// filesystem entry.
+func installFakeSibling(t *testing.T, want versionroute.Quarter) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics + 0o755 perm bits differ on Windows; covered by integration test")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, want.BackendName())
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o755))
+	t.Setenv("PATH", dir)
+	return path
+}
+
+// q is a tiny helper for readability in test setup.
+func q(year, quarter int) versionroute.Quarter {
+	return versionroute.Quarter{Year: year, Q: quarter}
+}
+
+// dispatchOK is shorthand for "Dispatch must succeed and return a
+// non-error result" — most tests don't care about the response
+// shape, only that the call completed.
+func dispatchOK(t *testing.T, p *PoolRouter, want versionroute.Quarter) {
+	t.Helper()
+	res, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, res.IsError, "unexpected tool-level error")
+}
+
+// TestPoolWarmReuse pins the central value proposition: two
+// Dispatch calls for the same quarter share one warm child, so the
+// second call skips spawn-and-init.
+func TestPoolWarmReuse(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0), // disable janitor — test is timing-free
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchOK(t, p, want)
+	dispatchOK(t, p, want)
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1, "second Dispatch must reuse the warm child")
+	calls, _, _, _ := clients[0].snapshot()
+	require.Equal(t, 2, calls, "both Dispatches should hit the same client")
+}
+
+// TestPoolPerQuarterIsolation pins that two distinct quarters get
+// distinct children. A regression that keyed the pool incorrectly
+// (e.g. by path or by backend name string) would surface here as
+// the first quarter's child being reused for the second.
+func TestPoolPerQuarterIsolation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	q1 := q(26, 1)
+	q2 := q(26, 2)
+	dir := t.TempDir()
+	for _, qq := range []versionroute.Quarter{q1, q2} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, qq.BackendName()), []byte{}, 0o755))
+	}
+	t.Setenv("PATH", dir)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchOK(t, p, q1)
+	dispatchOK(t, p, q2)
+	dispatchOK(t, p, q1)
+
+	require.Len(t, rec.spawned(q1), 1)
+	require.Len(t, rec.spawned(q2), 1)
+}
+
+// TestPoolIdleEviction pins that an entry whose lastUsed is older
+// than idleTimeout is closed by the janitor and the next Dispatch
+// re-spawns. Drives the clock manually so the test does not have
+// to wait real time.
+func TestPoolIdleEviction(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	var nowNanos atomic.Int64
+	start := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	nowNanos.Store(start.UnixNano())
+	now := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(5*time.Minute),
+		withJanitorTick(0), // disable background janitor; drive sweepIdle directly
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+		withClock(now),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchOK(t, p, want)
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+
+	// Advance 6 minutes (past idleTimeout) and sweep.
+	nowNanos.Store(start.Add(6 * time.Minute).UnixNano())
+	p.sweepIdle()
+
+	_, _, closes, closed := clients[0].snapshot()
+	require.Equal(t, 1, closes, "evicted child must be closed exactly once")
+	require.True(t, closed)
+
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 2, "post-eviction Dispatch must re-spawn")
+}
+
+// TestPoolDeadChildRecovery pins that a transport error from
+// CallTool evicts the entry, closes the dead child, and that the
+// next Dispatch re-spawns and succeeds. This is the broken-pipe /
+// child-exit recovery path.
+func TestPoolDeadChildRecovery(t *testing.T) {
+	want := q(26, 1)
+	path := installFakeSibling(t, want)
+
+	var spawnIdx atomic.Int32
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			// First spawn returns a client whose CallTool fails;
+			// second spawn returns a healthy client.
+			if spawnIdx.Add(1) == 1 {
+				return &fakeMCPClient{callErr: errors.New("broken pipe")}
+			}
+			return &fakeMCPClient{}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+	require.ErrorContains(t, err, "broken pipe")
+	require.ErrorContains(t, err, want.BackendName())
+	require.ErrorContains(t, err, path,
+		"transport error must include the resolved sibling path so an install/PATH problem is debuggable from one line")
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+	_, _, closes, closed := clients[0].snapshot()
+	require.Equal(t, 1, closes, "dead child must be closed exactly once on transport error")
+	require.True(t, closed)
+
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 2, "post-failure Dispatch must re-spawn transparently")
+}
+
+// TestPoolDeadChildRecoveryJoinsCloseError pins that when the
+// transport-error path's eviction Close ALSO fails, the operator
+// sees both errors joined into Dispatch's return value rather than
+// a clean broken-pipe error here plus a swallowed close failure
+// hidden in stderr. Without this, a sibling that hangs on
+// shutdown after refusing a call would leak silently.
+func TestPoolDeadChildRecoveryJoinsCloseError(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{
+				callErr:  errors.New("broken pipe"),
+				closeErr: errors.New("sibling refused EOF"),
+			}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+	require.ErrorContains(t, err, "broken pipe",
+		"transport error must surface")
+	require.ErrorContains(t, err, "sibling refused EOF",
+		"close-time error must be joined onto the transport error")
+	require.ErrorContains(t, err, "close after transport error",
+		"close failure must be labelled so the operator can tell which step failed")
+}
+
+// TestPoolSerializesSameQuarter pins the bounded-concurrency
+// guarantee from issue #145: mark3labs/mcp-go's stdio Client is not
+// safe for concurrent CallTool, so per-quarter requests must
+// serialize through the entry's mutex. The fake records the
+// observed concurrency level; if the pool ever lets two CallTools
+// run on the same client simultaneously, maxInFlight will be > 1.
+func TestPoolSerializesSameQuarter(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{callDelay: 50 * time.Millisecond}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	const goroutines = 5
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			dispatchOK(t, p, want)
+		}()
+	}
+	wg.Wait()
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1, "all goroutines must share one warm child")
+	calls, maxInFlight, _, _ := clients[0].snapshot()
+	require.Equal(t, goroutines, calls)
+	require.Equal(t, 1, maxInFlight,
+		"per-quarter CallTool must serialize; observed concurrency %d violates mcp-go's contract",
+		maxInFlight)
+}
+
+// TestPoolGracefulShutdown pins that Close stops the janitor,
+// closes every warm child exactly once, and that subsequent
+// Dispatch returns a transport error rather than silently spawning
+// a new child after shutdown.
+func TestPoolGracefulShutdown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	q1 := q(26, 1)
+	q2 := q(26, 2)
+	dir := t.TempDir()
+	for _, qq := range []versionroute.Quarter{q1, q2} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, qq.BackendName()), []byte{}, 0o755))
+	}
+	t.Setenv("PATH", dir)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+	)
+
+	dispatchOK(t, p, q1)
+	dispatchOK(t, p, q2)
+
+	require.NoError(t, p.Close())
+	require.NoError(t, p.Close(), "second Close must be a no-op")
+
+	for _, c := range rec.allSpawned() {
+		_, _, closes, closed := c.snapshot()
+		require.Equal(t, 1, closes, "every pooled child must be closed exactly once")
+		require.True(t, closed)
+	}
+
+	_, err := p.Dispatch(context.Background(), q1, mcp.CallToolRequest{})
+	require.ErrorContains(t, err, "closed",
+		"Dispatch on a closed pool must surface a transport error")
+}
+
+// TestPoolGracefulShutdownReportsCloseErrors pins that Close
+// surfaces close-time errors from the underlying clients, joined
+// across all of them, so a misbehaving sibling is visible to the
+// operator rather than silently swallowed.
+func TestPoolGracefulShutdownReportsCloseErrors(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{closeErr: errors.New("sibling refused EOF")}
+		})),
+	)
+
+	dispatchOK(t, p, want)
+	err := p.Close()
+	require.ErrorContains(t, err, "sibling refused EOF")
+	require.ErrorContains(t, err, want.BackendName())
+}
+
+// TestPoolMissingBackend pins that a Quarter with no installed
+// sibling produces the missing-backend tool error (with the
+// discovery hint) rather than a transport-layer Go error. This is
+// the behavior the deleted SpawnRouter tests covered.
+func TestPoolMissingBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	// Empty PATH so FindBackend has nowhere to look.
+	t.Setenv("PATH", t.TempDir())
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	res, err := p.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
+	require.NoError(t, err, "missing-backend must be a tool error, not a transport error")
+	text := requireToolError(t, res)
+	require.Contains(t, text, fakeQuarter.BackendName())
+	require.Contains(t, text, "not installed")
+	require.Contains(t, text, "Install the "+fakeQuarter.Tag()+" backend")
+
+	require.Empty(t, rec.allSpawned(),
+		"missing-backend path must not call spawn; it's resolved before that")
+}
+
+// TestPoolMissingBackendListsAlternatives pins that the discovery
+// list ("Available backends:") survives the proxy → pool path. The
+// deleted SpawnRouter test covered this for the spawn-per-call
+// router; the pool reuses missingBackendResult verbatim, so the
+// shape is identical.
+func TestPoolMissingBackendListsAlternatives(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH semantics differ on Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "crdb-sql-v261"), []byte{}, 0o755))
+	t.Setenv("PATH", dir)
+
+	p := NewPoolRouter(WithIdleTimeout(0), withSpawn(newSpawnRecord().asSpawnFunc(
+		func(versionroute.Quarter) *fakeMCPClient { return &fakeMCPClient{} },
+	)))
+	t.Cleanup(func() { _ = p.Close() })
+
+	res, err := p.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
+	require.NoError(t, err)
+	text := requireToolError(t, res)
+	require.Contains(t, text, "Available backends:")
+	require.Contains(t, text, "crdb-sql-v261")
+	require.Contains(t, text, fakeQuarter.BackendName())
+}
+
+// TestPoolSpawnFailureDoesNotPoisonEntry pins that a failed
+// spawn-and-init is recoverable: the entry is dropped so the next
+// Dispatch starts from scratch rather than repeatedly hitting the
+// same poisoned slot.
+func TestPoolSpawnFailureDoesNotPoisonEntry(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	rec.failNext(want, errors.New("init failed"))
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+	require.ErrorContains(t, err, "init failed")
+
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 1,
+		"second spawn (after the first failed before recording) is the only successful one")
+}
+
+// TestPoolJanitorRespectsActiveCalls pins that a janitor sweep does
+// not close a child while a CallTool is in flight: the eviction
+// blocks on the entry's mutex until the call completes. The test
+// uses an explicit barrier inside the fake's CallTool so the
+// "sweep was forced to wait" property is observable rather than
+// inferred from timing — a sleep-based version would pass even if
+// the sweep raced and closed the child immediately.
+func TestPoolJanitorRespectsActiveCalls(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	var nowNanos atomic.Int64
+	start := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	nowNanos.Store(start.UnixNano())
+	now := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(1*time.Second),
+		withJanitorTick(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{callEntered: entered, callRelease: release}
+		})),
+		withClock(now),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchDone := make(chan error, 1)
+	go func() {
+		_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+		dispatchDone <- err
+	}()
+
+	// Block until CallTool has entered — Dispatch now holds the
+	// entry's mutex.
+	<-entered
+
+	// Run sweep in a goroutine so we can prove it blocks. Advance
+	// the clock past idleTimeout first.
+	nowNanos.Store(start.Add(2 * time.Second).UnixNano())
+	sweepDone := make(chan struct{})
+	go func() {
+		p.sweepIdle()
+		close(sweepDone)
+	}()
+
+	// Verify the sweep does NOT complete while CallTool is in
+	// flight. 50ms is comfortably more than the runtime would need
+	// to schedule the sweep goroutine; if the sweep had not
+	// blocked, sweepDone would be closed by now.
+	select {
+	case <-sweepDone:
+		t.Fatal("sweepIdle returned while CallTool was still holding the entry mutex — eviction did not wait")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release the in-flight CallTool. Sweep should now be able to
+	// take the entry's mutex and proceed.
+	close(release)
+
+	require.NoError(t, <-dispatchDone, "in-flight CallTool must complete cleanly even when janitor races to evict")
+	select {
+	case <-sweepDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweepIdle did not return after CallTool released the entry mutex")
+	}
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+	_, _, closes, _ := clients[0].snapshot()
+	require.Equal(t, 1, closes, "evicted child must be closed exactly once")
+}
+
+// TestPoolJanitorDoesNotEvictWarmEntries is the negative companion
+// to TestPoolIdleEviction: an entry that has been used recently
+// must survive the sweep.
+func TestPoolJanitorDoesNotEvictWarmEntries(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	var nowNanos atomic.Int64
+	start := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	nowNanos.Store(start.UnixNano())
+	now := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(5*time.Minute),
+		withJanitorTick(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+		withClock(now),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchOK(t, p, want)
+	// Advance 1 minute (well under idleTimeout) and sweep.
+	nowNanos.Store(start.Add(1 * time.Minute).UnixNano())
+	p.sweepIdle()
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+	_, _, closes, _ := clients[0].snapshot()
+	require.Equal(t, 0, closes, "warm child must survive a sweep before idleTimeout elapses")
+
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 1, "second Dispatch must reuse the surviving child")
+}
+
+// TestPoolDispatchRetriesAfterEvictionRace pins the C1 race fix:
+// when an entry is evicted between checkout returning it and
+// Dispatch acquiring its mutex, Dispatch must restart with a
+// fresh checkout rather than re-spawn into the dead entry. The
+// dead-entry path would silently leak the new client because the
+// entry is no longer in PoolRouter.entries — no one will close it.
+//
+// Uses the dispatchAfterCheckout test hook to force the race
+// deterministically: the hook fires after checkout returns the
+// warm entry but before Dispatch can lock it, evicting it under
+// pool.mu so the subsequent Lock observes dead=true.
+func TestPoolDispatchRetriesAfterEvictionRace(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	rec := newSpawnRecord()
+	// hookArmed gates which Dispatch triggers the eviction. The
+	// warm-up call must run normally; the second call exercises
+	// the retry path. Atomic load+store rather than a bool because
+	// the hook may run from a different goroutine in future
+	// extensions.
+	var hookArmed atomic.Bool
+	var p *PoolRouter
+	hook := func(w versionroute.Quarter, entry *pooledEntry) {
+		if !hookArmed.CompareAndSwap(true, false) {
+			return
+		}
+		// Snapshot the warm client under the entry's mutex (the
+		// hook runs before Dispatch's own Lock, so we can take
+		// it freely), then evict-and-close — mirrors the natural
+		// race shape where sweepIdle would do the same thing.
+		entry.Lock()
+		c := entry.client
+		entry.client = nil
+		entry.Unlock()
+		require.NoError(t, p.evict(w, entry, c),
+			"hook's evict must succeed; the production retry path depends on a clean eviction here")
+	}
+	p = NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+		withDispatchAfterCheckout(hook),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	// Warm-up: hook is unarmed so this Dispatch completes the
+	// straight-through path and leaves a live entry in the pool.
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 1, "warm-up Dispatch must spawn exactly once")
+
+	// Arm the hook so the next Dispatch's checkout-to-Lock window
+	// closes with the entry already evicted.
+	hookArmed.Store(true)
+	dispatchOK(t, p, want)
+	require.False(t, hookArmed.Load(), "hook must have consumed its arm signal")
+	require.Len(t, rec.spawned(want), 2,
+		"Dispatch must re-spawn after the dead-entry retry (one warm-up + one retry)")
+
+	clients := rec.spawned(want)
+	_, _, closes0, _ := clients[0].snapshot()
+	require.Equal(t, 1, closes0, "evicted warm child must have been closed by the hook's evict")
+	_, _, closes1, _ := clients[1].snapshot()
+	require.Equal(t, 0, closes1, "post-retry client is still warm in the pool")
+}
+
+// TestPoolWithIdleTimeoutZeroSkipsJanitor pins that
+// WithIdleTimeout(0) opts out of background eviction entirely:
+// no janitor goroutine, and an entry that has been "idle" for an
+// arbitrary duration survives a manual sweepIdle. The behavioral
+// half is the load-bearing assertion; the janitor-not-running half
+// is verified by Close completing without any goroutine wait
+// (other tests' t.Cleanup calls would hang otherwise).
+func TestPoolWithIdleTimeoutZeroSkipsJanitor(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	var nowNanos atomic.Int64
+	start := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	nowNanos.Store(start.UnixNano())
+	now := func() time.Time { return time.Unix(0, nowNanos.Load()) }
+
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{}
+		})),
+		withClock(now),
+	)
+	t.Cleanup(func() { _ = p.Close() })
+
+	dispatchOK(t, p, want)
+	// Advance an unreasonably long time and force a sweep.
+	// Behavior with idleTimeout=0: nothing is ever idle enough.
+	nowNanos.Store(start.Add(48 * time.Hour).UnixNano())
+	p.sweepIdle()
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+	_, _, closes, _ := clients[0].snapshot()
+	require.Equal(t, 0, closes,
+		"WithIdleTimeout(0) must keep the warm child alive indefinitely")
+
+	dispatchOK(t, p, want)
+	require.Len(t, rec.spawned(want), 1, "subsequent Dispatch must reuse the same warm child")
+}
+
+// TestPoolCloseWaitsForActiveDispatch pins that Close blocks on
+// in-flight CallTool rather than yanking the pipe out from under
+// it. Uses the same barrier pattern as
+// TestPoolJanitorRespectsActiveCalls so the wait property is
+// observable, not inferred from timing.
+func TestPoolCloseWaitsForActiveDispatch(t *testing.T) {
+	want := q(26, 1)
+	installFakeSibling(t, want)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	rec := newSpawnRecord()
+	p := NewPoolRouter(
+		WithIdleTimeout(0),
+		withSpawn(rec.asSpawnFunc(func(versionroute.Quarter) *fakeMCPClient {
+			return &fakeMCPClient{callEntered: entered, callRelease: release}
+		})),
+	)
+
+	dispatchDone := make(chan error, 1)
+	go func() {
+		_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+		dispatchDone <- err
+	}()
+	<-entered
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- p.Close()
+	}()
+
+	// Close must NOT complete while CallTool is still in flight —
+	// it should be blocked on the entry's mutex.
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned (err=%v) while CallTool was still holding the entry mutex", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+
+	require.NoError(t, <-dispatchDone, "in-flight CallTool must complete cleanly during Close drain")
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err, "graceful Close after drain must succeed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return after CallTool released the entry mutex")
+	}
+
+	clients := rec.spawned(want)
+	require.Len(t, clients, 1)
+	_, _, closes, _ := clients[0].snapshot()
+	require.Equal(t, 1, closes, "warm child must be closed exactly once during graceful drain")
+
+	// Post-Close Dispatch must surface the closed-pool error.
+	_, err := p.Dispatch(context.Background(), want, mcp.CallToolRequest{})
+	require.ErrorContains(t, err, "closed")
+}

--- a/internal/mcp/proxy/proxy.go
+++ b/internal/mcp/proxy/proxy.go
@@ -16,17 +16,19 @@
 // dispatch share one source of truth for "where do my siblings
 // live?" and "what backend do I need for v26.1?".
 //
-// SpawnRouter is the first cut from issue #129: spawn the sibling
-// per call, run the MCP initialize handshake, forward one tools/call,
-// tear it down. The latency cost (process startup + handshake on
-// every routed call) is documented; warm pooling is tracked in #145.
+// PoolRouter (pool.go) is the production implementation: one warm
+// child per quarter, lazy spawn on first call, idle eviction after
+// a configurable window, transparent re-spawn on transport failure.
+// It implements issue #145 and replaces the spawn-per-call first
+// cut from #129. NoopRouter is the default when no Router is
+// installed; it surfaces a "routing not enabled" tool error rather
+// than silently dispatching locally.
 package proxy
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -59,10 +61,10 @@ import (
 //     error. The wrapper forwards these verbatim so the client
 //     sees the same shape it would for a local tool error.
 //
-// SpawnRouter (and any future Router that constructs results
-// itself) must NOT touch output.Envelope — those results bypass
-// the local handler's envelope stamping entirely, so the saved
-// "preserve env.Errors" rule does not apply here.
+// A Router that constructs results itself (NoopRouter,
+// missingBackendResult) must NOT touch output.Envelope — those
+// results bypass the local handler's envelope stamping entirely, so
+// the saved "preserve env.Errors" rule does not apply here.
 type Router interface {
 	Dispatch(
 		ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
@@ -96,68 +98,31 @@ func (NoopRouter) Dispatch(
 // same flake floor.
 const defaultInitTimeout = 10 * time.Second
 
-// SpawnRouter implements Router by spawning a sibling backend as a
-// child MCP server over stdio per call: locate the backend via
-// versionroute.FindBackend, exec it with `mcp` as the subcommand,
-// run the MCP initialize handshake, forward the single tools/call,
-// and tear the child down via client.Close.
+// spawnAndInit launches the sibling at path as a child MCP server
+// over stdio, runs the MCP initialize handshake against it under
+// initTimeout, and returns the connected client. On any error the
+// returned client is nil and the child has been torn down (no leak).
 //
-// This is the spawn-per-call first cut described in issue #129. The
-// per-call cost is one process spawn plus one MCP handshake on top
-// of the actual tool work; warm pooling that amortizes both is
-// tracked in #145, with a benchmark in #146.
-type SpawnRouter struct {
-	// initTimeout caps the MCP initialize handshake on each spawned
-	// child. The per-tool-call timeout flows from the ctx the
-	// caller supplies to Dispatch.
-	initTimeout time.Duration
-}
-
-// NewSpawnRouter returns a SpawnRouter with the package's default
-// init timeout. Production callers (cmd/mcp.go) use this; tests that
-// need a tighter handshake budget can construct SpawnRouter
-// directly.
-func NewSpawnRouter() *SpawnRouter {
-	return &SpawnRouter{initTimeout: defaultInitTimeout}
-}
-
-// Dispatch spawns the sibling matching want, performs the MCP
-// initialize handshake, forwards req, and returns the sibling's
-// CallToolResult. See the Router interface comment for the
-// transport-vs-tool error distinction.
-func (r *SpawnRouter) Dispatch(
-	ctx context.Context, want versionroute.Quarter, req mcp.CallToolRequest,
-) (*mcp.CallToolResult, error) {
-	path, found := versionroute.FindBackend(want)
-	if !found {
-		return missingBackendResult(want), nil
-	}
-
-	// nil env hands the parent's full environment to the child so any
-	// per-tool environment knobs (DSNs, COCKROACH_BIN for explain_sql,
-	// etc.) reach the sibling unchanged. The child also inherits
-	// stderr, so its diagnostics are visible alongside the parent's —
-	// load-bearing for debugging routed-call failures. Same reasoning
-	// as internal/mcp/integration_test.go newMCPClient.
+// nil env in NewStdioMCPClient hands the parent's full environment
+// to the child so any per-tool environment knobs (DSNs,
+// COCKROACH_BIN for explain_sql, etc.) reach the sibling unchanged.
+// The child also inherits stderr, so its diagnostics are visible
+// alongside the parent's — load-bearing for debugging routed-call
+// failures. Same reasoning as internal/mcp/integration_test.go's
+// newMCPClient.
+//
+// want is only used to compose a clear error message ("initialize
+// crdb-sql-v261 (/usr/local/bin/crdb-sql-v261): ..."); path is the
+// resolved binary location.
+func spawnAndInit(
+	ctx context.Context, want versionroute.Quarter, path string, initTimeout time.Duration,
+) (*client.Client, error) {
 	c, err := client.NewStdioMCPClient(path, nil /* env */, "mcp")
 	if err != nil {
 		return nil, fmt.Errorf("spawn %s: %w", path, err)
 	}
-	defer func() {
-		// Surface close errors to stderr rather than swallow them:
-		// a Close failure typically means the sibling crashed or
-		// hung mid-call, and silently dropping that signal hides
-		// process-leak regressions. Use stderr (not the envelope)
-		// because Dispatch has already returned its result by the
-		// time this fires.
-		if err := c.Close(); err != nil {
-			fmt.Fprintf(os.Stderr,
-				"crdb-sql mcp proxy: close sibling %s (%s): %v\n",
-				want.BackendName(), path, err)
-		}
-	}()
 
-	initCtx, cancel := context.WithTimeout(ctx, r.initTimeout)
+	initCtx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 	var initReq mcp.InitializeRequest
 	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
@@ -166,25 +131,30 @@ func (r *SpawnRouter) Dispatch(
 		Version: "0.0.0",
 	}
 	if _, err := c.Initialize(initCtx, initReq); err != nil {
+		// Tear the child down so a failed handshake does not leak a
+		// running subprocess. Surface any close-time error by
+		// joining it with the original — the operator needs both:
+		// what failed (init) and any cascading shutdown trouble.
+		closeErr := c.Close()
 		// Distinguish "init budget exhausted" from "init failed for
 		// some other reason" so the operator-facing message names
 		// the budget rather than leaving the cause as a generic
 		// "context deadline exceeded".
+		var wrapped error
 		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf(
+			wrapped = fmt.Errorf(
 				"initialize %s (%s): exceeded init timeout %s: %w",
-				want.BackendName(), path, r.initTimeout, err)
+				want.BackendName(), path, initTimeout, err)
+		} else {
+			wrapped = fmt.Errorf("initialize %s (%s): %w",
+				want.BackendName(), path, err)
 		}
-		return nil, fmt.Errorf("initialize %s (%s): %w",
-			want.BackendName(), path, err)
+		if closeErr != nil {
+			return nil, errors.Join(wrapped, fmt.Errorf("close after failed init: %w", closeErr))
+		}
+		return nil, wrapped
 	}
-
-	res, err := c.CallTool(ctx, req)
-	if err != nil {
-		return nil, fmt.Errorf("forward tools/call to %s (%s): %w",
-			want.BackendName(), path, err)
-	}
-	return res, nil
+	return c, nil
 }
 
 // missingBackendResult builds a tool-error CallToolResult whose

--- a/internal/mcp/proxy/proxy_test.go
+++ b/internal/mcp/proxy/proxy_test.go
@@ -7,9 +7,6 @@ package proxy
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -19,9 +16,9 @@ import (
 )
 
 // fakeQuarter is a Year.Quarter combination that is extremely
-// unlikely to be installed on any developer machine. SpawnRouter's
-// missing-backend tests target it so the test does not depend on the
-// host having (or not having) any specific sibling binary.
+// unlikely to be installed on any developer machine. Tests that
+// exercise missing-backend behavior target it so they do not depend
+// on the host having (or not having) any specific sibling binary.
 var fakeQuarter = versionroute.Quarter{Year: 99, Q: 4}
 
 // requireToolError asserts that res is a tool-level error and
@@ -43,7 +40,7 @@ func requireToolError(t *testing.T, res *mcp.CallToolResult) string {
 
 // TestNoopRouterReturnsToolError pins that the default Router does
 // not silently fall through. A wiring regression that left NoopRouter
-// in place where SpawnRouter was intended must surface as a clear
+// in place where PoolRouter was intended must surface as a clear
 // "routing not enabled" message rather than a confusing "answered
 // with the wrong parser" envelope.
 func TestNoopRouterReturnsToolError(t *testing.T) {
@@ -52,62 +49,4 @@ func TestNoopRouterReturnsToolError(t *testing.T) {
 	text := requireToolError(t, res)
 	require.Contains(t, text, "not enabled")
 	require.Contains(t, text, fakeQuarter.BackendName())
-}
-
-// TestSpawnRouterMissingBackendReportsDiscoveryHint pins the user-
-// facing missing-backend message. The wording deliberately mirrors
-// the CLI's writeMissingBackendError so an operator hitting either
-// surface sees the same diagnostic shape: which backend was needed,
-// what the running binary is, what alternatives exist, and the
-// install hint.
-func TestSpawnRouterMissingBackendReportsDiscoveryHint(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("PATH semantics + 0o755 perm bits differ on Windows; covered by integration test")
-	}
-	// Empty PATH so the only place FindBackend looks is the test
-	// binary's directory, which never contains a crdb-sql-v994.
-	t.Setenv("PATH", t.TempDir())
-
-	r := NewSpawnRouter()
-	res, err := r.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
-	require.NoError(t, err, "missing-backend must be a tool error, not a transport error")
-	text := requireToolError(t, res)
-	require.Contains(t, text, fakeQuarter.BackendName(),
-		"message must name the requested backend")
-	require.Contains(t, text, "not installed",
-		"message must explicitly state the backend is missing")
-	require.Contains(t, text, "Install the "+fakeQuarter.Tag()+" backend",
-		"message must give the install hint with the backend tag")
-}
-
-// TestSpawnRouterMissingBackendListsDiscoveredAlternatives covers
-// the missing-backend message's "Available backends" branch by
-// dropping a fake sibling into a tempdir on PATH. Without this
-// test the discovery-list formatting (column widths, IsSelf
-// rendering, BackendName for each entry) is uncovered, and a
-// regression that breaks operator-facing diagnostics — e.g.
-// rendering paths without their backend names — would slip past
-// TestSpawnRouterMissingBackendReportsDiscoveryHint, which
-// exercises only the no-backends branch.
-func TestSpawnRouterMissingBackendListsDiscoveredAlternatives(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("PATH semantics + 0o755 perm bits differ on Windows; covered by integration test")
-	}
-	dir := t.TempDir()
-	// Drop a fake sibling for v26.1 so Discover finds it. Empty
-	// file with the executable bit set is enough — isExecutable
-	// keys on the bit, not the contents.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "crdb-sql-v261"), []byte{}, 0o755))
-	t.Setenv("PATH", dir)
-
-	r := NewSpawnRouter()
-	res, err := r.Dispatch(context.Background(), fakeQuarter, mcp.CallToolRequest{})
-	require.NoError(t, err)
-	text := requireToolError(t, res)
-	require.Contains(t, text, "Available backends:",
-		"discovered backends must be listed under the Available backends header")
-	require.Contains(t, text, "crdb-sql-v261",
-		"the v261 sibling we planted must appear in the discovered list")
-	require.Contains(t, text, fakeQuarter.BackendName(),
-		"the missing backend's name must still appear so the operator knows what's needed")
 }


### PR DESCRIPTION
The first cut of per-call target_version routing (#129) spawned a
fresh sibling crdb-sql-vXXX subprocess per routed tool call, paid
the MCP initialize handshake, forwarded the call, and tore the
child down. Every routed call paid full process-spawn plus
handshake cost.

PoolRouter replaces that spawn-per-call SpawnRouter: at most one
warm child per versionroute.Quarter for the life of the parent
mcp server, lazy-spawned on first request for that quarter, idle-
evicted after 5 minutes, transparently re-spawned after a
transport failure or eviction. Per-quarter requests serialize
through the entry's mutex because mark3labs/mcp-go's stdio Client
is not safe for concurrent CallTool. cmd/mcp.go defers pool.Close
after server.ServeStdio returns so a clean parent exit closes
every warm sibling's stdin and lets the child exit cleanly; any
shutdown error is joined onto the cobra exit code so an orphan-
process problem does not escape with exit 0.

The Router interface and error contract are unchanged: transport
failures propagate as Go errors, missing-sibling and tool-level
failures return as IsError=true CallToolResult with a nil error.
SpawnRouter is removed; the spawn-and-initialize body becomes a
private helper (spawnAndInit) shared with the pool. NoopRouter
and missingBackendResult are unchanged.

pool_test.go uses an injected mcpClient interface and clock to
cover warm reuse, per-quarter isolation, idle eviction, dead-
child recovery (including the joined-Close-error surface),
per-quarter serialization, graceful shutdown (every child closed
exactly once, post-Close Dispatch surfaces "closed", Close waits
for in-flight CallTool), close-error reporting, missing-backend
hint surface, janitor-respects-active-calls (deterministic via
barrier channels), and the dead-entry retry path that prevents
re-spawning into an evicted slot. The integration test gains a
warm-reuse subtest that issues a second routed v261 call after
the first and asserts identical envelope output.

Resolves: #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)