### PR TITLE
mcp: clarify detect_risky_query is parser-only static analysis

### DIFF
--- a/internal/mcp/tools/detect_risky_query.go
+++ b/internal/mcp/tools/detect_risky_query.go
@@ -23,7 +23,7 @@ import (
 func DetectRiskyQueryTool() mcp.Tool {
 	return mcp.NewTool(
 		DetectRiskyQueryToolName,
-		mcp.WithDescription("Detect risky SQL patterns such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints."),
+		mcp.WithDescription("Detect risky SQL patterns via AST walk (parser-only; no cluster contact, no statement execution). Flags issues such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)


### PR DESCRIPTION
The MCP tool description led with \"Detect risky SQL patterns ...\" with
no signal that the analysis is purely static. The other static-analysis
tools advertise their mechanism in the description (summarize_sql:
\"via AST walk\"), and the cluster-touching tools that wrap a statement
without running it say so explicitly (explain_sql: \"The wrapped
statement is not executed\"). detect_risky_query was the outlier — its
description was silent on whether it touched a cluster, leaving an
agent to infer from the missing dsn parameter.

Mirror the summarize_sql lead-with-mechanism style and add an explicit
\"no cluster contact, no statement execution\" parenthetical so an agent
deciding whether to call detect_risky_query before execute_sql does not
have to guess.

CLI help text already says \"AST-only\" in cmd/risk.go and is unchanged.