### PR TITLE
release: fix snapshot build for per-quarter sibling

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,9 @@ builds:
   #      STUBS_VERSION=vN.M`).
   #   3. Create build/go.vNM.mod referencing the new fork tag.
   #   4. Append a builds: entry below mirroring this one but with
-  #      binary: crdb-sql-vNM, gomod.modfile: build/go.vNM.mod, and
+  #      binary: crdb-sql-vNM, an extra flags: entry
+  #      `-modfile=build/go.vNM.mod` (goreleaser v2 has no per-build
+  #      gomod key — the modfile rides on go build's own flags), and
   #      ldflag stamp builtQuarterStamp=vNM.
   # Then update build/parser-versions.yaml's quarters list and the
   # Makefile QUARTERS variable so `make build-all` picks it up.
@@ -67,10 +69,8 @@ builds:
   # requests --target-version 26.1.x. Built against the v0.26.1 parser
   # fork via build/go.v261.mod's replace directive.
   - id: crdb-sql-v261
-    main: .
+    main: ./cmd/crdb-sql
     binary: crdb-sql-v261
-    gomod:
-      modfile: build/go.v261.mod
     env:
       - CGO_ENABLED=0
     goos:
@@ -81,6 +81,7 @@ builds:
       - arm64
     flags:
       - -trimpath
+      - -modfile=build/go.v261.mod
     ldflags:
       - -s -w
       - -X github.com/spilchen/sql-ai-tools/cmd.Version={{.Version}}


### PR DESCRIPTION
## Summary

The `crdb-sql-v261` build entry added in 34c9786 placed the alternate modfile under a per-build `gomod:` key, but goreleaser v2 has no such field — `gomod` exists only as a top-level config section. Every snapshot run on `main` since that commit failed identically:

```
yaml: unmarshal errors:
  line 72: field gomod not found in type config.Build
```

Goreleaser bailed before producing any binaries, so the size-cap script never even ran (the suspected cause).

This PR passes `-modfile=build/go.v261.mod` through the build entry's `flags:` list instead — the canonical goreleaser v2 pattern for a custom modfile, matching what the Makefile already does in the `build-v%` target.

Also fixes `main: .` → `main: ./cmd/crdb-sql` in the same entry; package main lives under `cmd/crdb-sql`, not the repo root, so the build would have failed even after the schema was accepted.

The "how to add a sibling" comment is updated so the next contributor (`crdb-sql-v263`, etc.) reaches for the right pattern.

## Verification

Local reproduction of the CI step succeeds:

- `goreleaser release --snapshot --clean --skip=publish` produces all 8 binaries (35.8–39.1 MB each, well under the 50 MiB cap).
- `scripts/check-binary-size.sh` passes.
- `dist/crdb-sql-v261_linux_amd64_v1/crdb-sql-v261 version` reports `cockroachdb-parser: v0.26.1` and `builtins-stubs: v26.1`, confirming the alternate modfile is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)