### PR TITLE
safety: wire safe_write and full_access into explain_schema_change

### DIFF
--- a/cmd/explain_ddl.go
+++ b/cmd/explain_ddl.go
@@ -36,8 +36,11 @@ import (
 // declarative schema changer to compile a plan — and the safety
 // allowlist still gates the call: in the default read_only mode every
 // DDL is rejected (since DDL modifies schema), so users must escalate
-// to --mode=safe_write or --mode=full_access (issue #29) to
-// exercise this command.
+// to --mode=safe_write or --mode=full_access to exercise this
+// command. safe_write admits DDL but still rejects nested EXPLAIN,
+// privilege/role changes (DCL), cluster admin, tenant management,
+// and non-DDL inputs; full_access admits any DDL that parses while
+// still rejecting nested EXPLAIN and non-DDL inputs.
 func newExplainDDLCmd(state *rootState) *cobra.Command {
 	var (
 		expr    string
@@ -57,8 +60,11 @@ connection string is read from --dsn or CRDB_DSN (flag wins).
 The --mode flag selects the safety policy applied before the cluster
 call. The default "read_only" rejects every DDL (since DDL modifies
 schema), so this command requires --mode=safe_write or
---mode=full_access — both reserved for follow-up issue #29
-and currently rejected with a "not yet implemented" violation.`,
+--mode=full_access. safe_write admits DDL but still rejects nested
+EXPLAIN, privilege/role changes (DCL), cluster administration,
+tenant management, and non-DDL inputs; full_access admits any DDL
+that parses while still rejecting nested EXPLAIN and non-DDL
+inputs.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -72,11 +72,11 @@ const ModeParamName = "mode"
 // mode parameter so every Tier 3 tool documents the argument
 // identically. The accepted set is the same across tools, but the
 // modes that any given tool actually admits depend on the tool:
-// today only execute_sql wires safe_write and full_access;
-// explain_sql and explain_schema_change still report "not yet
-// implemented" for those modes (follow-up work). The per-tool
-// wording stays accurate via the envelope's safety_violation Reason.
-const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" additionally admits INSERT/UPDATE/DELETE; "full_access" admits any parsed statement. Today only execute_sql admits safe_write/full_access; explain_sql and explain_schema_change still report "not yet implemented" for those modes (follow-up work).`
+// today execute_sql and explain_schema_change wire safe_write and
+// full_access; explain_sql still reports "not yet implemented" for
+// those modes (follow-up work). The per-tool wording stays accurate
+// via the envelope's safety_violation Reason.
+const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" additionally admits INSERT/UPDATE/DELETE; "full_access" admits any parsed statement. For explain_schema_change, "read_only" rejects every DDL — use "safe_write" or "full_access" instead. Today explain_sql still reports "not yet implemented" for safe_write/full_access (follow-up work).`
 
 // StatementTimeoutParamName is the optional MCP tool parameter name
 // that lets a client override the per-call SET LOCAL statement_timeout

--- a/internal/mcp/tools/tools_test.go
+++ b/internal/mcp/tools/tools_test.go
@@ -227,6 +227,98 @@ func TestExplainSchemaChangeHandlerSafetyRejectionSurfacesEnvelopeError(t *testi
 	require.Equal(t, "read_only", env.Errors[0].Context["mode"])
 }
 
+// TestExplainSchemaChangeHandlerModeWiring exercises the per-mode
+// admit/reject contract through the MCP tool surface: that the mode
+// parameter actually flows into safety.Check with OpExplainDDL, and
+// that the new safe_write/full_access classifiers added in #152 are
+// reachable from the tool layer (not just unit-tested in isolation).
+//
+// The unreachable DSN serves the same purpose as in the surrounding
+// safety-rejection tests: an admit case must reach the connect step
+// and surface a "connect to CockroachDB" envelope error, while a
+// reject case must short-circuit with a CodeSafetyViolation. A
+// regression that drops the mode parameter, hard-codes read_only, or
+// inverts the admit/reject decision shows up as a code/context
+// mismatch here.
+func TestExplainSchemaChangeHandlerModeWiring(t *testing.T) {
+	tests := []struct {
+		name              string
+		mode              string
+		sql               string
+		expectedAdmit     bool
+		expectedTag       string
+		expectedReasonSub string
+	}{
+		{
+			name:          "safe_write admits ddl",
+			mode:          "safe_write",
+			sql:           "ALTER TABLE t ADD COLUMN x INT",
+			expectedAdmit: true,
+		},
+		{
+			name:          "full_access admits ddl",
+			mode:          "full_access",
+			sql:           "DROP TABLE users",
+			expectedAdmit: true,
+		},
+		{
+			name:              "safe_write rejects grant as privilege change",
+			mode:              "safe_write",
+			sql:               "GRANT SELECT ON t TO bob",
+			expectedTag:       "GRANT",
+			expectedReasonSub: "privilege/role changes require --mode=full_access",
+		},
+		{
+			name:              "safe_write rejects select as non-ddl",
+			mode:              "safe_write",
+			sql:               "SELECT 1",
+			expectedTag:       "SELECT",
+			expectedReasonSub: "explain_ddl requires a DDL statement",
+		},
+		{
+			name:              "full_access rejects select as non-ddl",
+			mode:              "full_access",
+			sql:               "SELECT 1",
+			expectedTag:       "SELECT",
+			expectedReasonSub: "explain_ddl requires a DDL statement",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ExplainSchemaChangeHandler(testParserVersion, "" /* defaultTargetVersion */)
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{
+				"sql":  tc.sql,
+				"dsn":  "postgres://nope:1/db?connect_timeout=1",
+				"mode": tc.mode,
+			}
+
+			res, err := handler(context.Background(), req)
+			require.NoError(t, err)
+			env := requireEnvelope(t, res)
+			require.Equal(t, output.ConnectionDisconnected, env.ConnectionStatus)
+			require.NotEmpty(t, env.Errors)
+
+			if tc.expectedAdmit {
+				// Safety admitted; the unreachable DSN forces a
+				// connect failure, which lands as an envelope error
+				// distinct from CodeSafetyViolation.
+				require.NotEqual(t, output.CodeSafetyViolation, env.Errors[0].Code,
+					"safety must admit; expected connect failure, got safety_violation")
+				require.Contains(t, env.Errors[0].Message, "connect to CockroachDB")
+				return
+			}
+			require.Len(t, env.Errors, 1)
+			require.Equal(t, output.CodeSafetyViolation, env.Errors[0].Code)
+			require.Equal(t, tc.expectedTag, env.Errors[0].Context["tag"])
+			require.Equal(t, tc.mode, env.Errors[0].Context["mode"])
+			require.Equal(t, "explain_ddl", env.Errors[0].Context["operation"])
+			require.Contains(t, env.Errors[0].Message, tc.expectedReasonSub)
+		})
+	}
+}
+
 // TestExplainSQLHandlerSafetyRejection verifies that the read_only
 // allowlist intercepts mutating inner statements before any cluster
 // contact, in the MCP surface. Mirror of the CLI safety-rejection

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -107,8 +107,9 @@ const (
 
 	// KindUnimplemented labels (mode, op) pairs that the package
 	// recognises at the flag layer but does not yet wire (today:
-	// safe_write/full_access for OpExplain/OpExplainDDL). The fix is
-	// for the upstream feature to land, not for the user to escalate.
+	// safe_write/full_access for OpExplain and OpSimulate). The fix
+	// is for the upstream feature to land, not for the user to
+	// escalate.
 	KindUnimplemented
 
 	// KindBadOpInput labels rejections caused by the user passing the
@@ -233,23 +234,30 @@ func CheckParsed(mode Mode, op Operation, stmts statements.Statements) *Violatio
 // Mode coverage is intentionally scoped per Operation:
 //
 //   - read_only is wired for every Op via classifyReadOnly.
-//   - safe_write and full_access are wired only for OpExecute (issue
-//     #29). OpExplain, OpExplainDDL, and OpSimulate in those modes
-//     still return the "not yet implemented" violation; wiring them
-//     is follow-up work so the other surfaces' mode story stays
-//     stable while exec adopts the full safety model.
+//   - safe_write and full_access are wired for OpExecute (issue #29)
+//     and OpExplainDDL (issue #152). OpExplain and OpSimulate in
+//     those modes still return the "not yet implemented" violation;
+//     wiring them is follow-up work so the other surfaces' mode
+//     story stays stable while the wired surfaces adopt the full
+//     safety model.
 func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 	switch mode {
 	case ModeReadOnly:
 		return classifyReadOnly(op, stmt)
 	case ModeSafeWrite:
-		if op == OpExecute {
+		switch op {
+		case OpExecute:
 			return classifySafeWriteExecute(stmt)
+		case OpExplainDDL:
+			return classifySafeWriteExplainDDL(stmt)
 		}
 		return notYetImplemented(mode, op, stmt)
 	case ModeFullAccess:
-		if op == OpExecute {
+		switch op {
+		case OpExecute:
 			return classifyFullAccessExecute(stmt)
+		case OpExplainDDL:
+			return classifyFullAccessExplainDDL(stmt)
 		}
 		return notYetImplemented(mode, op, stmt)
 	default:
@@ -674,5 +682,101 @@ func clusterAdminReason(stmt tree.Statement, mode Mode) string {
 // already rejected upstream by Check's defensive guard, so we have no
 // special case to handle here.
 func classifyFullAccessExecute(_ tree.Statement) *Violation {
+	return nil
+}
+
+// classifySafeWriteExplainDDL is the safe_write rule for OpExplainDDL.
+// Unlike classifySafeWriteExecute, schema modification is the *intent*
+// of the operation: EXPLAIN (DDL, SHAPE) compiles a DDL plan without
+// executing it, so safe_write admits DDL while still rejecting:
+//
+//   - Nested EXPLAIN wrappers — same defense-in-depth as elsewhere:
+//     the inner stmt is invisible to CanWriteData/CanModifySchema, and
+//     the dispatcher would reject it anyway.
+//   - Privilege/role changes (DCL) — GRANT/REVOKE/CREATE ROLE etc.
+//     escape the "DDL only" framing of explain-ddl and require the
+//     explicit full_access opt-in.
+//   - Cluster-admin DCL and tenant-management DML — same reasoning as
+//     classifySafeWriteExecute: cluster-level state changes need
+//     full_access regardless of operation.
+//   - Non-DDL inputs — EXPLAIN (DDL, SHAPE) only knows how to plan
+//     DDL, so a SELECT/DML here is a user error worth catching before
+//     any cluster contact.
+//
+// Note that DDL is admitted here even though classifySafeWriteExecute
+// rejects it; that asymmetry is the point of OpExplainDDL existing as
+// a separate operation.
+func classifySafeWriteExplainDDL(stmt tree.Statement) *Violation {
+	tag := stmt.StatementTag()
+	switch stmt.(type) {
+	case *tree.Explain, *tree.ExplainAnalyze:
+		return &Violation{
+			Tag:    tag,
+			Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+			Mode:   ModeSafeWrite,
+			Op:     OpExplainDDL,
+			Kind:   KindNestedExplain,
+		}
+	}
+	if v := classifyDCL(stmt, tag, ModeSafeWrite, OpExplainDDL); v != nil {
+		return v
+	}
+	if isTenantMgmtDMLStmt(stmt) {
+		return &Violation{
+			Tag:    tag,
+			Reason: clusterAdminReason(stmt, ModeSafeWrite),
+			Mode:   ModeSafeWrite,
+			Op:     OpExplainDDL,
+			Kind:   KindClusterAdmin,
+		}
+	}
+	if stmt.StatementType() != tree.TypeDDL {
+		return &Violation{
+			Tag:    tag,
+			Reason: "explain_ddl requires a DDL statement",
+			Mode:   ModeSafeWrite,
+			Op:     OpExplainDDL,
+			Kind:   KindBadOpInput,
+		}
+	}
+	return nil
+}
+
+// classifyFullAccessExplainDDL is the full_access rule for OpExplainDDL.
+// Mirrors classifyFullAccessExecute's "anything that parses" stance,
+// but still enforces the operation's input contract: EXPLAIN
+// (DDL, SHAPE) has no route for non-DDL statements, and the BadOpInput
+// rejection here gives a more actionable error than the cluster-side
+// failure that would otherwise reach the user. Nested EXPLAIN is also
+// rejected for the same defense-in-depth reasons as elsewhere.
+//
+// Note the asymmetry vs classifySafeWriteExplainDDL: full_access
+// deliberately skips the classifyDCL and isTenantMgmtDMLStmt gates,
+// so privilege/role changes and tenant-management statements fall
+// through to the non-DDL gate and reject as KindBadOpInput rather
+// than KindPrivilege/KindClusterAdmin. That matches
+// classifyFullAccessExecute's "trust the explicit opt-in" posture
+// while still surfacing a sensible error at the AST layer.
+func classifyFullAccessExplainDDL(stmt tree.Statement) *Violation {
+	tag := stmt.StatementTag()
+	switch stmt.(type) {
+	case *tree.Explain, *tree.ExplainAnalyze:
+		return &Violation{
+			Tag:    tag,
+			Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+			Mode:   ModeFullAccess,
+			Op:     OpExplainDDL,
+			Kind:   KindNestedExplain,
+		}
+	}
+	if stmt.StatementType() != tree.TypeDDL {
+		return &Violation{
+			Tag:    tag,
+			Reason: "explain_ddl requires a DDL statement",
+			Mode:   ModeFullAccess,
+			Op:     OpExplainDDL,
+			Kind:   KindBadOpInput,
+		}
+	}
 	return nil
 }

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -118,11 +118,203 @@ func TestCheckReadOnlyExplainDDL(t *testing.T) {
 	}
 }
 
+func TestCheckSafeWriteExplainDDL(t *testing.T) {
+	// safe_write admits DDL — the whole point of OpExplainDDL is to
+	// plan a schema change without executing it, so the safe_write/DDL
+	// asymmetry with classifySafeWriteExecute is intentional. DCL,
+	// cluster admin, tenant management, nested EXPLAIN, and non-DDL
+	// inputs are still rejected.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedKind   safety.ViolationKind
+		expectedReason string
+	}{
+		{name: "alter table add column admitted",
+			sql: "ALTER TABLE x ADD COLUMN y INT"},
+		{name: "create table admitted",
+			sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
+		{name: "drop table admitted",
+			sql: "DROP TABLE x"},
+		{name: "create index admitted",
+			sql: "CREATE INDEX i ON t (c)"},
+
+		{name: "select rejected as non-ddl",
+			sql:            "SELECT 1",
+			expectedReject: true,
+			expectedKind:   safety.KindBadOpInput,
+			expectedReason: "explain_ddl requires a DDL statement"},
+		{name: "insert rejected as non-ddl",
+			sql:            "INSERT INTO t VALUES (1)",
+			expectedReject: true,
+			expectedKind:   safety.KindBadOpInput,
+			expectedReason: "explain_ddl requires a DDL statement"},
+
+		// classifyDCL fires before the non-DDL gate so privilege/role
+		// changes get the privilege-specific Reason rather than the
+		// generic "requires a DDL statement" message — mirrors the
+		// Reason taxonomy on classifySafeWriteExecute.
+		{name: "grant rejected as privilege change",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedReject: true,
+			expectedKind:   safety.KindPrivilege,
+			expectedReason: "privilege/role changes require --mode=full_access"},
+		{name: "revoke rejected as privilege change",
+			sql:            "REVOKE SELECT ON t FROM bob",
+			expectedReject: true,
+			expectedKind:   safety.KindPrivilege,
+			expectedReason: "privilege/role changes require --mode=full_access"},
+
+		{name: "configure zone rejected as cluster admin",
+			sql:            "ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "zone configuration changes require full_access"},
+		{name: "set cluster setting rejected as cluster admin",
+			sql:            "SET CLUSTER SETTING sql.defaults.distsql = 'on'",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "cluster setting changes require full_access"},
+		{name: "set tracing rejected as cluster admin",
+			sql:            "SET TRACING = on",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tracing changes require full_access"},
+		// CREATE VIRTUAL CLUSTER is the TypeDCL tenant-lifecycle node;
+		// pin it alongside the TypeDML tenant nodes below so the
+		// classifyDCL → cluster-admin route is exercised on this path.
+		{name: "create tenant rejected as cluster admin",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo'",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+
+		// Tenant-management DML nodes (parser quirk — see
+		// isTenantMgmtDMLStmt) must reject under safe_write/OpExplainDDL
+		// with the tenant-management Reason. Without the dedicated
+		// guard AlterTenantCapability would slip past every check
+		// (CanWriteData/CanModifySchema both false) and be admitted.
+		{name: "alter tenant capability rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+		{name: "alter tenant replication rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+		{name: "create tenant from replication rejected as cluster admin",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+
+		{name: "nested explain rejected",
+			sql:            "EXPLAIN ALTER TABLE t ADD COLUMN x INT",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+		{name: "nested explain analyze rejected",
+			sql:            "EXPLAIN ANALYZE ALTER TABLE t ADD COLUMN x INT",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeSafeWrite, safety.OpExplainDDL, tc.sql)
+			require.NoError(t, err)
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v)
+			require.Equal(t, safety.ModeSafeWrite, v.Mode)
+			require.Equal(t, safety.OpExplainDDL, v.Op)
+			require.Equal(t, tc.expectedKind, v.Kind)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
+func TestCheckFullAccessExplainDDL(t *testing.T) {
+	// full_access on OpExplainDDL admits any DDL that parses; unlike
+	// classifyFullAccessExecute, the operation's input contract still
+	// applies (EXPLAIN (DDL, SHAPE) has no route for non-DDL), and
+	// nested EXPLAIN is still rejected as defense-in-depth.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedKind   safety.ViolationKind
+		expectedReason string
+	}{
+		{name: "alter table add column admitted",
+			sql: "ALTER TABLE x ADD COLUMN y INT"},
+		{name: "create table admitted",
+			sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
+		{name: "drop table admitted",
+			sql: "DROP TABLE x"},
+		{name: "create index admitted",
+			sql: "CREATE INDEX i ON t (c)"},
+
+		// GRANT and SELECT both fall through to the non-DDL gate
+		// because full_access skips the DCL classifier — that mirrors
+		// classifyFullAccessExecute's "anything that parses" stance,
+		// constrained by the OpExplainDDL input contract.
+		{name: "grant rejected as non-ddl",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedReject: true,
+			expectedKind:   safety.KindBadOpInput,
+			expectedReason: "explain_ddl requires a DDL statement"},
+		{name: "select rejected as non-ddl",
+			sql:            "SELECT 1",
+			expectedReject: true,
+			expectedKind:   safety.KindBadOpInput,
+			expectedReason: "explain_ddl requires a DDL statement"},
+		{name: "insert rejected as non-ddl",
+			sql:            "INSERT INTO t VALUES (1)",
+			expectedReject: true,
+			expectedKind:   safety.KindBadOpInput,
+			expectedReason: "explain_ddl requires a DDL statement"},
+
+		{name: "nested explain rejected",
+			sql:            "EXPLAIN ALTER TABLE t ADD COLUMN x INT",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+		{name: "nested explain analyze rejected",
+			sql:            "EXPLAIN ANALYZE ALTER TABLE t ADD COLUMN x INT",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeFullAccess, safety.OpExplainDDL, tc.sql)
+			require.NoError(t, err)
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v)
+			require.Equal(t, safety.ModeFullAccess, v.Mode)
+			require.Equal(t, safety.OpExplainDDL, v.Op)
+			require.Equal(t, tc.expectedKind, v.Kind)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
 func TestCheckRejectsUnimplementedModes(t *testing.T) {
-	// safe_write and full_access for the non-execute surfaces still
-	// report "not yet implemented" — only OpExecute (issue #29)
-	// wires those modes today; OpExplain/OpExplainDDL/OpSimulate are
-	// tracked separately as follow-up work.
+	// safe_write and full_access for the not-yet-wired surfaces still
+	// report "not yet implemented". OpExecute (issue #29) and
+	// OpExplainDDL (issue #152) wire those modes today; OpExplain and
+	// OpSimulate are tracked separately as follow-up work.
 	tests := []struct {
 		name string
 		mode safety.Mode
@@ -130,8 +322,6 @@ func TestCheckRejectsUnimplementedModes(t *testing.T) {
 	}{
 		{name: "safe_write OpExplain not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpExplain},
 		{name: "full_access OpExplain not yet implemented", mode: safety.ModeFullAccess, op: safety.OpExplain},
-		{name: "safe_write OpExplainDDL not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpExplainDDL},
-		{name: "full_access OpExplainDDL not yet implemented", mode: safety.ModeFullAccess, op: safety.OpExplainDDL},
 		{name: "safe_write OpSimulate not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpSimulate},
 		{name: "full_access OpSimulate not yet implemented", mode: safety.ModeFullAccess, op: safety.OpSimulate},
 	}

--- a/internal/safety/mode.go
+++ b/internal/safety/mode.go
@@ -26,9 +26,9 @@
 // Design doc reference: §Safety Model (read_only is the default,
 // safe_write and full_access are opt-in escalations). Issue #21
 // wired read_only end-to-end; issue #29 wired safe_write and
-// full_access for OpExecute. The explain surfaces still report
-// "not yet implemented" for safe_write/full_access — wiring them is
-// follow-up work.
+// full_access for OpExecute; issue #152 wired them for OpExplainDDL.
+// OpExplain and OpSimulate still report "not yet implemented" for
+// safe_write/full_access — wiring them is follow-up work.
 package safety
 
 import "fmt"
@@ -40,8 +40,9 @@ type Mode string
 
 // Mode values. ModeReadOnly is the default for every Tier 3 command;
 // the other two are recognised by ParseMode and admitted by Check
-// for OpExecute (issue #29). For OpExplain/OpExplainDDL/OpSimulate,
-// safe_write and full_access still report "not yet implemented".
+// for OpExecute (issue #29) and OpExplainDDL (issue #152). For
+// OpExplain and OpSimulate, safe_write and full_access still report
+// "not yet implemented".
 const (
 	ModeReadOnly   Mode = "read_only"
 	ModeSafeWrite  Mode = "safe_write"
@@ -62,9 +63,9 @@ const DefaultMode = ModeReadOnly
 // is actionable on its own.
 //
 // safe_write and full_access parse successfully for every Op even
-// though Check rejects them for OpExplain/OpExplainDDL/OpSimulate
-// today — the split keeps the flag-parsing layer stable so the only
-// churn when those modes land for the other surfaces is inside Check.
+// though Check rejects them for OpExplain and OpSimulate today —
+// the split keeps the flag-parsing layer stable so the only churn
+// when those modes land for the other surfaces is inside Check.
 func ParseMode(s string) (Mode, error) {
 	switch Mode(s) {
 	case "":


### PR DESCRIPTION
## Summary

Before: `explain_schema_change` (OpExplainDDL) only honored `read_only`, which rejects every DDL since DDL modifies schema — making the surface effectively unusable. `safe_write` and `full_access` parsed but returned `KindUnimplemented` from the AST allowlist.

After: both modes are wired through dedicated classifiers that mirror the OpExecute pattern from #29 with one deliberate asymmetry: schema modification is the *intent* of OpExplainDDL, so DDL is admitted (not rejected as in `classifySafeWriteExecute`).

- `safe_write` admits DDL but still rejects nested EXPLAIN, privilege/role changes (DCL), cluster admin, tenant management, and non-DDL inputs.
- `full_access` admits any DDL that parses; it still rejects nested EXPLAIN and non-DDL inputs because EXPLAIN (DDL, SHAPE) has no route for non-DDL and an AST-layer reject is more actionable than the cluster-side failure.

The dispatcher (`conn.Manager.ExplainDDL`) is unchanged — it already runs in a read-write txn because the cluster's read-only-txn check fires before the SHAPE-only flag is consulted, and the AST allowlist is the load-bearing safety check for this surface.

Updates the unimplemented-mode test table, the package and `ParseMode` doc comments, the MCP `ModeParamDescription`, and the `explain-ddl` help text to drop the `explain_schema_change` carve-out wording. New MCP-handler test `TestExplainSchemaChangeHandlerModeWiring` exercises both admit modes (reaching connect failure) and reject paths (DCL, non-DDL) end-to-end through the tool surface.

Resolves: #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)