### PR TITLE
safety: wire safe_write and full_access for OpExplain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ registers in [`internal/mcp/server.go`](internal/mcp/server.go) and
 | `summarize_sql` / `summarize` | 1 | Structured per-statement summary (tables touched, operations). |
 | `list_tables` / `list-tables` | 2-3 | Tables from loaded `--schema` files or a live `--dsn` cluster. |
 | `describe_table` / `describe` | 2-3 | Columns, types, nullability, primary key, indexes. |
-| `explain_sql` / `explain` | 3 | EXPLAIN output as structured JSON. Requires `--dsn`. |
-| `explain_schema_change` / `explain-ddl` | 3 | EXPLAIN (DDL, SHAPE) — schema-change plan with phases and operations. Currently rejects every input: the default `read_only` mode forbids DDL planning and `safe_write`/`full_access` are wired only for `execute_sql` (the per-mode rules for `explain-ddl` are follow-up work). |
+| `explain_sql` / `explain` | 3 | EXPLAIN output as structured JSON. `--mode read_only` (default) admits the read-only set; `--mode safe_write` additionally admits DML so the planner returns a plan for inner writes; `--mode full_access` admits anything that parses (the cluster-side read-only txn wrapper still surfaces SQLSTATE 25006 for inner DDL). Requires `--dsn`. |
+| `explain_schema_change` / `explain-ddl` | 3 | EXPLAIN (DDL, SHAPE) — schema-change plan with phases and operations. The default `read_only` mode rejects every DDL (since DDL modifies schema), so this command requires `--mode safe_write` (admits DDL but rejects DCL/cluster-admin/non-DDL) or `--mode full_access` (admits any DDL that parses). Requires `--dsn`. |
 | `simulate_sql` / `simulate` | 3 | Side-effect-free by construction: dispatches each statement to a non-mutating EXPLAIN flavor — SELECT runs through `EXPLAIN ANALYZE` inside `BEGIN READ ONLY` (the read does execute, but writes are blocked at the cluster), DML through plain `EXPLAIN` (planner-only, write never applied), DDL through `EXPLAIN (DDL, SHAPE)` (planner-only). Requires `--dsn`. |
 | `execute_sql` / `exec` | 3 | Run SQL against the cluster behind the safety allowlist. `--mode read_only` (default) admits the same set as `explain`; `--mode safe_write` additionally admits DML; `--mode full_access` admits anything that parses. Schema/privilege/cluster-admin ops require `full_access`. Requires `--dsn`. |
 
@@ -271,9 +271,9 @@ side-effect-free dispatch (see the catalog row for the exact rules).
 For actual writes, `crdb-sql exec --dsn ... --mode safe_write -e
 "..."` runs SQL behind the safety allowlist; the default
 `--mode read_only` admits the same shape as `explain`. `crdb-sql
-explain-ddl` is the planned schema-change-impact tool, but it cannot
-run today — its per-mode rules are still follow-up work and every
-input is rejected.
+explain-ddl --dsn ... --mode safe_write -e "ALTER TABLE ..."`
+returns the declarative schema-change plan — read_only rejects DDL
+by design, so this command requires safe_write or full_access.
 
 ### Connecting to a secure cluster
 
@@ -394,11 +394,11 @@ so configure your editor to run `gofmt`/`goimports` on save.
 ## Project status
 
 Tier 1 and Tier 2 are usable today. Tier 3 connected tools (`ping`,
-`list-tables`, `describe`, `explain`, `simulate`, `exec`) work;
-`exec` honours all three safety modes (`read_only`, `safe_write`,
-`full_access`). `explain-ddl` is the only Tier 3 tool that cannot run
-today — its per-mode rules are still follow-up work, so every input
-is rejected.
+`list-tables`, `describe`, `explain`, `explain-ddl`, `simulate`,
+`exec`) work; `exec`, `explain`, and `explain-ddl` honour all three
+safety modes (`read_only`, `safe_write`, `full_access`). `simulate`
+is the remaining Tier 3 surface whose `safe_write`/`full_access`
+wiring is still follow-up work.
 
 See [`docs/`](docs/) for the design document, hackathon plan, and
 research lessons that inform the architecture.

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -53,8 +53,11 @@ connection string is read from --dsn or CRDB_DSN (flag wins).
 
 The --mode flag selects the safety policy applied before the cluster
 call. Default is "read_only", which permits SELECT, SHOW, and other
-non-mutating statements. "safe_write" and "full_access" are reserved
-for follow-up issues and currently reject every statement.`,
+non-mutating statements. "safe_write" additionally admits DML
+(INSERT/UPDATE/DELETE/UPSERT) so the planner can return a plan for
+the inner write. "full_access" admits any parsed statement; the
+cluster's read-only transaction wrapper still surfaces SQLSTATE 25006
+for inner DDL the planner refuses to plan under read-only.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)

--- a/docs/design_doc.md
+++ b/docs/design_doc.md
@@ -428,15 +428,17 @@ Tools that require a higher capability tier return structured
 | `safe_write` | No | Above + INSERT, UPDATE, DELETE, UPSERT | `SET LOCAL sql_safe_updates = on` (cluster rejects bare UPDATE/DELETE), row-scan truncation, statement timeouts |
 | `full_access` | No | Anything that parses (DDL, DCL, etc.) | Row-scan truncation, statement timeouts (audit log planned) |
 
-Mode wiring per Tier 3 surface (issue #29 lands `execute_sql`; the
-explain surfaces still report "not yet implemented" for `safe_write` /
-`full_access` — wiring them is follow-up work):
+Mode wiring per Tier 3 surface (issues #29, #151, and #152 land
+`execute_sql`, `explain_sql`, and `explain_schema_change`
+respectively; `simulate_sql` still reports "not yet implemented"
+for `safe_write` / `full_access` — wiring it is follow-up work):
 
-| Tool                   | `read_only` | `safe_write` | `full_access` |
-|------------------------|-------------|--------------|---------------|
-| `execute_sql` / `exec` | ✅          | ✅           | ✅            |
-| `explain_sql`          | ✅          | ⏳           | ⏳            |
-| `explain_schema_change`| ✅          | ⏳           | ⏳            |
+| Tool                    | `read_only` | `safe_write` | `full_access` |
+|-------------------------|-------------|--------------|---------------|
+| `execute_sql` / `exec`  | ✅          | ✅           | ✅            |
+| `explain_sql`           | ✅          | ✅           | ✅            |
+| `explain_schema_change` | ✅          | ✅           | ✅            |
+| `simulate_sql`          | ✅          | ⏳           | ⏳            |
 
 **LIMIT injection** (read_only only): `safety.MaybeInjectLimit` parses
 the SQL and, when the input is a single bare `SELECT` whose result is

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -72,11 +72,12 @@ const ModeParamName = "mode"
 // mode parameter so every Tier 3 tool documents the argument
 // identically. The accepted set is the same across tools, but the
 // modes that any given tool actually admits depend on the tool:
-// today execute_sql and explain_schema_change wire safe_write and
-// full_access; explain_sql still reports "not yet implemented" for
-// those modes (follow-up work). The per-tool wording stays accurate
-// via the envelope's safety_violation Reason.
-const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" additionally admits INSERT/UPDATE/DELETE; "full_access" admits any parsed statement. For explain_schema_change, "read_only" rejects every DDL — use "safe_write" or "full_access" instead. Today explain_sql still reports "not yet implemented" for safe_write/full_access (follow-up work).`
+// execute_sql, explain_sql, and explain_schema_change all wire
+// safe_write and full_access today. For explain_schema_change,
+// read_only rejects every DDL — use safe_write or full_access
+// instead. The per-tool wording stays accurate via the envelope's
+// safety_violation Reason.
+const ModeParamDescription = `Optional safety mode applied before any cluster contact. Defaults to "read_only", which permits non-mutating statements only. "safe_write" additionally admits INSERT/UPDATE/DELETE; "full_access" admits any parsed statement. For explain_schema_change, "read_only" rejects every DDL — use "safe_write" or "full_access" instead.`
 
 // StatementTimeoutParamName is the optional MCP tool parameter name
 // that lets a client override the per-call SET LOCAL statement_timeout

--- a/internal/safety/allowlist.go
+++ b/internal/safety/allowlist.go
@@ -107,9 +107,8 @@ const (
 
 	// KindUnimplemented labels (mode, op) pairs that the package
 	// recognises at the flag layer but does not yet wire (today:
-	// safe_write/full_access for OpExplain and OpSimulate). The fix
-	// is for the upstream feature to land, not for the user to
-	// escalate.
+	// safe_write/full_access for OpSimulate only). The fix is for
+	// the upstream feature to land, not for the user to escalate.
 	KindUnimplemented
 
 	// KindBadOpInput labels rejections caused by the user passing the
@@ -234,12 +233,10 @@ func CheckParsed(mode Mode, op Operation, stmts statements.Statements) *Violatio
 // Mode coverage is intentionally scoped per Operation:
 //
 //   - read_only is wired for every Op via classifyReadOnly.
-//   - safe_write and full_access are wired for OpExecute (issue #29)
-//     and OpExplainDDL (issue #152). OpExplain and OpSimulate in
-//     those modes still return the "not yet implemented" violation;
-//     wiring them is follow-up work so the other surfaces' mode
-//     story stays stable while the wired surfaces adopt the full
-//     safety model.
+//   - safe_write and full_access are wired for OpExecute (issue #29),
+//     OpExplain (issue #151), and OpExplainDDL (issue #152).
+//     OpSimulate in those modes still returns the "not yet
+//     implemented" violation; wiring it is follow-up work.
 func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 	switch mode {
 	case ModeReadOnly:
@@ -248,6 +245,8 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 		switch op {
 		case OpExecute:
 			return classifySafeWriteExecute(stmt)
+		case OpExplain:
+			return classifySafeWriteExplain(stmt)
 		case OpExplainDDL:
 			return classifySafeWriteExplainDDL(stmt)
 		}
@@ -256,6 +255,8 @@ func classify(mode Mode, op Operation, stmt tree.Statement) *Violation {
 		switch op {
 		case OpExecute:
 			return classifyFullAccessExecute(stmt)
+		case OpExplain:
+			return classifyFullAccessExplain(stmt)
 		case OpExplainDDL:
 			return classifyFullAccessExplainDDL(stmt)
 		}
@@ -555,6 +556,57 @@ func classifySafeWriteExecute(stmt tree.Statement) *Violation {
 	return nil
 }
 
+// classifySafeWriteExplain is the safe_write rule for OpExplain. The
+// admission set mirrors classifySafeWriteExecute — read-only set plus
+// DML, with DDL and DCL still gated to full_access — so an agent can
+// switch between `explain` and `execute` for the same statement
+// without re-discovering the per-mode matrix.
+//
+// Plain EXPLAIN (without ANALYZE) does not execute the wrapped
+// statement; the cluster-side BEGIN READ ONLY wrapper in
+// Manager.runExplain is the runtime defense-in-depth. The AST gate
+// here still exists because it is the only layer that can reject DDL
+// before any cluster contact, and because the nested-EXPLAIN guard
+// must also live here (CanWriteData/CanModifySchema do not descend
+// into *Explain/*ExplainAnalyze nodes, so a wrapped INSERT would
+// otherwise be admitted as ordinary DML and the runtime read-only
+// txn would be the only thing catching it).
+func classifySafeWriteExplain(stmt tree.Statement) *Violation {
+	tag := stmt.StatementTag()
+	switch stmt.(type) {
+	case *tree.Explain, *tree.ExplainAnalyze:
+		return &Violation{
+			Tag:    tag,
+			Reason: "nested EXPLAIN is not permitted; pass the inner statement directly",
+			Mode:   ModeSafeWrite,
+			Op:     OpExplain,
+			Kind:   KindNestedExplain,
+		}
+	}
+	if v := classifyDCL(stmt, tag, ModeSafeWrite, OpExplain); v != nil {
+		return v
+	}
+	if isTenantMgmtDMLStmt(stmt) {
+		return &Violation{
+			Tag:    tag,
+			Reason: clusterAdminReason(stmt, ModeSafeWrite),
+			Mode:   ModeSafeWrite,
+			Op:     OpExplain,
+			Kind:   KindClusterAdmin,
+		}
+	}
+	if tree.CanModifySchema(stmt) {
+		return &Violation{
+			Tag:    tag,
+			Reason: "statement modifies schema; rerun with --mode=full_access",
+			Mode:   ModeSafeWrite,
+			Op:     OpExplain,
+			Kind:   KindSchema,
+		}
+	}
+	return nil
+}
+
 // classifyDCL produces the Violation for a TypeDCL statement, or nil
 // if stmt isn't TypeDCL. It splits CRDB's overloaded TypeDCL set
 // (privilege/role changes vs. cluster admin / tenant lifecycle) so
@@ -682,6 +734,16 @@ func clusterAdminReason(stmt tree.Statement, mode Mode) string {
 // already rejected upstream by Check's defensive guard, so we have no
 // special case to handle here.
 func classifyFullAccessExecute(_ tree.Statement) *Violation {
+	return nil
+}
+
+// classifyFullAccessExplain is the full_access rule for OpExplain.
+// Mirrors classifyFullAccessExecute: anything that parses is admitted.
+// Defense-in-depth at runtime is the BEGIN READ ONLY wrapper in
+// Manager.runExplain, which surfaces SQLSTATE 25006 if the planner
+// would otherwise treat the inner statement as a write — the same
+// shape EXPLAIN ANALYZE INSERT already returns under read_only today.
+func classifyFullAccessExplain(_ tree.Statement) *Violation {
 	return nil
 }
 

--- a/internal/safety/allowlist_test.go
+++ b/internal/safety/allowlist_test.go
@@ -311,17 +311,15 @@ func TestCheckFullAccessExplainDDL(t *testing.T) {
 }
 
 func TestCheckRejectsUnimplementedModes(t *testing.T) {
-	// safe_write and full_access for the not-yet-wired surfaces still
-	// report "not yet implemented". OpExecute (issue #29) and
-	// OpExplainDDL (issue #152) wire those modes today; OpExplain and
-	// OpSimulate are tracked separately as follow-up work.
+	// safe_write and full_access for the simulate surface still
+	// report "not yet implemented" — OpExecute (issue #29), OpExplain
+	// (issue #151), and OpExplainDDL (issue #152) are wired today;
+	// OpSimulate is tracked separately as follow-up work.
 	tests := []struct {
 		name string
 		mode safety.Mode
 		op   safety.Operation
 	}{
-		{name: "safe_write OpExplain not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpExplain},
-		{name: "full_access OpExplain not yet implemented", mode: safety.ModeFullAccess, op: safety.OpExplain},
 		{name: "safe_write OpSimulate not yet implemented", mode: safety.ModeSafeWrite, op: safety.OpSimulate},
 		{name: "full_access OpSimulate not yet implemented", mode: safety.ModeFullAccess, op: safety.OpSimulate},
 	}
@@ -330,7 +328,7 @@ func TestCheckRejectsUnimplementedModes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			v, err := safety.Check(tc.mode, tc.op, "SELECT 1")
 			require.NoError(t, err)
-			require.NotNil(t, v, "non-read_only modes are not admitted yet for explain ops")
+			require.NotNil(t, v, "non-read_only modes are not admitted yet for these ops")
 			require.Contains(t, v.Reason, "not yet implemented")
 			require.Equal(t, tc.mode, v.Mode)
 		})
@@ -562,6 +560,163 @@ func TestCheckFullAccessExecute(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			v, err := safety.Check(safety.ModeFullAccess, safety.OpExecute, tc.sql)
+			require.NoError(t, err)
+			require.Nil(t, v, "full_access admits any parsed statement")
+		})
+	}
+}
+
+func TestCheckSafeWriteExplain(t *testing.T) {
+	// safe_write for OpExplain mirrors safe_write for OpExecute: the
+	// read-only set plus DML is admitted; DDL and DCL still escalate to
+	// full_access. Plain EXPLAIN does not execute the wrapped statement,
+	// but the AST gate is still the first line of defense — see the
+	// docstring on classifySafeWriteExplain.
+	tests := []struct {
+		name           string
+		sql            string
+		expectedReject bool
+		expectedKind   safety.ViolationKind
+		expectedReason string
+	}{
+		{name: "select admitted", sql: "SELECT 1"},
+		{name: "show admitted", sql: "SHOW TABLES"},
+		{name: "insert admitted", sql: "INSERT INTO t VALUES (1)"},
+		{name: "update admitted", sql: "UPDATE t SET x = 1 WHERE id = 1"},
+		{name: "delete admitted", sql: "DELETE FROM t WHERE id = 1"},
+		{name: "upsert admitted", sql: "UPSERT INTO t VALUES (1)"},
+		{name: "unqualified update admitted at AST layer",
+			sql: "UPDATE t SET x = 1"},
+
+		{name: "create table rejected with full_access hint",
+			sql:            "CREATE TABLE x (id INT PRIMARY KEY)",
+			expectedReject: true,
+			expectedKind:   safety.KindSchema,
+			expectedReason: "rerun with --mode=full_access"},
+		{name: "drop table rejected",
+			sql:            "DROP TABLE users",
+			expectedReject: true,
+			expectedKind:   safety.KindSchema,
+			expectedReason: "rerun with --mode=full_access"},
+		{name: "truncate rejected as schema",
+			sql:            "TRUNCATE TABLE t",
+			expectedReject: true,
+			expectedKind:   safety.KindSchema,
+			expectedReason: "rerun with --mode=full_access"},
+		{name: "grant rejected as privilege change",
+			sql:            "GRANT SELECT ON t TO bob",
+			expectedReject: true,
+			expectedKind:   safety.KindPrivilege,
+			expectedReason: "privilege/role changes require --mode=full_access"},
+		{name: "configure zone rejected as cluster admin",
+			sql:            "ALTER TABLE t CONFIGURE ZONE USING num_replicas = 5",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "zone configuration changes require full_access"},
+		{name: "set cluster setting rejected as cluster admin",
+			sql:            "SET CLUSTER SETTING sql.defaults.distsql = 'on'",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "cluster setting changes require full_access"},
+		{name: "set tracing rejected as cluster admin",
+			sql:            "SET TRACING = on",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tracing changes require full_access"},
+
+		// Tenant-management DML nodes parallel the OpExecute table —
+		// the parser tags them TypeDML rather than TypeDCL, so without
+		// the isTenantMgmtDMLStmt guard AlterTenantCapability would be
+		// silently admitted (neither CanWriteData nor CanModifySchema)
+		// and the other two would be admitted as ordinary DML and
+		// silently regress to KindWrite — pinning Kind here closes
+		// that loop.
+		{name: "alter tenant capability rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+		{name: "alter tenant replication rejected as cluster admin",
+			sql:            "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+		{name: "create tenant from replication rejected as cluster admin",
+			sql:            "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'",
+			expectedReject: true,
+			expectedKind:   safety.KindClusterAdmin,
+			expectedReason: "tenant management requires full_access"},
+
+		// The nested-EXPLAIN guard is what stops EXPLAIN ANALYZE from
+		// laundering writes past the AST gate — without it, the inner
+		// INSERT of an EXPLAIN ANALYZE wrapper would be admitted as
+		// ordinary DML and only the runtime read-only txn would catch
+		// the actual write. Pinning KindNestedExplain matters because
+		// envelope.suggestionsFor short-circuits this Kind to "no
+		// escalation hint" — a regression to KindWrite would tell
+		// agents to retry under a mode that still rejects nested
+		// explain.
+		{name: "explain analyze insert rejected as nested",
+			sql:            "EXPLAIN ANALYZE INSERT INTO t VALUES (1)",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+		{name: "explain wrapper rejected as nested",
+			sql:            "EXPLAIN SELECT 1",
+			expectedReject: true,
+			expectedKind:   safety.KindNestedExplain,
+			expectedReason: "nested EXPLAIN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeSafeWrite, safety.OpExplain, tc.sql)
+			require.NoError(t, err)
+			if !tc.expectedReject {
+				require.Nil(t, v, "expected statement to be admitted")
+				return
+			}
+			require.NotNil(t, v)
+			require.Equal(t, safety.ModeSafeWrite, v.Mode)
+			require.Equal(t, safety.OpExplain, v.Op)
+			require.Equal(t, tc.expectedKind, v.Kind)
+			require.Contains(t, v.Reason, tc.expectedReason)
+		})
+	}
+}
+
+func TestCheckFullAccessExplain(t *testing.T) {
+	// full_access for OpExplain admits anything that parses, mirroring
+	// classifyFullAccessExecute. Defense-in-depth at runtime is the
+	// BEGIN READ ONLY wrapper in Manager.runExplain — anything the
+	// planner refuses to plan under read-only surfaces as SQLSTATE
+	// 25006 to the caller.
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{name: "select", sql: "SELECT 1"},
+		{name: "insert", sql: "INSERT INTO t VALUES (1)"},
+		{name: "delete", sql: "DELETE FROM t WHERE id = 1"},
+		{name: "create table", sql: "CREATE TABLE x (id INT PRIMARY KEY)"},
+		{name: "drop table", sql: "DROP TABLE users"},
+		{name: "grant", sql: "GRANT SELECT ON t TO bob"},
+		{name: "set cluster setting", sql: "SET CLUSTER SETTING sql.defaults.distsql = 'on'"},
+
+		// Pin the same tenant-DML escape that TestCheckFullAccessExecute
+		// pins for OpExecute — full_access is the explicit opt-in for
+		// these statements, so the allowlist must admit them.
+		{name: "alter tenant capability admitted under full_access",
+			sql: "ALTER VIRTUAL CLUSTER 'foo' GRANT CAPABILITY can_admin_split"},
+		{name: "alter tenant replication admitted under full_access",
+			sql: "ALTER VIRTUAL CLUSTER 'foo' PAUSE REPLICATION"},
+		{name: "create tenant from replication admitted under full_access",
+			sql: "CREATE VIRTUAL CLUSTER 'foo' FROM REPLICATION OF 'bar' ON 'connstr'"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := safety.Check(safety.ModeFullAccess, safety.OpExplain, tc.sql)
 			require.NoError(t, err)
 			require.Nil(t, v, "full_access admits any parsed statement")
 		})

--- a/internal/safety/envelope.go
+++ b/internal/safety/envelope.go
@@ -100,22 +100,34 @@ func escalationTargetFor(v *Violation) (Mode, bool) {
 	switch v.Mode {
 	case ModeReadOnly:
 		switch v.Op {
-		case OpExplain, OpExplainDDL:
-			// The explain surfaces don't yet wire safe_write /
-			// full_access, but for read_only rejections the path
-			// forward when those land will be safe_write — keep the
-			// hint in place so agents can already discover the lever.
-			return ModeSafeWrite, true
-		case OpExecute:
+		case OpExplain, OpExecute:
+			// OpExplain and OpExecute share the same escalation
+			// matrix because their safe_write/full_access
+			// classifiers admit the same per-Kind set: writes go to
+			// safe_write, schema/DCL skip straight to full_access.
+			// Suggesting safe_write for a KindSchema rejection here
+			// would loop the agent — the safe_write classifier also
+			// rejects schema mutations.
 			switch v.Kind {
 			case KindWrite:
 				return ModeSafeWrite, true
 			case KindSchema, KindPrivilege, KindClusterAdmin:
 				return ModeFullAccess, true
 			}
+		case OpExplainDDL:
+			// classifyReadOnly's OpExplainDDL branch tags every
+			// rejection that reaches here as KindSchema (the DDL
+			// itself); KindBadOpInput from non-DDL inputs is
+			// short-circuited at the top of this function. safe_write
+			// is the smallest mode that admits DDL on the
+			// explain-ddl path (per classifySafeWriteExplainDDL),
+			// so the smallest-bump principle picks it.
+			return ModeSafeWrite, true
 		}
 	case ModeSafeWrite:
-		if v.Op == OpExecute {
+		switch v.Op {
+		case OpExplain, OpExecute:
+			// Same shared matrix as the read_only arm above.
 			switch v.Kind {
 			case KindSchema, KindPrivilege, KindClusterAdmin:
 				return ModeFullAccess, true

--- a/internal/safety/envelope_test.go
+++ b/internal/safety/envelope_test.go
@@ -37,56 +37,43 @@ func TestEnvelope(t *testing.T) {
 	require.NotEmpty(t, e.Context["reason"])
 }
 
-func TestEnvelopeSuggestionsByOp(t *testing.T) {
-	// Both OpExplain and OpExplainDDL escalation suggestions point at
-	// safe_write — the lowest-privilege mode that admits the call per
-	// design doc §Safety Model. Jumping to full_access would violate
-	// principle of least privilege, and the test pins the symmetry so
-	// a future change can't accidentally regress only one op.
-	//
-	// Kind is set explicitly to KindSchema (the most common explain
-	// rejection class) so the test exercises the same code path a
-	// real classifyReadOnly call would produce — Violations from
-	// production code never have Kind=0.
-	tests := []struct {
-		name string
-		op   safety.Operation
-	}{
-		{name: "explain", op: safety.OpExplain},
-		{name: "explain_ddl", op: safety.OpExplainDDL},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			e := safety.Envelope(&safety.Violation{
-				Tag:  "ANY",
-				Mode: safety.ModeReadOnly,
-				Op:   tc.op,
-				Kind: safety.KindSchema,
-			})
-			require.Len(t, e.Suggestions, 1)
-			require.Equal(t, string(safety.ModeSafeWrite), e.Suggestions[0].Replacement)
-			require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
-		})
-	}
+func TestEnvelopeExplainDDLSuggestion(t *testing.T) {
+	// classifyReadOnly's OpExplainDDL branch tags every reachable
+	// rejection as KindSchema (KindBadOpInput is short-circuited at
+	// the top of escalationTargetFor). safe_write is the smallest
+	// mode that admits DDL on the explain-ddl path
+	// (classifySafeWriteExplainDDL). This pins that contract — a
+	// regression suggesting full_access here would skip the
+	// least-privilege step.
+	e := safety.Envelope(&safety.Violation{
+		Tag:  "CREATE TABLE",
+		Mode: safety.ModeReadOnly,
+		Op:   safety.OpExplainDDL,
+		Kind: safety.KindSchema,
+	})
+	require.Len(t, e.Suggestions, 1)
+	require.Equal(t, string(safety.ModeSafeWrite), e.Suggestions[0].Replacement)
+	require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
 }
 
 func TestEnvelopeNoSuggestionForUnimplementedModes(t *testing.T) {
-	// OpExplain in safe_write/full_access still reports "not yet
-	// implemented" (the explain-side mode wiring is tracked
-	// separately). No escalation makes sense — the user has to wait
-	// — so no suggestion is offered.
+	// OpSimulate in safe_write/full_access still reports "not yet
+	// implemented" (the OpSimulate mode wiring is tracked
+	// separately). No escalation makes sense — the user has to
+	// wait — so no suggestion is offered.
 	e := safety.Envelope(&safety.Violation{
 		Tag:  "SELECT",
 		Mode: safety.ModeSafeWrite,
-		Op:   safety.OpExplain,
+		Op:   safety.OpSimulate,
 		Kind: safety.KindUnimplemented,
 	})
 	require.Empty(t, e.Suggestions)
 }
 
-func TestEnvelopeExecuteSuggestions(t *testing.T) {
-	// OpExecute escalation is asymmetric: a write under read_only
+func TestEnvelopeExecuteAndExplainSuggestions(t *testing.T) {
+	// OpExecute and OpExplain share the same escalation matrix
+	// (issue #151 wired OpExplain to mirror OpExecute's per-Kind
+	// behavior). The matrix is asymmetric: a write under read_only
 	// escalates to safe_write (the smallest bump), but schema changes
 	// and DCL under read_only must jump to full_access because
 	// safe_write itself rejects them. A safe_write rejection of
@@ -94,7 +81,12 @@ func TestEnvelopeExecuteSuggestions(t *testing.T) {
 	// stop. The decision is driven by Violation.Kind, not by the
 	// human-readable Reason text, so wording tweaks in the classifier
 	// cannot silently break the escalation contract.
-	tests := []struct {
+	//
+	// Running the same matrix against both ops pins that any future
+	// refactor that diverges OpExplain from OpExecute would surface
+	// here — losing the parallel would silently break agents that
+	// switch between the two surfaces for the same statement.
+	cases := []struct {
 		name                string
 		mode                safety.Mode
 		kind                safety.ViolationKind
@@ -144,18 +136,28 @@ func TestEnvelopeExecuteSuggestions(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			e := safety.Envelope(&safety.Violation{
-				Tag:  "ANY",
-				Mode: tc.mode,
-				Op:   safety.OpExecute,
-				Kind: tc.kind,
+	ops := []struct {
+		name string
+		op   safety.Operation
+	}{
+		{name: "execute", op: safety.OpExecute},
+		{name: "explain", op: safety.OpExplain},
+	}
+
+	for _, op := range ops {
+		for _, tc := range cases {
+			t.Run(op.name+"/"+tc.name, func(t *testing.T) {
+				e := safety.Envelope(&safety.Violation{
+					Tag:  "ANY",
+					Mode: tc.mode,
+					Op:   op.op,
+					Kind: tc.kind,
+				})
+				require.Len(t, e.Suggestions, 1)
+				require.Equal(t, string(tc.expectedReplacement), e.Suggestions[0].Replacement)
+				require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
 			})
-			require.Len(t, e.Suggestions, 1)
-			require.Equal(t, string(tc.expectedReplacement), e.Suggestions[0].Replacement)
-			require.Equal(t, "safety_mode_escalation", e.Suggestions[0].Reason)
-		})
+		}
 	}
 }
 

--- a/internal/safety/mode.go
+++ b/internal/safety/mode.go
@@ -25,10 +25,10 @@
 //
 // Design doc reference: §Safety Model (read_only is the default,
 // safe_write and full_access are opt-in escalations). Issue #21
-// wired read_only end-to-end; issue #29 wired safe_write and
-// full_access for OpExecute; issue #152 wired them for OpExplainDDL.
-// OpExplain and OpSimulate still report "not yet implemented" for
-// safe_write/full_access — wiring them is follow-up work.
+// wired read_only end-to-end; issues #29, #151, and #152 wired
+// safe_write/full_access for OpExecute, OpExplain, and OpExplainDDL
+// respectively. OpSimulate still reports "not yet implemented" for
+// safe_write/full_access — wiring it is follow-up work.
 package safety
 
 import "fmt"
@@ -40,9 +40,9 @@ type Mode string
 
 // Mode values. ModeReadOnly is the default for every Tier 3 command;
 // the other two are recognised by ParseMode and admitted by Check
-// for OpExecute (issue #29) and OpExplainDDL (issue #152). For
-// OpExplain and OpSimulate, safe_write and full_access still report
-// "not yet implemented".
+// for OpExecute (#29), OpExplain (#151), and OpExplainDDL (#152).
+// For OpSimulate, safe_write and full_access still report "not yet
+// implemented".
 const (
 	ModeReadOnly   Mode = "read_only"
 	ModeSafeWrite  Mode = "safe_write"
@@ -63,9 +63,9 @@ const DefaultMode = ModeReadOnly
 // is actionable on its own.
 //
 // safe_write and full_access parse successfully for every Op even
-// though Check rejects them for OpExplain and OpSimulate today —
-// the split keeps the flag-parsing layer stable so the only churn
-// when those modes land for the other surfaces is inside Check.
+// though Check rejects them for OpSimulate today — the split keeps
+// the flag-parsing layer stable so the only churn when those modes
+// land for OpSimulate is inside Check.
 func ParseMode(s string) (Mode, error) {
 	switch Mode(s) {
 	case "":


### PR DESCRIPTION
explain_sql previously rejected every safe_write or full_access
request with the placeholder "safety mode \"X\" is not yet
implemented" violation, so an agent that wanted EXPLAIN of a DML
statement (e.g. EXPLAIN DELETE FROM users WHERE id = 1) couldn't
get a plan back even though plain EXPLAIN never executes the
wrapped statement and is safe to serve.

This commit closes that gap by mirroring the OpExecute wiring from
issue #29:

  - classifySafeWriteExplain admits the read-only set plus DML and
    rejects DDL/DCL/tenant-management/nested-EXPLAIN with the same
    Reasons and Kinds as classifySafeWriteExecute, but tagged
    Op: OpExplain.
  - classifyFullAccessExplain admits anything that parses, mirroring
    classifyFullAccessExecute. Defense-in-depth at runtime is the
    existing BEGIN READ ONLY wrapper in conn.Manager.runExplain — no
    runtime plumbing change is needed because plain EXPLAIN doesn't
    execute the inner statement.
  - The classify dispatcher routes OpExplain through the new
    functions alongside the OpExecute (#29) and OpExplainDDL (#152)
    wirings already on main; only OpSimulate now keeps the
    notYetImplemented fallback.

envelope.escalationTargetFor needed a parallel update: now that
OpExplain produces KindSchema/KindPrivilege/KindClusterAdmin
violations, the suggestion matrix has to point those at full_access
rather than safe_write (which would loop the agent — safe_write
OpExplain rejects the same Kinds). Since OpExplain and OpExecute
now share an identical per-Kind escalation table, the two ops are
folded into one switch arm under both ModeReadOnly and ModeSafeWrite.
This also fixes a pre-existing wrong hint: read_only OpExplain on
DDL was suggesting safe_write, which would have started looping the
moment OpExplain's safe_write classifier landed.

Doc updates ride along: the package, Mode, and ParseMode docstrings
in mode.go, the dispatcher and KindUnimplemented docstrings in
allowlist.go, the cmd/explain.go --mode long help, the MCP
ModeParamDescription, and the per-op admission matrix in the design
doc — all now describe execute/explain/explain-ddl as wired and
simulate as the only remaining unwired surface.

Test coverage:
  - TestCheckSafeWriteExplain pins the per-Kind matrix (DML admit,
    DDL→KindSchema, GRANT→KindPrivilege, cluster-admin →
    KindClusterAdmin, tenant-DML → KindClusterAdmin, nested EXPLAIN
    → KindNestedExplain).
  - TestCheckFullAccessExplain pins the admit-everything contract,
    including the three tenant-management DML escapes.
  - TestEnvelopeExecuteAndExplainSuggestions runs the full
    escalation matrix against both OpExecute and OpExplain so a
    future refactor that diverges them would surface here.
  - TestCheckRejectsUnimplementedModes is trimmed to the two
    OpSimulate rows that still legitimately produce
    KindUnimplemented; OpExplain rows are dropped.

Resolves: #151