### PR TITLE
sqlformat,cli,mcp: strip REPL prompts on every parser-touching tool

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -93,7 +93,12 @@ call:
 For read_only SELECTs that lack a LIMIT clause, --max-rows is injected
 into the rewritten SQL so the cluster does not stream an unbounded
 result. Set --max-rows=0 to disable both injection and runtime
-truncation.`,
+truncation.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -106,6 +111,9 @@ truncation.`,
 				return r.RenderError(baseEnv, err)
 			}
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			if state.dsn == "" {
 				return r.RenderError(baseEnv,
@@ -128,15 +136,24 @@ truncation.`,
 			// inspectors must run first.
 			parsed, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				return renderParseErrorTranslated(r, baseEnv, parseErr, sql, originalSQL, strip)
 			}
 			baseEnv.Errors = append(baseEnv.Errors,
 				version.Inspect(parsed, state.targetVersion, nil)...)
 
 			if violation := safety.CheckParsed(parsedMode, safety.OpExecute, parsed); violation != nil {
+				safetyErr := safety.Envelope(violation)
+				// safety.Envelope carries no Position today, so the
+				// branch below is a no-op. Run it to stay future-proof
+				// if safety later attaches positions, matching the
+				// pattern used by cmd/explain.go, cmd/explain_ddl.go,
+				// and cmd/simulate.go.
+				if strip.Removed {
+					safetyErr.Position = diag.AdjustPosition(safetyErr.Position, originalSQL, strip.Translate)
+				}
 				return r.RenderErrorEntry(baseEnv,
 					fmt.Errorf("safety violation: %s", violation.Reason),
-					safety.Envelope(violation))
+					safetyErr)
 			}
 
 			// LIMIT injection is scoped to read_only because the other
@@ -159,7 +176,27 @@ truncation.`,
 				MaxRows: maxRows,
 			})
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, rewritten))
+				clusterErr := diag.FromClusterError(err, rewritten)
+				// Order matters: when both `injected` and
+				// `strip.Removed` are true, `injected` must win because
+				// the canonicalized rewrite invalidates the strip map.
+				switch {
+				case injected:
+					// rewritten is the canonicalized AST re-serialized by
+					// tree.AsStringWithFlags, not stripped SQL with an
+					// appended LIMIT. Pgwire positions index into rewritten,
+					// so strip.Translate (stripped → original) cannot
+					// honestly translate them. Drop Position rather than
+					// report wrong line/column.
+					clusterErr.Position = nil
+					if clusterErr.Context == nil {
+						clusterErr.Context = make(map[string]any, 1)
+					}
+					clusterErr.Context[output.ContextPositionOmittedReason] = output.ReasonLimitInjectionRewroteSQL
+				case strip.Removed:
+					clusterErr.Position = diag.AdjustPosition(clusterErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, clusterErr)
 			}
 
 			if injected {

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -57,7 +57,12 @@ non-mutating statements. "safe_write" additionally admits DML
 (INSERT/UPDATE/DELETE/UPSERT) so the planner can return a plan for
 the inner write. "full_access" admits any parsed statement; the
 cluster's read-only transaction wrapper still surfaces SQLSTATE 25006
-for inner DDL the planner refuses to plan under read-only.`,
+for inner DDL the planner refuses to plan under read-only.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -70,6 +75,9 @@ for inner DDL the planner refuses to plan under read-only.`,
 				return r.RenderError(baseEnv, err)
 			}
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			if state.dsn == "" {
 				return r.RenderError(baseEnv,
@@ -87,12 +95,24 @@ for inner DDL the planner refuses to plan under read-only.`,
 			// were missing.
 			violation, err := safety.Check(parsedMode, safety.OpExplain, sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+				parseErr := diag.FromParseError(err, sql)
+				if strip.Removed {
+					parseErr.Position = diag.AdjustPosition(parseErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, parseErr)
 			}
 			if violation != nil {
+				safetyErr := safety.Envelope(violation)
+				// safety.Envelope carries no Position today, so the
+				// branch below is a no-op. Run it to stay future-proof
+				// if safety later attaches positions, matching the
+				// pattern in the MCP-side handler and cmd/exec.go.
+				if strip.Removed {
+					safetyErr.Position = diag.AdjustPosition(safetyErr.Position, originalSQL, strip.Translate)
+				}
 				return r.RenderErrorEntry(baseEnv,
 					fmt.Errorf("safety violation: %s", violation.Reason),
-					safety.Envelope(violation))
+					safetyErr)
 			}
 
 			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
@@ -100,7 +120,11 @@ for inner DDL the planner refuses to plan under read-only.`,
 
 			result, err := mgr.Explain(cmd.Context(), sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
+				clusterErr := diag.FromClusterError(err, sql)
+				if strip.Removed {
+					clusterErr.Position = diag.AdjustPosition(clusterErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, clusterErr)
 			}
 
 			baseEnv.ConnectionStatus = output.ConnectionConnected

--- a/cmd/explain_ddl.go
+++ b/cmd/explain_ddl.go
@@ -64,7 +64,12 @@ schema), so this command requires --mode=safe_write or
 EXPLAIN, privilege/role changes (DCL), cluster administration,
 tenant management, and non-DDL inputs; full_access admits any DDL
 that parses while still rejecting nested EXPLAIN and non-DDL
-inputs.`,
+inputs.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -77,6 +82,9 @@ inputs.`,
 				return r.RenderError(baseEnv, err)
 			}
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			if state.dsn == "" {
 				return r.RenderError(baseEnv,
@@ -90,12 +98,24 @@ inputs.`,
 
 			violation, err := safety.Check(parsedMode, safety.OpExplainDDL, sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+				parseErr := diag.FromParseError(err, sql)
+				if strip.Removed {
+					parseErr.Position = diag.AdjustPosition(parseErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, parseErr)
 			}
 			if violation != nil {
+				safetyErr := safety.Envelope(violation)
+				// safety.Envelope carries no Position today, so the
+				// branch below is a no-op. Run it to stay future-proof
+				// if safety later attaches positions, matching the
+				// pattern in the MCP-side handler and cmd/exec.go.
+				if strip.Removed {
+					safetyErr.Position = diag.AdjustPosition(safetyErr.Position, originalSQL, strip.Translate)
+				}
 				return r.RenderErrorEntry(baseEnv,
 					fmt.Errorf("safety violation: %s", violation.Reason),
-					safety.Envelope(violation))
+					safetyErr)
 			}
 
 			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
@@ -103,7 +123,11 @@ inputs.`,
 
 			result, err := mgr.ExplainDDL(cmd.Context(), sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
+				clusterErr := diag.FromClusterError(err, sql)
+				if strip.Removed {
+					clusterErr.Position = diag.AdjustPosition(clusterErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, clusterErr)
 			}
 
 			baseEnv.ConnectionStatus = output.ConnectionConnected

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -87,7 +87,8 @@ CockroachDB parser's built-in formatter. Input is read from the -e flag
 
 Pasted output from a cockroach sql REPL session is auto-cleaned: primary
 prompts (user@host:port/db>) and continuation prompts (->) are stripped
-before parsing, so transcripts paste in unmodified.
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.
 
 Use --color=always|never|auto to control ANSI syntax highlighting in
 text mode. The default (auto) colorizes only when stdout is a terminal.
@@ -109,11 +110,14 @@ JSON output is never colorized.`,
 				return r.RenderError(baseEnv, err)
 			}
 
-			sql = strings.TrimSpace(sqlformat.StripShellPrompts(sql))
+			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			parsed, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				return renderParseErrorTranslated(r, baseEnv, parseErr, sql, originalSQL, strip)
 			}
 			baseEnv.Errors = append(baseEnv.Errors,
 				version.Inspect(parsed, state.targetVersion, nil)...)

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -39,7 +39,12 @@ func newParseCmd(state *rootState) *cobra.Command {
 (inline SQL), a positional file argument, or stdin. For each statement
 the output includes the statement type (DDL, DML, DCL, or TCL), the
 statement tag (e.g. SELECT, ALTER TABLE), the original SQL text, and a
-normalized form with literal constants replaced by placeholders.`,
+normalized form with literal constants replaced by placeholders.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
@@ -53,10 +58,13 @@ normalized form with literal constants replaced by placeholders.`,
 			}
 
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			parsed, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				return renderParseErrorTranslated(r, baseEnv, parseErr, sql, originalSQL, strip)
 			}
 			stmts := sqlparse.ClassifyParsed(parsed)
 			baseEnv.Errors = append(baseEnv.Errors,

--- a/cmd/preprocess.go
+++ b/cmd/preprocess.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+)
+
+// preprocessSQL strips cockroach sql REPL prompts from sql and, when
+// any prompt bytes were removed, appends an output.CodeInputPreprocessed
+// WARNING to env so the modification is visible to JSON consumers. It
+// mirrors the MCP-side preprocessSQL helper so the two surfaces produce
+// identical envelope shapes for the same input.
+//
+// The returned StripResult exposes .Stripped (the SQL the caller should
+// pass to the parser, safety check, semcheck, and cluster manager) and
+// .Translate (the offset mapper that translateErrorPositions consumes
+// after each diagnostic-producing step).
+//
+// The function is a hot-path no-op when the input contains no prompts.
+func preprocessSQL(env *output.Envelope, sql string) sqlformat.StripResult {
+	strip := sqlformat.StripShellPromptsWithMap(sql)
+	if !strip.Removed {
+		return strip
+	}
+	bytesRemoved := len(sql) - len(strip.Stripped)
+	env.Errors = append(env.Errors, output.Error{
+		Code:     output.CodeInputPreprocessed,
+		Severity: output.SeverityWarning,
+		Message:  "input was preprocessed: cockroach sql REPL prompts removed before parsing",
+		Context: map[string]any{
+			"bytes_removed": bytesRemoved,
+		},
+	})
+	return strip
+}
+
+// renderParseErrorTranslated wraps renderParseError with the offset
+// translation needed when sql came from a stripped paste. The
+// underlying diag.FromParseError computes a Position relative to sql
+// (the stripped buffer); this helper re-derives that Position against
+// originalSQL so the JSON envelope reports user-visible coordinates.
+//
+// When strip is the no-op (Removed == false), this delegates straight
+// to renderParseError.
+func renderParseErrorTranslated(
+	r output.Renderer, env output.Envelope, parseErr error, sql, originalSQL string, strip sqlformat.StripResult,
+) error {
+	if !strip.Removed {
+		return renderParseError(r, env, parseErr, sql)
+	}
+	e := diag.FromParseError(parseErr, sql)
+	e.Position = diag.AdjustPosition(e.Position, originalSQL, strip.Translate)
+	return renderDiagErrors(r, env, []output.Error{e})
+}

--- a/cmd/preprocess_test.go
+++ b/cmd/preprocess_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// messySQL is the verbatim transcript paste from issue #161. The CLI
+// surface must accept it on every Tier 1 subcommand and surface the
+// input_preprocessed warning, mirroring the MCP test suite.
+const messySQL = "root@localhost:26257/movr> SELECT r.city,r.id AS ride_id,\n" +
+	"                        -> u.name AS rider_name,v.type AS vehicle_type,\n" +
+	"                        ->    r.start_address,r.end_address,\n" +
+	"                        -> r.revenue FROM rides r INNER JOIN\n" +
+	"                        -> users u ON r.rider_id=u.id AND r.city=u.city INNER JOIN vehicles v\n" +
+	"                        ->       ON r.vehicle_id=v.id AND\n" +
+	"                        -> r.vehicle_city=v.city WHERE r.city='new york'\n" +
+	"                        ->  AND r.revenue > 50.00\n" +
+	"                        -> ORDER BY r.revenue DESC;\n"
+
+// runCmdJSON drives a CLI subcommand end to end with messy SQL fed via
+// stdin and --output=json. It returns the parsed envelope so callers
+// can assert on it. fail=true means we expect ErrRendered (or any
+// non-nil error) — used by Tier 3 tests where the cluster contact
+// fails. For Tier 1 the call must succeed.
+func runCmdJSON(t *testing.T, sql string, args ...string) output.Envelope {
+	t.Helper()
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetIn(strings.NewReader(sql))
+	root.SetArgs(append([]string{"--output", "json"}, args...))
+
+	// Some subcommands return ErrRendered on a failed run while still
+	// emitting a complete envelope on stdout; we accept either nil or
+	// non-nil and assert on the envelope shape instead.
+	_ = root.Execute()
+
+	var env output.Envelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env), "stdout=%q stderr=%q", stdout.String(), stderr.String())
+	return env
+}
+
+// requireInputPreprocessedWarning extracts the single
+// input_preprocessed warning entry from env.Errors and pins its
+// shape: WARNING severity, bytes_removed > 0. Mirrors the MCP-side
+// helper so the two surfaces stay observable through the same
+// assertion path.
+func requireInputPreprocessedWarning(t *testing.T, env output.Envelope) {
+	t.Helper()
+	var found *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Code == output.CodeInputPreprocessed {
+			require.Nil(t, found, "more than one input_preprocessed warning: %+v", env.Errors)
+			found = &env.Errors[i]
+		}
+	}
+	require.NotNil(t, found, "no input_preprocessed warning found in %+v", env.Errors)
+	require.Equal(t, output.SeverityWarning, found.Severity)
+	require.Greater(t, found.Context["bytes_removed"], float64(0))
+}
+
+// TestPreprocessTier1CLISubcommandsEmitWarning verifies every Tier 1
+// CLI subcommand accepts the messy.sql fixture and surfaces the
+// input_preprocessed warning. The data payload must also be populated
+// so the run is observably successful.
+func TestPreprocessTier1CLISubcommandsEmitWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "parse", args: []string{"parse"}},
+		{name: "validate", args: []string{"validate"}},
+		{name: "summarize", args: []string{"summarize"}},
+		{name: "risk", args: []string{"risk"}},
+		{name: "format", args: []string{"format"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := runCmdJSON(t, messySQL, tc.args...)
+			requireInputPreprocessedWarning(t, env)
+			require.NotEmpty(t, env.Data, "data payload must be populated for messy SQL after stripping")
+			for _, e := range env.Errors {
+				require.NotEqual(t, output.SeverityError, e.Severity,
+					"unexpected ERROR-severity entry on success path: %+v", e)
+			}
+		})
+	}
+}
+
+// TestPreprocessIsNoOpForNonPasteCLIInput pins the hot-path contract:
+// SQL with no REPL prompts must not trigger the input_preprocessed
+// warning on the CLI surface either.
+func TestPreprocessIsNoOpForNonPasteCLIInput(t *testing.T) {
+	env := runCmdJSON(t, "SELECT 1;", "parse")
+	for _, e := range env.Errors {
+		require.NotEqual(t, output.CodeInputPreprocessed, e.Code,
+			"input_preprocessed must not fire for prompt-free SQL: %+v", e)
+	}
+}
+
+// TestPreprocessTier3CLISubcommandsEmitWarning verifies the Tier 3
+// CLI subcommands strip the prompt and surface input_preprocessed
+// even when the cluster contact fails. An unreachable --dsn forces
+// the cluster step to fail fast; the assertion is that the warning
+// sits in the envelope alongside the connect error rather than being
+// overwritten by it. Mirrors TestPreprocessTier3ToolsEmitWarningOnMessyPaste
+// in internal/mcp/tools/preprocess_test.go for the MCP surface.
+func TestPreprocessTier3CLISubcommandsEmitWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "explain", args: []string{"explain", "--dsn", "postgres://flaghost:26257/db?connect_timeout=1"}},
+		{name: "explain-ddl", args: []string{"explain-ddl", "--mode", "safe_write",
+			"--dsn", "postgres://flaghost:26257/db?connect_timeout=1"}},
+		{name: "simulate", args: []string{"simulate", "--dsn", "postgres://flaghost:26257/db?connect_timeout=1"}},
+		{name: "exec", args: []string{"exec", "--dsn", "postgres://flaghost:26257/db?connect_timeout=1"}},
+	}
+	// explain-ddl rejects SELECT under any mode, so feed it a DDL paste.
+	const ddlMessy = "root@localhost:26257/movr> ALTER TABLE rides\n" +
+		"                        -> ADD COLUMN flagged BOOL DEFAULT false;\n"
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := messySQL
+			if tc.name == "explain-ddl" {
+				input = ddlMessy
+			}
+			env := runCmdJSON(t, input, tc.args...)
+			requireInputPreprocessedWarning(t, env)
+		})
+	}
+}
+
+// TestPreprocessCLIParseErrorTranslatesPosition pins the CLI-side
+// position-translation contract. Mirrors the MCP-surface test
+// TestPreprocessParseSQLTranslatesPositionToOriginal so a regression
+// in renderParseErrorTranslated (cmd/preprocess.go) is caught
+// independently of the MCP code path.
+func TestPreprocessCLIParseErrorTranslatesPosition(t *testing.T) {
+	const prompt = "root@localhost:26257/movr> "
+	env := runCmdJSON(t, prompt+"GARB AGE\n", "parse")
+
+	requireInputPreprocessedWarning(t, env)
+	var parseErr *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Severity == output.SeverityError {
+			parseErr = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, parseErr, "expected a parse error in env.Errors: %+v", env.Errors)
+	require.NotNil(t, parseErr.Position, "parse error must carry a Position so the agent can locate the typo")
+
+	// In stripped-buffer coordinates the error sits at line 1 column 1
+	// (the 'G' of "GARB AGE"). In the original it sits at column
+	// len(prompt)+1 — that's what the agent must see.
+	require.Equal(t, 1, parseErr.Position.Line)
+	require.Equal(t, len(prompt)+1, parseErr.Position.Column,
+		"position must be re-derived against the original input, not the stripped buffer")
+	require.Equal(t, len(prompt), parseErr.Position.ByteOffset)
+}
+
+// TestPreprocessValidateKeepsCapabilityRequired pins that the
+// input_preprocessed warning sits ALONGSIDE other warnings, not
+// instead of them. validate_sql with messy SQL and no schemas should
+// produce both input_preprocessed (stripping fired) and
+// capability_required (name resolution skipped). A regression that
+// reverted the append-based envelope handling to assignment would
+// drop one of the two.
+func TestPreprocessValidateKeepsCapabilityRequired(t *testing.T) {
+	env := runCmdJSON(t, messySQL, "validate")
+
+	requireInputPreprocessedWarning(t, env)
+
+	var sawCapability bool
+	for _, e := range env.Errors {
+		if e.Code == "capability_required" {
+			sawCapability = true
+			break
+		}
+	}
+	require.True(t, sawCapability,
+		"capability_required warning must sit alongside input_preprocessed: %+v", env.Errors)
+}

--- a/cmd/risk.go
+++ b/cmd/risk.go
@@ -39,7 +39,12 @@ WHERE clause, DROP/TRUNCATE statements, SELECT *, SERIAL or missing
 primary keys, deep OFFSET pagination, and XA two-phase-commit
 statements. Input is read from the -e flag (inline SQL), a positional
 file argument, or stdin. Each finding includes a reason code, severity,
-human-readable message, and fix hint.`,
+human-readable message, and fix hint.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
@@ -52,9 +57,13 @@ human-readable message, and fix hint.`,
 				return r.RenderError(baseEnv, err)
 			}
 
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
+
 			parsed, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				return renderParseErrorTranslated(r, baseEnv, parseErr, sql, originalSQL, strip)
 			}
 			baseEnv.Errors = append(baseEnv.Errors,
 				version.Inspect(parsed, state.targetVersion, nil)...)

--- a/cmd/simulate.go
+++ b/cmd/simulate.go
@@ -69,7 +69,12 @@ statement in the order parsed. The connection string is read from
 Because no flavor executes the inner write or DDL at the cluster
 level, the default --mode=read_only admits every dispatched class.
 Statement types with no EXPLAIN form (BEGIN/COMMIT, GRANT/REVOKE)
-are rejected before any cluster contact.`,
+are rejected before any cluster contact.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierConnected, cmd)
@@ -82,6 +87,9 @@ are rejected before any cluster contact.`,
 				return r.RenderError(baseEnv, err)
 			}
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			if state.dsn == "" {
 				return r.RenderError(baseEnv,
@@ -102,12 +110,24 @@ are rejected before any cluster contact.`,
 			// violation.
 			violation, err := safety.Check(parsedMode, safety.OpSimulate, sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromParseError(err, sql))
+				parseErr := diag.FromParseError(err, sql)
+				if strip.Removed {
+					parseErr.Position = diag.AdjustPosition(parseErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, parseErr)
 			}
 			if violation != nil {
+				safetyErr := safety.Envelope(violation)
+				// safety.Envelope carries no Position today, so the
+				// branch below is a no-op. Run it to stay future-proof
+				// if safety later attaches positions, matching the
+				// pattern in the MCP-side handler and cmd/exec.go.
+				if strip.Removed {
+					safetyErr.Position = diag.AdjustPosition(safetyErr.Position, originalSQL, strip.Translate)
+				}
 				return r.RenderErrorEntry(baseEnv,
 					fmt.Errorf("safety violation: %s", violation.Reason),
-					safety.Envelope(violation))
+					safetyErr)
 			}
 
 			mgr := conn.NewManager(state.dsn, conn.WithStatementTimeout(timeout))
@@ -115,7 +135,11 @@ are rejected before any cluster contact.`,
 
 			result, err := mgr.Simulate(cmd.Context(), sql)
 			if err != nil {
-				return r.RenderErrorEntry(baseEnv, err, diag.FromClusterError(err, sql))
+				clusterErr := diag.FromClusterError(err, sql)
+				if strip.Removed {
+					clusterErr.Position = diag.AdjustPosition(clusterErr.Position, originalSQL, strip.Translate)
+				}
+				return r.RenderErrorEntry(baseEnv, err, clusterErr)
 			}
 
 			baseEnv.ConnectionStatus = output.ConnectionConnected

--- a/cmd/summarize.go
+++ b/cmd/summarize.go
@@ -42,7 +42,12 @@ WHERE predicates, joins, columns mutated by DML (affected_columns),
 the full read-and-write column footprint (referenced_columns), a
 select_star flag set when the projection uses '*' or 't.*', and a
 risk level delegated to the same rules as 'crdb-sql risk'. Input is
-read from the -e flag, a positional file argument, or stdin.`,
+read from the -e flag, a positional file argument, or stdin.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			r, baseEnv, err := newEnvelope(state, output.TierZeroConfig, cmd)
@@ -55,9 +60,13 @@ read from the -e flag, a positional file argument, or stdin.`,
 				return r.RenderError(baseEnv, err)
 			}
 
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
+
 			parsed, parseErr := parser.Parse(sql)
 			if parseErr != nil {
-				return renderParseError(r, baseEnv, parseErr, sql)
+				return renderParseErrorTranslated(r, baseEnv, parseErr, sql, originalSQL, strip)
 			}
 			baseEnv.Errors = append(baseEnv.Errors,
 				version.Inspect(parsed, state.targetVersion, nil)...)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -68,7 +68,12 @@ tell that the check did not run.
 
 If no -e and no file argument are given and a crdb-sql.yaml config is
 present in the working directory, validate iterates every query file
-matched by the config and reports per-file results in one envelope.`,
+matched by the config and reports per-file results in one envelope.
+
+Pasted output from a cockroach sql REPL session is auto-cleaned: primary
+prompts (user@host:port/db>) and continuation prompts (->) are stripped
+before parsing, and the JSON envelope carries an input_preprocessed
+warning so the modification is visible.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if expr == "" && len(args) == 0 && len(schemaFiles) == 0 && state.cfg != nil {
@@ -92,6 +97,9 @@ matched by the config and reports per-file results in one envelope.`,
 			// Trim surrounding whitespace so trailing newlines from
 			// stdin/file do not skew position reporting.
 			sql = strings.TrimSpace(sql)
+			originalSQL := sql
+			strip := preprocessSQL(&baseEnv, sql)
+			sql = strip.Stripped
 
 			stmts, parseErr := parser.Parse(sql)
 			if parseErr != nil {
@@ -105,8 +113,12 @@ matched by the config and reports per-file results in one envelope.`,
 					FunctionResolution: validateresult.CheckSkipped,
 					NameResolution:     validateresult.CheckSkipped,
 				}
+				e := diag.FromParseError(parseErr, sql)
+				if strip.Removed {
+					e.Position = diag.AdjustPosition(e.Position, originalSQL, strip.Translate)
+				}
 				return renderValidateFailure(r, baseEnv,
-					[]output.Error{diag.FromParseError(parseErr, sql)}, parseChecks)
+					[]output.Error{e}, parseChecks)
 			}
 
 			// Version-aware feature warnings are advisory: they
@@ -141,6 +153,12 @@ matched by the config and reports per-file results in one envelope.`,
 			checks.NameResolution = semRes.NameResolution
 
 			if len(semErrs) > 0 {
+				if strip.Removed {
+					for i := range semErrs {
+						semErrs[i].Position = diag.AdjustPosition(
+							semErrs[i].Position, originalSQL, strip.Translate)
+					}
+				}
 				return renderValidateFailure(r, baseEnv, semErrs, checks)
 			}
 

--- a/internal/diag/position.go
+++ b/internal/diag/position.go
@@ -124,6 +124,32 @@ func CharIndexToByteOffset(sql string, charIdx int) int {
 	return len(sql)
 }
 
+// AdjustPosition translates a Position computed against a stripped SQL
+// buffer back to coordinates in the original input. originalSQL is the
+// pre-strip text; translate maps stripped byte offsets to original
+// byte offsets (typically sqlformat.StripResult.Translate). Returns
+// nil when pos is nil so callers can chain the call unconditionally.
+//
+// Line and Column are recomputed against originalSQL via the same
+// 1-based / byte-counting convention used by the rest of this package
+// (see lineColumn). Pass a no-op identity translate (or simply skip the
+// call) when the stripper did not modify the input — every other field
+// then re-derives to the same values.
+func AdjustPosition(
+	pos *output.Position, originalSQL string, translate func(int) int,
+) *output.Position {
+	if pos == nil {
+		return nil
+	}
+	origOffset := translate(pos.ByteOffset)
+	line, col := lineColumn(originalSQL, origOffset)
+	return &output.Position{
+		Line:       line,
+		Column:     col,
+		ByteOffset: origOffset,
+	}
+}
+
 // lineColumn converts a 0-based byte offset within sql into a 1-based
 // line and column. The column counts bytes from the last newline (or
 // start of string), not runes, matching the CockroachDB parser's

--- a/internal/diag/position_test.go
+++ b/internal/diag/position_test.go
@@ -206,3 +206,64 @@ func TestLineColumn(t *testing.T) {
 		})
 	}
 }
+
+// TestAdjustPosition pins the contract that AdjustPosition translates
+// stripped-buffer Positions back to original-input coordinates and
+// re-derives Line/Column against the original. The translate function
+// in each case is the simplest possible non-trivial mapper: a constant
+// prefix offset added to every input. This isolates the AdjustPosition
+// logic from the more elaborate sqlformat.StripResult.Translate logic
+// covered separately in internal/sqlformat/strip_test.go.
+func TestAdjustPosition(t *testing.T) {
+	const original = "root@:26257/db> SELECT 1;\nSELECT bad FROM" // 41 bytes total
+	const promptLen = len("root@:26257/db> ")                     // 16
+
+	identity := func(off int) int { return off }
+	addPrompt := func(off int) int { return off + promptLen }
+
+	tests := []struct {
+		name        string
+		pos         *output.Position
+		originalSQL string
+		translate   func(int) int
+		expected    *output.Position
+	}{
+		{
+			name:      "nil position is preserved",
+			pos:       nil,
+			translate: identity,
+			expected:  nil,
+		},
+		{
+			name:        "identity translate re-derives line/column unchanged",
+			pos:         &output.Position{Line: 99, Column: 99, ByteOffset: 0},
+			originalSQL: original,
+			translate:   identity,
+			expected:    &output.Position{Line: 1, Column: 1, ByteOffset: 0},
+		},
+		{
+			name:        "prompt-prefix translate shifts byte offset and column",
+			pos:         &output.Position{Line: 1, Column: 1, ByteOffset: 0},
+			originalSQL: original,
+			translate:   addPrompt,
+			expected:    &output.Position{Line: 1, Column: promptLen + 1, ByteOffset: promptLen},
+		},
+		{
+			name:        "translate across newline updates line number",
+			pos:         &output.Position{Line: 1, Column: 1, ByteOffset: 10}, // "SELECT bad" first byte in stripped
+			originalSQL: original,
+			// In stripped buffer offset 10 is 'S' of "SELECT bad". After
+			// the prompt translate it lands at byte 26 of original, the
+			// 'S' of the second statement on line 2.
+			translate: addPrompt,
+			expected:  &output.Position{Line: 2, Column: 1, ByteOffset: 26},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AdjustPosition(tc.pos, tc.originalSQL, tc.translate)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/internal/mcp/tools/detect_risky_query.go
+++ b/internal/mcp/tools/detect_risky_query.go
@@ -23,7 +23,7 @@ import (
 func DetectRiskyQueryTool() mcp.Tool {
 	return mcp.NewTool(
 		DetectRiskyQueryToolName,
-		mcp.WithDescription("Detect risky SQL patterns via AST walk (parser-only; no cluster contact, no statement execution). Flags issues such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints."),
+		mcp.WithDescription("Detect risky SQL patterns via AST walk (parser-only; no cluster contact, no statement execution). Flags issues such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
@@ -47,9 +47,15 @@ func DetectRiskyQueryHandler(parserVersion, defaultTargetVersion string) server.
 
 		env := baseEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
+		before := len(env.Errors)
 		parsed, err := parser.Parse(sql)
 		if err != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, before, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)

--- a/internal/mcp/tools/execute.go
+++ b/internal/mcp/tools/execute.go
@@ -34,7 +34,7 @@ const defaultExecuteMaxRows = 1000
 func ExecuteSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ExecuteSQLToolName,
-		mcp.WithDescription(`Execute SQL against a CockroachDB cluster with safety guardrails. Returns rows, columns, and the command tag in a structured envelope. The mode parameter selects the safety policy: read_only (default) admits non-mutating statements only; safe_write also admits INSERT/UPDATE/DELETE; full_access admits any parsed statement. For read_only SELECTs without a LIMIT, max_rows is injected so the cluster does not stream an unbounded result.`),
+		mcp.WithDescription("Execute SQL against a CockroachDB cluster with safety guardrails. Returns rows, columns, and the command tag in a structured envelope. The mode parameter selects the safety policy: read_only (default) admits non-mutating statements only; safe_write also admits INSERT/UPDATE/DELETE; full_access admits any parsed statement. For read_only SELECTs without a LIMIT, max_rows is injected so the cluster does not stream an unbounded result. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement to execute")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
@@ -84,25 +84,38 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 
 		env := connectedEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
 		// Parse once up front so version.Inspect, safety.CheckParsed,
 		// and safety.MaybeInjectLimitParsed share a single AST. Append
 		// (not assign) into env.Errors so a pre-stamped warning from
-		// connectedEnvelope (e.g. target_version_mismatch) survives a
-		// downstream parse / safety / cluster failure.
+		// connectedEnvelope (e.g. target_version_mismatch) or
+		// preprocessSQL (input_preprocessed) survives a downstream
+		// parse / safety / cluster failure.
 		//
 		// Order matters: version.Inspect and safety.CheckParsed are
 		// read-only walks; safety.MaybeInjectLimitParsed mutates
 		// stmts[0].AST.Limit in place when injection fires, so the
 		// inspectors must run first.
+		parseBefore := len(env.Errors)
 		parsed, err := parser.Parse(sql)
 		if err != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, parseBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)
 
+		safetyBefore := len(env.Errors)
 		if violation := safety.CheckParsed(mode, safety.OpExecute, parsed); violation != nil {
 			env.Errors = append(env.Errors, safety.Envelope(violation))
+			// safety.Envelope carries no Position today, so translate is
+			// a no-op — but run it to stay future-proof if safety later
+			// attaches positions, matching the pattern in explain.go,
+			// explain_schema_change.go, and simulate.go.
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 
@@ -126,12 +139,33 @@ func ExecuteSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
+		clusterBefore := len(env.Errors)
 		result, err := mgr.Execute(ctx, rewritten, conn.ExecuteOptions{
 			Mode:    mode,
 			MaxRows: maxRows,
 		})
 		if err != nil {
-			env.Errors = append(env.Errors, diag.FromClusterError(err, rewritten))
+			clusterErr := diag.FromClusterError(err, rewritten)
+			// When LIMIT injection fires, rewritten is the canonicalized
+			// AST re-serialized by tree.AsStringWithFlags — not stripped
+			// SQL with an appended clause. Pgwire positions index into
+			// rewritten, so strip.Translate (which maps stripped offsets
+			// to original) cannot honestly translate them. Drop the
+			// Position rather than report a confidently-wrong line/column.
+			if injected {
+				clusterErr.Position = nil
+				if clusterErr.Context == nil {
+					clusterErr.Context = make(map[string]any, 1)
+				}
+				clusterErr.Context[output.ContextPositionOmittedReason] = output.ReasonLimitInjectionRewroteSQL
+			}
+			env.Errors = append(env.Errors, clusterErr)
+			// Translate any other appended errors (none today, but the
+			// loop is the right place for future diagnostics that share
+			// the stripped frame). The injected-cluster-error case above
+			// has already nilled its Position so the translate is a no-op
+			// for it.
+			translateErrorPositions(&env, clusterBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/explain.go
+++ b/internal/mcp/tools/explain.go
@@ -26,7 +26,7 @@ import (
 func ExplainSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ExplainSQLToolName,
-		mcp.WithDescription(`Run EXPLAIN against a CockroachDB cluster and return the plan as structured JSON. The wrapped statement is not executed (this is plain EXPLAIN, not EXPLAIN ANALYZE). Returns the operator tree, header (distribution/vectorized), and the raw tabular rows.`),
+		mcp.WithDescription("Run EXPLAIN against a CockroachDB cluster and return the plan as structured JSON. The wrapped statement is not executed (this is plain EXPLAIN, not EXPLAIN ANALYZE). Returns the operator tree, header (distribution/vectorized), and the raw tabular rows. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL DML statement to explain")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
@@ -76,18 +76,30 @@ func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 
 		env := connectedEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
 		// Safety check runs before any cluster contact: a rejection
 		// surfaces in env.Errors with connection_status=disconnected,
 		// matching the CLI's behaviour. Parse errors propagate via
 		// diag.FromParseError so the agent gets the SQLSTATE-tagged
 		// syntax diagnostic, not a misleading safety violation.
+		//
+		// Note: safety.Check / safety.Envelope-built diagnostics carry
+		// no Position field today, so translation is a no-op for the
+		// safety-rejection branch — but we run it anyway to stay
+		// future-proof if safety later attaches positions.
+		safetyBefore := len(env.Errors)
 		violation, err := safety.Check(mode, safety.OpExplain, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		if violation != nil {
-			env.Errors = []output.Error{safety.Envelope(violation)}
+			env.Errors = append(env.Errors, safety.Envelope(violation))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 
@@ -99,9 +111,11 @@ func ExplainSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHa
 		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
+		clusterBefore := len(env.Errors)
 		result, err := mgr.Explain(ctx, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromClusterError(err, sql))
+			translateErrorPositions(&env, clusterBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/explain_schema_change.go
+++ b/internal/mcp/tools/explain_schema_change.go
@@ -32,7 +32,7 @@ import (
 func ExplainSchemaChangeTool() mcp.Tool {
 	return mcp.NewTool(
 		ExplainSchemaChangeToolName,
-		mcp.WithDescription(`Run EXPLAIN (DDL, SHAPE) against a CockroachDB cluster and return the declarative schema-changer plan as structured JSON. The wrapped DDL is not executed — the schema changer only compiles a plan. Returns the operations list (with backfill / merge / validate steps), the canonicalized statement, and the raw text the cluster returned.`),
+		mcp.WithDescription("Run EXPLAIN (DDL, SHAPE) against a CockroachDB cluster and return the declarative schema-changer plan as structured JSON. The wrapped DDL is not executed — the schema changer only compiles a plan. Returns the operations list (with backfill / merge / validate steps), the canonicalized statement, and the raw text the cluster returned. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("DDL statement to plan (e.g. ALTER TABLE ... ADD COLUMN ...)")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
@@ -81,13 +81,20 @@ func ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion string) serv
 
 		env := connectedEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
+		safetyBefore := len(env.Errors)
 		violation, err := safety.Check(mode, safety.OpExplainDDL, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		if violation != nil {
-			env.Errors = []output.Error{safety.Envelope(violation)}
+			env.Errors = append(env.Errors, safety.Envelope(violation))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 
@@ -99,9 +106,11 @@ func ExplainSchemaChangeHandler(parserVersion, defaultTargetVersion string) serv
 		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
+		clusterBefore := len(env.Errors)
 		result, err := mgr.ExplainDDL(ctx, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromClusterError(err, sql))
+			translateErrorPositions(&env, clusterBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -24,7 +24,7 @@ import (
 func FormatSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		FormatSQLToolName,
-		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format. Returns an envelope with the formatted SQL string."),
+		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format. Returns an envelope with the formatted SQL string. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to format (may contain multiple semicolon-separated statements)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
@@ -50,12 +50,18 @@ func FormatSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHan
 
 		// Auto-clean cockroach sql REPL prompts the same way the CLI
 		// format subcommand does, so MCP clients pasting transcripts
-		// get the same forgiving behavior.
-		sql = sqlformat.StripShellPrompts(sql)
+		// get the same forgiving behavior. preprocessSQL also surfaces
+		// the input_preprocessed warning when stripping fired, so the
+		// caller can see the modification.
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
 
+		before := len(env.Errors)
 		parsed, err := parser.Parse(sql)
 		if err != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, before, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -23,7 +23,7 @@ import (
 func ParseSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ParseSQLToolName,
-		mcp.WithDescription("Parse and classify SQL statements. Returns an envelope with statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input."),
+		mcp.WithDescription("Parse and classify SQL statements. Returns an envelope with statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
@@ -48,9 +48,15 @@ func ParseSQLHandler(parserVersion, defaultTargetVersion string) server.ToolHand
 
 		env := baseEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
+		before := len(env.Errors)
 		parsed, err := parser.Parse(sql)
 		if err != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, before, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		stmts := sqlparse.ClassifyParsed(parsed)

--- a/internal/mcp/tools/preprocess.go
+++ b/internal/mcp/tools/preprocess.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"github.com/spilchen/sql-ai-tools/internal/diag"
+	"github.com/spilchen/sql-ai-tools/internal/output"
+	"github.com/spilchen/sql-ai-tools/internal/sqlformat"
+)
+
+// preprocessSQL strips cockroach sql REPL prompts from sql and, when
+// any prompt bytes were removed, appends an output.CodeInputPreprocessed
+// WARNING to env so the modification is visible to callers. The handler
+// should pass the returned StripResult.Stripped through to every
+// downstream parser/safety/semcheck/cluster step, and the original sql
+// to translateErrorPositions whenever a step appends to env.Errors.
+//
+// The function is a hot-path no-op when the input contains no prompts:
+// no allocation beyond what sqlformat.StripShellPromptsWithMap already
+// does, and env is left untouched.
+func preprocessSQL(env *output.Envelope, sql string) sqlformat.StripResult {
+	strip := sqlformat.StripShellPromptsWithMap(sql)
+	if !strip.Removed {
+		return strip
+	}
+	bytesRemoved := len(sql) - len(strip.Stripped)
+	env.Errors = append(env.Errors, output.Error{
+		Code:     output.CodeInputPreprocessed,
+		Severity: output.SeverityWarning,
+		Message:  "input was preprocessed: cockroach sql REPL prompts removed before parsing",
+		Context: map[string]any{
+			"bytes_removed": bytesRemoved,
+		},
+	})
+	return strip
+}
+
+// translateErrorPositions remaps Position fields on every error in
+// env.Errors[fromIdx:] from stripped-SQL coordinates back to the
+// original input. fromIdx is the value of len(env.Errors) captured
+// immediately before the diagnostic-producing step (parse / safety /
+// semcheck / cluster); errors appended earlier (e.g. an
+// input_preprocessed warning or a target_version_mismatch warning) are
+// left alone because their positions, when present, are already in
+// the correct frame.
+//
+// The call is a no-op when the stripper did not remove anything, so
+// handlers can call it unconditionally after each diagnostic step.
+//
+// Invariant: fromIdx must be captured BEFORE the diagnostic step that
+// produced the new env.Errors entries. Capturing fromIdx after the
+// step would silently no-op (the loop runs zero times) and ship
+// stripped-buffer Position values to the caller — exactly the bug this
+// helper exists to prevent. There is no compile-time check; callers
+// must keep `before := len(env.Errors)` adjacent to the step.
+func translateErrorPositions(
+	env *output.Envelope, fromIdx int, originalSQL string, strip sqlformat.StripResult,
+) {
+	if !strip.Removed {
+		return
+	}
+	for i := fromIdx; i < len(env.Errors); i++ {
+		env.Errors[i].Position = diag.AdjustPosition(env.Errors[i].Position, originalSQL, strip.Translate)
+	}
+}

--- a/internal/mcp/tools/preprocess_test.go
+++ b/internal/mcp/tools/preprocess_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tools
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spilchen/sql-ai-tools/internal/output"
+)
+
+// messySQL is the verbatim transcript paste from issue #161. Every
+// line carries a cockroach sql REPL prompt artifact (primary or
+// continuation); the stripped form parses as a single SELECT.
+const messySQL = "root@localhost:26257/movr> SELECT r.city,r.id AS ride_id,\n" +
+	"                        -> u.name AS rider_name,v.type AS vehicle_type,\n" +
+	"                        ->    r.start_address,r.end_address,\n" +
+	"                        -> r.revenue FROM rides r INNER JOIN\n" +
+	"                        -> users u ON r.rider_id=u.id AND r.city=u.city INNER JOIN vehicles v\n" +
+	"                        ->       ON r.vehicle_id=v.id AND\n" +
+	"                        -> r.vehicle_city=v.city WHERE r.city='new york'\n" +
+	"                        ->  AND r.revenue > 50.00\n" +
+	"                        -> ORDER BY r.revenue DESC;\n"
+
+// findInputPreprocessedWarning returns the input_preprocessed warning
+// from env.Errors and asserts there is exactly one. Tests that drive
+// messySQL through any handler should observe exactly one such warning
+// regardless of the tier the handler operates at.
+func findInputPreprocessedWarning(t *testing.T, env output.Envelope) output.Error {
+	t.Helper()
+	var matches []output.Error
+	for _, e := range env.Errors {
+		if e.Code == output.CodeInputPreprocessed {
+			matches = append(matches, e)
+		}
+	}
+	require.Len(t, matches, 1, "expected exactly one input_preprocessed warning, got %d (errors=%+v)", len(matches), env.Errors)
+	require.Equal(t, output.SeverityWarning, matches[0].Severity)
+	require.Greater(t, matches[0].Context["bytes_removed"], float64(0),
+		"bytes_removed must be > 0 when the warning fires")
+	return matches[0]
+}
+
+// callHandlerWithSQL is a tiny shim that invokes a Tier 1 (sql-only)
+// MCP handler with a single SQL argument and returns the unmarshalled
+// envelope. Tier 3 tools embed their own DSN argument and use the
+// callTier3Handler shim instead.
+func callHandlerWithSQL(
+	t *testing.T, handler func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error), sql string,
+) output.Envelope {
+	t.Helper()
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"sql": sql}
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	return requireEnvelope(t, res)
+}
+
+// callTier3Handler invokes a Tier 3 handler with messy SQL and an
+// unreachable DSN. The cluster contact will fail, but the
+// input_preprocessed warning must still be present in the envelope —
+// stripping happens before any network attempt.
+func callTier3Handler(
+	t *testing.T, handler func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error), sql string,
+) output.Envelope {
+	t.Helper()
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"sql": sql,
+		// Unreachable DSN ensures we never actually contact a cluster
+		// while still letting the safety + preprocess plumbing run end
+		// to end. connect_timeout=1 keeps the test fast.
+		"dsn": "postgres://flaghost:26257/db?connect_timeout=1",
+	}
+	res, err := handler(context.Background(), req)
+	require.NoError(t, err)
+	return requireEnvelope(t, res)
+}
+
+// TestPreprocessTier1ToolsEmitWarningOnMessyPaste verifies every Tier 1
+// (sql-only) MCP handler accepts the issue #161 fixture in one shot
+// and surfaces the input_preprocessed warning. The data payload must
+// also be populated so the agent gets the actual tool result, not just
+// the warning.
+func TestPreprocessTier1ToolsEmitWarningOnMessyPaste(t *testing.T) {
+	tools := []struct {
+		name    string
+		handler func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "parse_sql", handler: ParseSQLHandler(testParserVersion, "")},
+		{name: "validate_sql", handler: ValidateSQLHandler(testParserVersion, "")},
+		{name: "summarize_sql", handler: SummarizeSQLHandler(testParserVersion, "")},
+		{name: "detect_risky_query", handler: DetectRiskyQueryHandler(testParserVersion, "")},
+		{name: "format_sql", handler: FormatSQLHandler(testParserVersion, "")},
+	}
+	for _, tc := range tools {
+		t.Run(tc.name, func(t *testing.T) {
+			env := callHandlerWithSQL(t, tc.handler, messySQL)
+			findInputPreprocessedWarning(t, env)
+			require.NotEmpty(t, env.Data, "data payload must be populated on the success path")
+			// No ERROR-severity entries: the messy paste must parse
+			// after stripping. Warnings (input_preprocessed and any
+			// version-mismatch hints) are allowed.
+			for _, e := range env.Errors {
+				require.NotEqual(t, output.SeverityError, e.Severity,
+					"unexpected ERROR-severity entry: %+v", e)
+			}
+		})
+	}
+}
+
+// TestPreprocessTier3ToolsEmitWarningOnMessyPaste verifies the
+// connected-tier MCP handlers also strip the prompt and surface the
+// warning. Cluster contact fails (unreachable DSN) so env.Errors
+// includes the connect failure; the assertion is that the
+// input_preprocessed warning sits alongside it.
+func TestPreprocessTier3ToolsEmitWarningOnMessyPaste(t *testing.T) {
+	tools := []struct {
+		name    string
+		handler func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "explain_sql", handler: ExplainSQLHandler(testParserVersion, "")},
+		{name: "explain_schema_change", handler: ExplainSchemaChangeHandler(testParserVersion, "")},
+		{name: "simulate_sql", handler: SimulateSQLHandler(testParserVersion, "")},
+		{name: "execute_sql", handler: ExecuteSQLHandler(testParserVersion, "")},
+	}
+	for _, tc := range tools {
+		t.Run(tc.name, func(t *testing.T) {
+			env := callTier3Handler(t, tc.handler, messySQL)
+			findInputPreprocessedWarning(t, env)
+		})
+	}
+}
+
+// TestPreprocessParseSQLTranslatesPositionToOriginal pins the position-
+// translation contract: when the stripped buffer has a parse error,
+// the Position attached to the envelope error must point inside the
+// original paste (the user's coordinates), not the stripped buffer.
+//
+// The fixture is a single-line prompt followed by garbage that fails
+// to parse. The error sits at the very first non-whitespace token in
+// the *stripped* buffer (column 1), but in the *original* it sits one
+// character past the prompt prefix (column 28).
+func TestPreprocessParseSQLTranslatesPositionToOriginal(t *testing.T) {
+	const prompt = "root@localhost:26257/movr> "
+	const original = prompt + "GARB AGE\n"
+
+	handler := ParseSQLHandler(testParserVersion, "")
+	env := callHandlerWithSQL(t, handler, original)
+
+	// One ERROR (the parse failure) plus one WARNING
+	// (input_preprocessed). Order is preprocessSQL first, parse error
+	// second.
+	findInputPreprocessedWarning(t, env)
+	var parseErr *output.Error
+	for i := range env.Errors {
+		if env.Errors[i].Severity == output.SeverityError {
+			parseErr = &env.Errors[i]
+			break
+		}
+	}
+	require.NotNil(t, parseErr, "expected a parser error entry in env.Errors: %+v", env.Errors)
+	require.NotNil(t, parseErr.Position, "parse error must have a Position so the agent can locate the typo")
+
+	// In the stripped buffer the error sits at line 1 column 1 (the
+	// 'G' of "GARB AGE"). In the original buffer that 'G' is at line 1
+	// column len(prompt)+1 — that is the value the agent must see.
+	require.Equal(t, 1, parseErr.Position.Line)
+	require.Equal(t, len(prompt)+1, parseErr.Position.Column,
+		"position must be re-derived against the original input, not the stripped buffer")
+	require.Equal(t, len(prompt), parseErr.Position.ByteOffset)
+}
+
+// TestPreprocessIsNoOpForNonPasteInput pins the hot-path contract: a
+// SQL string with no REPL prompts must not trigger the
+// input_preprocessed warning. Without this guard, every non-paste
+// caller would receive a misleading "input was preprocessed" entry.
+func TestPreprocessIsNoOpForNonPasteInput(t *testing.T) {
+	handler := ParseSQLHandler(testParserVersion, "")
+	env := callHandlerWithSQL(t, handler, "SELECT 1;")
+
+	for _, e := range env.Errors {
+		require.NotEqual(t, output.CodeInputPreprocessed, e.Code,
+			"input_preprocessed must not fire for prompt-free SQL: %+v", e)
+	}
+}
+
+// TestPreprocessValidateSQLKeepsCapabilityRequired pins that the
+// input_preprocessed warning sits ALONGSIDE other warnings, not
+// instead of them. validate_sql with messy SQL and no schemas should
+// produce both input_preprocessed (stripping fired) and
+// capability_required (name resolution skipped). A regression that
+// reverted the append-based envelope handling to assignment would
+// drop one of the two — exactly the bug the override-to-append
+// migration in the explain/explain_schema_change/simulate handlers
+// was meant to prevent.
+func TestPreprocessValidateSQLKeepsCapabilityRequired(t *testing.T) {
+	handler := ValidateSQLHandler(testParserVersion, "")
+	env := callHandlerWithSQL(t, handler, messySQL)
+
+	findInputPreprocessedWarning(t, env)
+
+	var sawCapability bool
+	for _, e := range env.Errors {
+		if e.Code == "capability_required" {
+			sawCapability = true
+			break
+		}
+	}
+	require.True(t, sawCapability,
+		"capability_required must sit alongside input_preprocessed: %+v", env.Errors)
+}
+
+// TestPreprocessTier3PreservesConnectFailure pins that Tier 3 handlers
+// surface BOTH the input_preprocessed warning AND the underlying
+// connect failure. The override-to-append migration in this PR
+// changed `env.Errors = []output.Error{...}` to `append(...)` in
+// explain/explain_schema_change/simulate; this test would catch a
+// future regression that re-introduced overwrite semantics.
+func TestPreprocessTier3PreservesConnectFailure(t *testing.T) {
+	tools := []struct {
+		name    string
+		handler func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error)
+	}{
+		{name: "explain_sql", handler: ExplainSQLHandler(testParserVersion, "")},
+		{name: "simulate_sql", handler: SimulateSQLHandler(testParserVersion, "")},
+		{name: "execute_sql", handler: ExecuteSQLHandler(testParserVersion, "")},
+	}
+	for _, tc := range tools {
+		t.Run(tc.name, func(t *testing.T) {
+			env := callTier3Handler(t, tc.handler, messySQL)
+			findInputPreprocessedWarning(t, env)
+			require.GreaterOrEqual(t, len(env.Errors), 2,
+				"expected input_preprocessed warning and a connect/cluster error: %+v", env.Errors)
+			var sawClusterError bool
+			for _, e := range env.Errors {
+				if e.Code != output.CodeInputPreprocessed && e.Severity == output.SeverityError {
+					sawClusterError = true
+					break
+				}
+			}
+			require.True(t, sawClusterError,
+				"connect failure must remain visible alongside input_preprocessed: %+v", env.Errors)
+		})
+	}
+}

--- a/internal/mcp/tools/simulate.go
+++ b/internal/mcp/tools/simulate.go
@@ -30,7 +30,7 @@ import (
 func SimulateSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		SimulateSQLToolName,
-		mcp.WithDescription(`Simulate one or more SQL statements without applying them. Each parsed statement is dispatched to a non-executing EXPLAIN flavor: SELECT runs through EXPLAIN ANALYZE (real runtime stats; reads have no side effects), INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN (planner estimates only — the write is never applied), and DDL runs through EXPLAIN (DDL, SHAPE) plus a SHOW STATISTICS row-count annotation per affected table. Multi-statement input returns one entry per statement in parse order.`),
+		mcp.WithDescription("Simulate one or more SQL statements without applying them. Each parsed statement is dispatched to a non-executing EXPLAIN flavor: SELECT runs through EXPLAIN ANALYZE (real runtime stats; reads have no side effects), INSERT/UPDATE/DELETE/UPSERT runs through plain EXPLAIN (planner estimates only — the write is never applied), and DDL runs through EXPLAIN (DDL, SHAPE) plus a SHOW STATISTICS row-count annotation per affected table. Multi-statement input returns one entry per statement in parse order. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL statement(s) to simulate. Multi-statement input is split per ';' and each statement is dispatched independently.")),
 		mcp.WithString("dsn", mcp.Required(), mcp.Description("CockroachDB connection string (postgres:// URI). For TLS-only clusters, supply sslmode/sslrootcert/sslcert/sslkey either as URI query params or as the matching top-level fields below.")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
@@ -81,18 +81,25 @@ func SimulateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 
 		env := connectedEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
 		// Safety check runs before any cluster contact: a rejection
 		// surfaces in env.Errors with connection_status=disconnected,
 		// matching the CLI's behaviour. Parse errors propagate via
 		// diag.FromParseError so the agent gets the SQLSTATE-tagged
 		// syntax diagnostic, not a misleading safety violation.
+		safetyBefore := len(env.Errors)
 		violation, err := safety.Check(mode, safety.OpSimulate, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromParseError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		if violation != nil {
-			env.Errors = []output.Error{safety.Envelope(violation)}
+			env.Errors = append(env.Errors, safety.Envelope(violation))
+			translateErrorPositions(&env, safetyBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 
@@ -104,9 +111,11 @@ func SimulateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 		mgr := conn.NewManager(mergedDSN, conn.WithStatementTimeout(timeout))
 		defer mgr.Close(ctx) //nolint:errcheck // best-effort cleanup
 
+		clusterBefore := len(env.Errors)
 		result, err := mgr.Simulate(ctx, sql)
 		if err != nil {
-			env.Errors = []output.Error{diag.FromClusterError(err, sql)}
+			env.Errors = append(env.Errors, diag.FromClusterError(err, sql))
+			translateErrorPositions(&env, clusterBefore, originalSQL, strip)
 			return envelopeResult(env)
 		}
 

--- a/internal/mcp/tools/summarize.go
+++ b/internal/mcp/tools/summarize.go
@@ -23,7 +23,7 @@ import (
 func SummarizeSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		SummarizeSQLToolName,
-		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected_columns (DML write set), referenced_columns (full read+write footprint), select_star (true when projection uses '*' or 't.*' so referenced_columns is a lower bound), and risk level."),
+		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected_columns (DML write set), referenced_columns (full read+write footprint), select_star (true when projection uses '*' or 't.*' so referenced_columns is a lower bound), and risk level. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to summarize")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)
@@ -49,9 +49,15 @@ func SummarizeSQLHandler(parserVersion, defaultTargetVersion string) server.Tool
 
 		env := baseEnvelope(parserVersion, target)
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
+		before := len(env.Errors)
 		parsed, err := parser.Parse(sql)
 		if err != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(err, sql))
+			translateErrorPositions(&env, before, originalSQL, strip)
 			return envelopeResult(env)
 		}
 		env.Errors = append(env.Errors, version.Inspect(parsed, target, nil)...)

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -34,7 +34,7 @@ import (
 func ValidateSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ValidateSQLToolName,
-		mcp.WithDescription(`Validate SQL for syntax, type, and (with the schemas argument) name errors. Returns an envelope whose data is {"valid": true, "checks": {syntax, type_check, name_resolution}}; each check is "ok" or "skipped". Failures are reported as structured envelope errors with SQLSTATE codes, severity, message, and source position.`),
+		mcp.WithDescription("Validate SQL for syntax, type, and (with the schemas argument) name errors. Returns an envelope whose data is {\"valid\": true, \"checks\": {syntax, type_check, name_resolution}}; each check is \"ok\" or \"skipped\". Failures are reported as structured envelope errors with SQLSTATE codes, severity, message, and source position. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to validate")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithArray(schemasParam,
@@ -75,9 +75,15 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 			env = schemaFileEnvelope(parserVersion, target)
 		}
 
+		originalSQL := sql
+		strip := preprocessSQL(&env, sql)
+		sql = strip.Stripped
+
+		before := len(env.Errors)
 		stmts, parseErr := parser.Parse(sql)
 		if parseErr != nil {
 			env.Errors = append(env.Errors, diag.FromParseError(parseErr, sql))
+			translateErrorPositions(&env, before, originalSQL, strip)
 			return failureEnvelope(env, validateresult.Checks{
 				Syntax:             validateresult.CheckFailed,
 				TypeCheck:          validateresult.CheckSkipped,
@@ -110,6 +116,7 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 			schemawarn.Append(&env, cat)
 		}
 
+		semBefore := len(env.Errors)
 		semRes, semErrs := semcheck.Run(stmts, sql, cat)
 		checks.TypeCheck = semRes.TypeCheck
 		checks.FunctionResolution = semRes.FunctionResolution
@@ -117,6 +124,7 @@ func ValidateSQLHandler(parserVersion, defaultTargetVersion string) server.ToolH
 
 		if len(semErrs) > 0 {
 			env.Errors = append(env.Errors, semErrs...)
+			translateErrorPositions(&env, semBefore, originalSQL, strip)
 			return failureEnvelope(env, checks)
 		}
 

--- a/internal/output/envelope.go
+++ b/internal/output/envelope.go
@@ -120,6 +120,34 @@ const (
 	// programmatically — for example, prompt the user to escalate the
 	// safety mode — without parsing the human-readable Message.
 	CodeSafetyViolation = "safety_violation"
+
+	// CodeInputPreprocessed is emitted (severity WARNING) by the MCP
+	// and CLI handlers whenever sqlformat.StripShellPromptsWithMap
+	// removed cockroach sql REPL prompt bytes from the caller's input
+	// before parsing. The accompanying Error.Context carries the
+	// bytes_removed integer so agents can confirm the modification
+	// programmatically.
+	CodeInputPreprocessed = "input_preprocessed"
+)
+
+// Wire-contract Context keys and values. Promoted here so the MCP and
+// CLI sides cannot drift via a typo in one place.
+const (
+	// ContextPositionOmittedReason is the Error.Context key set by the
+	// execute handlers when they intentionally drop a cluster error's
+	// Position because no honest translation is possible. The value is
+	// one of the Reason* constants below; agents should branch on the
+	// value, not parse the human-readable Message.
+	ContextPositionOmittedReason = "position_omitted_reason"
+
+	// ReasonLimitInjectionRewroteSQL is set as the value of
+	// ContextPositionOmittedReason when safety.MaybeInjectLimitParsed
+	// re-serialized the AST through tree.AsStringWithFlags. The
+	// resulting `rewritten` SQL is canonicalized — comments dropped,
+	// whitespace normalized — so pgwire positions index into a buffer
+	// the strip map cannot translate. Position is dropped rather than
+	// reported in a frame the caller cannot reconstruct.
+	ReasonLimitInjectionRewroteSQL = "limit_injection_rewrote_sql"
 )
 
 // Severity is the severity level of a structured Error. Values use the

--- a/internal/sqlformat/strip.go
+++ b/internal/sqlformat/strip.go
@@ -7,6 +7,7 @@ package sqlformat
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -58,30 +59,127 @@ var continuationPromptRE = regexp.MustCompile(`^[ \t]*-> ?`)
 // stripped. This is exceedingly rare in REPL transcripts and not worth
 // the complexity of full lexer-aware line classification at this layer.
 func StripShellPrompts(sql string) string {
+	return StripShellPromptsWithMap(sql).Stripped
+}
+
+// StripResult is the value produced by StripShellPromptsWithMap. It pairs
+// the stripped SQL with an offset map that lets callers translate byte
+// offsets in the stripped buffer back to the original input — needed so
+// parser/cluster error positions can be reported in the user's original
+// coordinates after the stripper has shortened earlier lines.
+//
+// Removed reports whether any prompt bytes were dropped. When false,
+// Stripped is byte-identical to the function input and Translate is the
+// identity, so handlers can safely treat the no-op case the same as the
+// strip-applied case.
+//
+// segments is the per-removal cumulative-delta table consumed by
+// Translate. Each entry records the offset in Stripped where a stretch
+// of "no further bytes removed" begins, plus the total number of bytes
+// dropped from the original before that offset. Lookup is a binary
+// search for the largest StrippedStart ≤ query offset, so translation
+// is O(log N) in the number of stripped lines.
+type StripResult struct {
+	Stripped string
+	Removed  bool
+	segments []stripSegment
+}
+
+// stripSegment is one entry in StripResult.segments. Entries are kept
+// sorted by StrippedStart ascending so Translate can binary-search them.
+type stripSegment struct {
+	// StrippedStart is the 0-based byte offset in Stripped at which
+	// the post-removal text begins.
+	StrippedStart int
+	// CumDelta is the cumulative number of bytes removed from the
+	// original input prior to StrippedStart. The translation rule is
+	// originalOffset = strippedOffset + CumDelta.
+	CumDelta int
+}
+
+// StripShellPromptsWithMap behaves like StripShellPrompts but also
+// returns an offset map. Use this when you intend to surface error
+// positions back to the caller, so a "syntax error at column 30" in the
+// stripped buffer can be reported as the matching column in the
+// original paste. For pure formatting / display use cases the simpler
+// StripShellPrompts is sufficient.
+func StripShellPromptsWithMap(sql string) StripResult {
 	if sql == "" {
-		return sql
+		return StripResult{Stripped: sql}
 	}
 
 	lines := strings.SplitAfter(sql, "\n")
 	var (
-		buf         strings.Builder
+		buf      strings.Builder
+		segments []stripSegment
+		// cumDelta tracks bytes removed from the original input so far.
+		// It is appended into a new segment whenever it changes, anchored
+		// at the post-removal offset in the stripped output.
+		cumDelta    int
 		seenPrimary bool
 	)
 	buf.Grow(len(sql))
 
+	recordSegment := func(promptLen int) {
+		cumDelta += promptLen
+		segments = append(segments, stripSegment{
+			StrippedStart: buf.Len(),
+			CumDelta:      cumDelta,
+		})
+	}
+
 	for _, line := range lines {
 		if loc := primaryPromptRE.FindStringIndex(line); loc != nil {
 			seenPrimary = true
+			recordSegment(loc[1])
 			buf.WriteString(line[loc[1]:])
 			continue
 		}
 		if seenPrimary {
 			if loc := continuationPromptRE.FindStringIndex(line); loc != nil {
+				recordSegment(loc[1])
 				buf.WriteString(line[loc[1]:])
 				continue
 			}
 		}
 		buf.WriteString(line)
 	}
-	return buf.String()
+
+	return StripResult{
+		Stripped: buf.String(),
+		Removed:  len(segments) > 0,
+		segments: segments,
+	}
+}
+
+// Translate maps a 0-based byte offset in r.Stripped to the matching
+// 0-based byte offset in the original input. Negative offsets clamp to
+// 0; offsets past len(r.Stripped) clamp to len(original).
+//
+// Translation works by binary-searching segments for the largest
+// StrippedStart ≤ strippedOffset and adding its CumDelta. When no
+// segments were produced (no prompts removed), Translate is the
+// identity.
+func (r StripResult) Translate(strippedOffset int) int {
+	if strippedOffset < 0 {
+		strippedOffset = 0
+	}
+	if strippedOffset > len(r.Stripped) {
+		strippedOffset = len(r.Stripped)
+	}
+	if len(r.segments) == 0 {
+		return strippedOffset
+	}
+
+	// sort.Search finds the first segment whose StrippedStart >
+	// strippedOffset; the segment one before that is the largest
+	// StrippedStart ≤ strippedOffset. When idx == 0, no segment
+	// applies (the offset falls before any removal happened).
+	idx := sort.Search(len(r.segments), func(i int) bool {
+		return r.segments[i].StrippedStart > strippedOffset
+	})
+	if idx == 0 {
+		return strippedOffset
+	}
+	return strippedOffset + r.segments[idx-1].CumDelta
 }

--- a/internal/sqlformat/strip_test.go
+++ b/internal/sqlformat/strip_test.go
@@ -6,6 +6,7 @@
 package sqlformat
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -104,6 +105,121 @@ func TestStripShellPrompts(t *testing.T) {
 			require.Equal(t, tc.expected, got)
 		})
 	}
+}
+
+// messySQL is the verbatim transcript paste from issue #161. It
+// exercises a primary prompt followed by eight padded continuation
+// prompts spanning a multi-table SELECT — every line of which would
+// otherwise carry stray REPL chrome past column 30.
+const messySQL = "root@localhost:26257/movr> SELECT r.city,r.id AS ride_id,\n" +
+	"                        -> u.name AS rider_name,v.type AS vehicle_type,\n" +
+	"                        ->    r.start_address,r.end_address,\n" +
+	"                        -> r.revenue FROM rides r INNER JOIN\n" +
+	"                        -> users u ON r.rider_id=u.id AND r.city=u.city INNER JOIN vehicles v\n" +
+	"                        ->       ON r.vehicle_id=v.id AND\n" +
+	"                        -> r.vehicle_city=v.city WHERE r.city='new york'\n" +
+	"                        ->  AND r.revenue > 50.00\n" +
+	"                        -> ORDER BY r.revenue DESC;\n"
+
+// TestStripShellPromptsMessyFixture pins behavior on the issue #161
+// fixture: every prompt line gets cleaned, so the result parses as one
+// well-formed SELECT.
+func TestStripShellPromptsMessyFixture(t *testing.T) {
+	want := "SELECT r.city,r.id AS ride_id,\n" +
+		"u.name AS rider_name,v.type AS vehicle_type,\n" +
+		"   r.start_address,r.end_address,\n" +
+		"r.revenue FROM rides r INNER JOIN\n" +
+		"users u ON r.rider_id=u.id AND r.city=u.city INNER JOIN vehicles v\n" +
+		"      ON r.vehicle_id=v.id AND\n" +
+		"r.vehicle_city=v.city WHERE r.city='new york'\n" +
+		" AND r.revenue > 50.00\n" +
+		"ORDER BY r.revenue DESC;\n"
+
+	require.Equal(t, want, StripShellPrompts(messySQL))
+}
+
+// TestStripShellPromptsWithMapNoOp verifies that input without prompts
+// returns Removed=false, no segments, and an identity Translate. This
+// is the hot path for non-paste callers and needs to be cheap.
+func TestStripShellPromptsWithMapNoOp(t *testing.T) {
+	in := "SELECT 1;\nSELECT 2;\n"
+	got := StripShellPromptsWithMap(in)
+
+	require.Equal(t, in, got.Stripped)
+	require.False(t, got.Removed)
+	require.Empty(t, got.segments)
+
+	// Identity for in-range offsets; negative clamps to 0; past-end
+	// clamps to len(Stripped) (which equals len(original) here).
+	cases := []struct {
+		in, want int
+	}{
+		{-5, 0},
+		{0, 0},
+		{1, 1},
+		{5, 5},
+		{len(in), len(in)},
+		{len(in) + 100, len(in)},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, got.Translate(tc.in), "off=%d", tc.in)
+	}
+}
+
+// TestStripShellPromptsWithMapTranslatesMessyFixture asserts that byte
+// offsets in the stripped messy.sql round-trip back to the right
+// coordinates in the original paste. We pick semantically meaningful
+// landmarks (start of statement, start of each continuation line, end
+// of buffer) so a regression in the segment math fails loudly.
+func TestStripShellPromptsWithMapTranslatesMessyFixture(t *testing.T) {
+	got := StripShellPromptsWithMap(messySQL)
+	require.True(t, got.Removed)
+
+	// For each landmark, locate its position in the stripped buffer
+	// and the original buffer separately, then assert that translating
+	// the stripped offset reaches the original offset.
+	cases := []string{
+		"SELECT r.city",
+		"u.name AS rider_name",
+		"r.revenue FROM rides",
+		"ORDER BY r.revenue DESC;",
+	}
+	for _, needle := range cases {
+		strippedIdx := strings.Index(got.Stripped, needle)
+		require.NotEqual(t, -1, strippedIdx, "needle %q missing from stripped", needle)
+		originalIdx := strings.Index(messySQL, needle)
+		require.NotEqual(t, -1, originalIdx, "needle %q missing from messy", needle)
+
+		require.Equal(t, originalIdx, got.Translate(strippedIdx),
+			"translate(%d) for %q", strippedIdx, needle)
+	}
+
+	// Edge cases: offset 0 in the stripped buffer is the 'S' of
+	// "SELECT", which sat at len("root@localhost:26257/movr> ") in
+	// the original. Offsets past the end clamp to len(original).
+	// Negative offsets clamp to 0 then translate as 0.
+	primaryPrompt := "root@localhost:26257/movr> "
+	require.Equal(t, len(primaryPrompt), got.Translate(0))
+	require.Equal(t, len(messySQL), got.Translate(len(got.Stripped)+100))
+	require.Equal(t, len(primaryPrompt), got.Translate(-1))
+}
+
+// TestStripShellPromptsWithMapTranslateAfterPromptOnFirstLine pins the
+// subtle case where the very first line carries a primary prompt: the
+// stripped offset 0 still maps to original offset 0 because the prompt
+// is not yet "before" any retained byte; offset 1 in stripped maps to
+// original offset 1 + len("root@localhost:26257/movr> ").
+func TestStripShellPromptsWithMapTranslateAfterPromptOnFirstLine(t *testing.T) {
+	in := "root@localhost:26257/movr> SELECT 1;\n"
+	got := StripShellPromptsWithMap(in)
+	require.True(t, got.Removed)
+	require.Equal(t, "SELECT 1;\n", got.Stripped)
+
+	// "S" sits at stripped offset 0; in the original it sits at the
+	// length of the primary prompt (including its trailing space).
+	prompt := "root@localhost:26257/movr> "
+	require.Equal(t, len(prompt), got.Translate(0))
+	require.Equal(t, len(prompt)+5, got.Translate(5))
 }
 
 // TestStripShellPromptsRoundTripsThroughFormat verifies that a pasted


### PR DESCRIPTION
## Summary

The `format_sql` MCP tool and `crdb-sql format` CLI already auto-cleaned cockroach sql REPL prompts so pasted transcripts parsed in one shot. Every other parser-touching surface — `parse_sql`, `validate_sql`, `summarize_sql`, `detect_risky_query`, `explain_sql`, `explain_schema_change`, `simulate_sql`, `execute_sql`, plus matching CLI subcommands — bailed out at the first prompt with `SQLSTATE 42601`. This PR extends the strip pass to all of them with three new pieces beyond what the format path did before:

- `sqlformat.StripShellPromptsWithMap` returns a `StripResult` with a binary-searched offset map. Translation is `O(log N)` per error, so handlers can re-derive parser/cluster/semcheck error positions in the user's *original* input coordinates. The existing `StripShellPrompts` becomes a thin wrapper.
- A new `output.CodeInputPreprocessed` warning (`severity: WARNING`, `Context["bytes_removed"]`) is appended to the envelope whenever the stripper actually removed bytes — without it the modification was invisible.
- `diag.AdjustPosition` re-derives line/column from the original input via the strip translator so a "syntax error at column 30" no longer points into the stripped buffer.

Each affected MCP handler now strips up front, parses (or safety-checks or executes) against the stripped SQL, then translates positions on every error appended after the strip. The CLI mirrors the same flow through `cmd/preprocess.go`. The standardized "Tolerates cockroach sql REPL paste artifacts… do not pre-strip" sentence was appended to every affected tool description and CLI Long help so a fresh agent learns the contract from the registration.

A subtlety in `execute`/`exec`: when `safety.MaybeInjectLimitParsed` fires it re-serializes the AST through `tree.AsStringWithFlags` (canonicalized SQL, not stripped+suffix), so the strip map cannot honestly translate cluster-side positions in the rewritten frame. The handlers detect this and drop the Position with a new `output.ContextPositionOmittedReason = output.ReasonLimitInjectionRewroteSQL` context tag instead of reporting wrong line/column.

The continuation-prompt-without-primary safeguard that lets SQL using the JSON `->` operator pass through unchanged is preserved.

## Out of scope (preserved)

- Stripping output from other shells (`psql`, MySQL CLI).
- Heuristics that try to repair stray characters glued to keywords (e.g. `JOINj`).
- Translating positions inside the *data payload* (`risk.Position`, `summarize.Summary.Position`) back to original-input coordinates — only envelope-error positions are translated. The data payload's `sql`/`original_sql` fields still carry the stripped form. Future work.

## Test plan

- [x] `make build`
- [x] `make lint`
- [x] `make test`
- [x] `make test-integration`
- [x] End-to-end smoke against `messy.sql` from issue #161 through `crdb-sql parse / validate / risk / summarize / format` — every command succeeds and emits the `input_preprocessed` warning with `bytes_removed: 243`
- [x] JSON `->` operator negative case still parses without triggering the warning

Resolves: #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)