### PR TITLE
mcp/tools: tighten parser-only tool descriptions

### DIFF
--- a/internal/mcp/tools/detect_risky_query.go
+++ b/internal/mcp/tools/detect_risky_query.go
@@ -23,7 +23,7 @@ import (
 func DetectRiskyQueryTool() mcp.Tool {
 	return mcp.NewTool(
 		DetectRiskyQueryToolName,
-		mcp.WithDescription("Detect risky SQL patterns via AST walk (parser-only; no cluster contact, no statement execution). Flags issues such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints. Syntax errors include \"did you mean?\" suggestions when the offending token resembles a SQL keyword. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
+		mcp.WithDescription("Detect risky SQL patterns via AST walk (parser-only; no cluster contact, no statement execution). Flags issues such as DELETE/UPDATE without WHERE, DROP/TRUNCATE, SELECT *, SERIAL or missing primary keys, deep OFFSET pagination, and XA two-phase-commit statements. Returns findings with reason codes, severity, and fix hints. "+SharedParserBehaviorTag),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to analyze for risky patterns")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)

--- a/internal/mcp/tools/format.go
+++ b/internal/mcp/tools/format.go
@@ -24,7 +24,7 @@ import (
 func FormatSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		FormatSQLToolName,
-		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format. Returns an envelope with the formatted SQL string. Syntax errors include \"did you mean?\" suggestions when the offending token resembles a SQL keyword. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
+		mcp.WithDescription("Pretty-print SQL statements in canonical CockroachDB format (parser-only; no cluster contact). Returns an envelope with the formatted SQL string. Use for human-readable display in messages back to the user, or as a normalization step when comparing two SQL strings for semantic equivalence. For literal-redacted fingerprinting, prefer parse_sql (returns a normalized form). "+SharedParserBehaviorTag),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to format (may contain multiple semicolon-separated statements)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)

--- a/internal/mcp/tools/parse.go
+++ b/internal/mcp/tools/parse.go
@@ -23,7 +23,7 @@ import (
 func ParseSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ParseSQLToolName,
-		mcp.WithDescription("Parse and classify SQL statements. Returns an envelope with statement type (DDL/DML/DCL/TCL), tag, and original SQL for each statement in the input. Syntax errors include \"did you mean?\" suggestions when the offending token resembles a SQL keyword. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
+		mcp.WithDescription("Parse and classify SQL statements (parser-only; no cluster contact). For each statement returns: statement_type (DDL/DML/DCL/TCL), tag (e.g. SELECT, INSERT), the original sql, and a normalized form with literal constants redacted to _ (suitable as a fingerprint for dedup, query-log grouping, or cache keys — structurally identical queries with different constants share one normalized form). Use when you need to classify or fingerprint SQL; for type and name correctness use validate_sql. "+SharedParserBehaviorTag),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to parse (may contain multiple semicolon-separated statements)")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)

--- a/internal/mcp/tools/summarize.go
+++ b/internal/mcp/tools/summarize.go
@@ -23,7 +23,7 @@ import (
 func SummarizeSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		SummarizeSQLToolName,
-		mcp.WithDescription("Summarize SQL statements via AST walk. Returns per-statement operation, tables, predicates, joins, affected_columns (DML write set), referenced_columns (full read+write footprint), select_star (true when projection uses '*' or 't.*' so referenced_columns is a lower bound), and risk level. Syntax errors include \"did you mean?\" suggestions when the offending token resembles a SQL keyword. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
+		mcp.WithDescription("Summarize SQL statements via AST walk (parser-only; no cluster contact). Returns per-statement operation, tables, predicates, joins, affected_columns (DML write set), referenced_columns (full read+write footprint), select_star (true when projection uses '*' or 't.*' so referenced_columns is a lower bound), and risk level. "+SharedParserBehaviorTag),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to summarize")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 	)

--- a/internal/mcp/tools/tools.go
+++ b/internal/mcp/tools/tools.go
@@ -62,6 +62,17 @@ const TargetVersionParamName = "target_version"
 // argument identically.
 const TargetVersionParamDescription = "Optional target CockroachDB version (MAJOR.MINOR or MAJOR.MINOR.PATCH, with optional leading 'v'). Overrides the server-level default for this call."
 
+// SharedParserBehaviorTag is the trailing fragment appended to every
+// parser-only tool's WithDescription. It documents two behaviors that
+// every tool in this group inherits from the shared SQL preprocessing
+// path: keyword "did you mean?" suggestions on syntax errors (see
+// diag.FromParseError) and tolerance of cockroach sql REPL paste
+// artifacts (see preprocessSQL). Hoisting it into one constant keeps
+// the per-tool descriptions short and prevents per-tool drift; the
+// bracketed tag form makes it visually distinct from the use-case
+// prose that precedes it.
+const SharedParserBehaviorTag = "[Shared parser behavior: keyword \"did you mean?\" suggestions on syntax errors; tolerates cockroach sql REPL paste artifacts (root@host prompt + `-> ` continuation).]"
+
 // ModeParamName is the optional MCP tool parameter name that lets a
 // client override the safety mode applied before any cluster contact.
 // Mirrors the CLI's --mode flag. Tier 3 tools that accept it run the

--- a/internal/mcp/tools/validate.go
+++ b/internal/mcp/tools/validate.go
@@ -34,7 +34,7 @@ import (
 func ValidateSQLTool() mcp.Tool {
 	return mcp.NewTool(
 		ValidateSQLToolName,
-		mcp.WithDescription("Validate SQL for syntax, type, and (with the schemas argument) name errors. Returns an envelope whose data is {\"valid\": true, \"checks\": {syntax, type_check, name_resolution}}; each check is \"ok\" or \"skipped\". Failures are reported as structured envelope errors with SQLSTATE codes, severity, message, and source position. Syntax errors include \"did you mean?\" suggestions when the offending token resembles a SQL keyword. Tolerates cockroach sql REPL paste artifacts (leading `root@host:port/db>` prompt and `-> ` continuation prompts). Pass raw paste in one shot; do not pre-strip."),
+		mcp.WithDescription("Validate SQL for syntax, function resolution, type, and (with the schemas argument) name errors (parser-only; no cluster contact). Returns an envelope whose data is {\"valid\": true, \"checks\": {syntax, function_resolution, type_check, name_resolution}}; each check is \"ok\", \"skipped\", or \"failed\". Failures are reported as structured envelope errors with SQLSTATE codes, severity, message, and source position. Use as a pre-flight gate before execute_sql, especially in CI/automation where you can't or won't contact the cluster. For classification or fingerprinting only, use parse_sql (cheaper). "+SharedParserBehaviorTag),
 		mcp.WithString("sql", mcp.Required(), mcp.Description("SQL string to validate")),
 		mcp.WithString(TargetVersionParamName, mcp.Description(TargetVersionParamDescription)),
 		mcp.WithArray(schemasParam,


### PR DESCRIPTION
## Summary

Rewrite the `WithDescription` strings on the five parser-only MCP tools (`parse_sql`, `format_sql`, `validate_sql`, `summarize_sql`, `detect_risky_query`) so an agent can pick the right tool from the description alone — no trial-and-error.

Before, every description ended with the same two sentences about `did you mean?` keyword suggestions and REPL paste tolerance — ~50 tokens of identical prose duplicated five times in every `tools/list` response. `parse_sql` never mentioned its `normalized` field (the literal-redacted fingerprint that justifies the tool's existence), `format_sql` read like a developer convenience with no agent use case, and `validate_sql` advertised three checks while the envelope actually returned four (`function_resolution` was missing). `parse_sql` vs `validate_sql` vs `summarize_sql` were ambiguous for any "check this SQL" prompt.

After:

- Each description leads with `(parser-only; no cluster contact)` so an agent reasoning about DSN/permissions can decide at a glance.
- `parse_sql` surfaces `normalized` with a one-line use-case sentence (dedup, query-log grouping, cache keys) and cross-references `validate_sql` for type/name correctness.
- `format_sql` names its two real use cases (human display, semantic equivalence comparison) and points at `parse_sql` for fingerprinting.
- `validate_sql` lists all four checks (`syntax`, `function_resolution`, `type_check`, `name_resolution`), the three `CheckStatus` values (`ok`/`skipped`/`failed`), and cross-references `parse_sql` for classification.
- `summarize_sql` and `detect_risky_query` keep their existing body text (already use-case-led) but now share the deduped boilerplate.
- The duplicated boilerplate compresses to a `SharedParserBehaviorTag` constant in `tools.go`, appended once per description.

Docs-only pass — no behavior, envelope, or schema changes.

Resolves: #165